### PR TITLE
Bump jackson version for bug fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <url>https://github.com/conveyal/datatools-server.git</url>
     </scm>
     <properties>
-        <jackson.version>2.9.6</jackson.version>
+        <jackson.version>2.9.8</jackson.version>
     </properties>
     <build>
         <resources>


### PR DESCRIPTION
There are a few jackson-databind vulnerabilities that 2.9.8 fixes.