### PR TITLE
Fix deprecation warnings for ConcurrentHashSet

### DIFF
--- a/src/main/java/com/conveyal/datatools/common/status/MonitorableJob.java
+++ b/src/main/java/com/conveyal/datatools/common/status/MonitorableJob.java
@@ -1,8 +1,8 @@
 package com.conveyal.datatools.common.status;
 
 import com.conveyal.datatools.manager.DataManager;
+import com.google.common.collect.Sets;
 import org.apache.commons.lang3.exception.ExceptionUtils;
-import org.eclipse.jetty.util.ConcurrentHashSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -10,6 +10,7 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
@@ -74,10 +75,10 @@ public abstract class MonitorableJob implements Runnable {
      * It is a standard start-up stage for all monitorable jobs.
      */
     private void registerJob() {
-        ConcurrentHashSet<MonitorableJob> userJobs = DataManager.userJobsMap.get(this.owner);
-        if (userJobs == null) {
-            userJobs = new ConcurrentHashSet<>();
-        }
+        Set<MonitorableJob> userJobs = DataManager.userJobsMap.get(this.owner);
+        // If there are no current jobs for the user, create a new empty set. NOTE: this should be a concurrent hash
+        // set so that it is threadsafe.
+        if (userJobs == null) userJobs = Sets.newConcurrentHashSet();
         userJobs.add(this);
 
         DataManager.userJobsMap.put(this.owner, userJobs);
@@ -89,7 +90,7 @@ public abstract class MonitorableJob implements Runnable {
      */
     private void unRegisterJob () {
         // remove this job from the user-job map
-        ConcurrentHashSet<MonitorableJob> userJobs = DataManager.userJobsMap.get(this.owner);
+        Set<MonitorableJob> userJobs = DataManager.userJobsMap.get(this.owner);
         if (userJobs != null) userJobs.remove(this);
     }
 

--- a/src/main/java/com/conveyal/datatools/manager/ConvertMain.java
+++ b/src/main/java/com/conveyal/datatools/manager/ConvertMain.java
@@ -10,7 +10,6 @@ import com.conveyal.datatools.manager.controllers.api.StatusController;
 import com.conveyal.datatools.manager.models.FeedSource;
 import com.conveyal.datatools.manager.persistence.Persistence;
 import org.apache.commons.io.FileUtils;
-import org.eclipse.jetty.util.ConcurrentHashSet;
 import org.mapdb.Fun;
 
 import java.io.File;
@@ -97,7 +96,7 @@ public class ConvertMain {
         int totalJobs = StatusController.getAllJobs().size();
         while (!StatusController.filterActiveJobs(StatusController.getAllJobs()).isEmpty()) {
             // While there are still active jobs, continue waiting.
-            ConcurrentHashSet<MonitorableJob> activeJobs = StatusController.filterActiveJobs(StatusController.getAllJobs());
+            Set<MonitorableJob> activeJobs = StatusController.filterActiveJobs(StatusController.getAllJobs());
             System.out.println(String.format("%d/%d jobs still active. Checking for completion again in 5 seconds...", activeJobs.size(), totalJobs));
 //            System.out.println(String.join(", ", activeJobs.stream().map(job -> job.name).collect(Collectors.toList())));
             int jobsInExecutor = ((ThreadPoolExecutor) DataManager.heavyExecutor).getActiveCount();

--- a/src/main/java/com/conveyal/datatools/manager/DataManager.java
+++ b/src/main/java/com/conveyal/datatools/manager/DataManager.java
@@ -32,9 +32,9 @@ import com.conveyal.gtfs.loader.Table;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.google.common.collect.Sets;
 import com.google.common.io.Resources;
 import org.apache.commons.io.Charsets;
-import org.eclipse.jetty.util.ConcurrentHashSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import spark.utils.IOUtils;
@@ -48,6 +48,7 @@ import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
@@ -83,8 +84,11 @@ public class DataManager {
     // TODO: define type for ExternalFeedResource Strings
     public static final Map<String, ExternalFeedResource> feedResources = new HashMap<>();
 
-    // Stores jobs underway by user ID.
-    public static Map<String, ConcurrentHashSet<MonitorableJob>> userJobsMap = new ConcurrentHashMap<>();
+    /**
+     * Stores jobs underway by user ID. NOTE: any set created and stored here must be created with
+     * {@link Sets#newConcurrentHashSet()} or similar thread-safe Set.
+     */
+    public static Map<String, Set<MonitorableJob>> userJobsMap = new ConcurrentHashMap<>();
 
     // Stores ScheduledFuture objects that kick off runnable tasks (e.g., fetch project feeds at 2:00 AM).
     public static Map<String, ScheduledFuture> autoFetchMap = new HashMap<>();

--- a/src/main/java/com/conveyal/datatools/manager/models/Deployment.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/Deployment.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
 import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.text.DateFormat;
@@ -42,7 +41,6 @@ import org.slf4j.LoggerFactory;
 
 import static com.mongodb.client.model.Filters.and;
 import static com.mongodb.client.model.Filters.eq;
-import static com.mongodb.client.model.Filters.not;
 
 /**
  * A deployment of (a given version of) OTP on a given set of feeds.
@@ -247,8 +245,7 @@ public class Deployment extends Model implements Serializable {
             ZipEntry manifestEntry = new ZipEntry("manifest.json");
             out.putNextEntry(manifestEntry);
             // create the json manifest
-            JsonManager<Deployment> jsonManifest = new JsonManager<Deployment>(Deployment.class,
-                    JsonViews.UserInterface.class);
+            JsonManager<Deployment> jsonManifest = new JsonManager<>(Deployment.class, JsonViews.UserInterface.class);
             // this mixin gives us full feed validation results, not summarized
             jsonManifest.addMixin(Deployment.class, DeploymentFullFeedVersionMixin.class);
             byte[] manifest = jsonManifest.write(this).getBytes();


### PR DESCRIPTION
When compiling the application, Intellij was throwing a bunch of deprecation warnings for `ConcurrentHashSet`. This replaces the use of `new ConcurrentHashSet()` with `Sets.newConcurrentHashSet()` to silence those warnings.