### PR TITLE
Add origin namespace and remove branding URL from feed merge

### DIFF
--- a/src/main/java/com/conveyal/datatools/manager/controllers/api/GtfsPlusController.java
+++ b/src/main/java/com/conveyal/datatools/manager/controllers/api/GtfsPlusController.java
@@ -3,7 +3,7 @@ package com.conveyal.datatools.manager.controllers.api;
 import com.conveyal.datatools.common.utils.SparkUtils;
 import com.conveyal.datatools.manager.DataManager;
 import com.conveyal.datatools.manager.auth.Auth0UserProfile;
-import com.conveyal.datatools.manager.gtfsplus.ValidationIssue;
+import com.conveyal.datatools.manager.gtfsplus.GtfsPlusValidation;
 import com.conveyal.datatools.manager.jobs.ProcessSingleFeedJob;
 import com.conveyal.datatools.manager.models.FeedVersion;
 import com.conveyal.datatools.manager.persistence.FeedStore;
@@ -11,6 +11,7 @@ import com.conveyal.datatools.manager.persistence.Persistence;
 import com.conveyal.datatools.manager.utils.HashUtils;
 import com.conveyal.datatools.manager.utils.json.JsonUtil;
 import com.fasterxml.jackson.databind.JsonNode;
+import org.eclipse.jetty.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import spark.Request;
@@ -22,11 +23,8 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Collection;
 import java.util.Enumeration;
 import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
 import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
@@ -35,7 +33,7 @@ import java.util.zip.ZipOutputStream;
 import static com.conveyal.datatools.common.utils.SparkUtils.formatJobMessage;
 import static com.conveyal.datatools.common.utils.SparkUtils.copyRequestStreamIntoFile;
 import static com.conveyal.datatools.common.utils.SparkUtils.logMessageAndHalt;
-import static com.conveyal.datatools.manager.gtfsplus.GtfsPlusValidation.validateGtfsPlus;
+import static spark.Spark.delete;
 import static spark.Spark.get;
 import static spark.Spark.post;
 
@@ -133,6 +131,9 @@ public class GtfsPlusController {
         return SparkUtils.downloadFile(gtfsPlusFile, gtfsPlusFile.getName() + ".zip", req, res);
     }
 
+    /** HTTP endpoint used to return the last modified timestamp for a GTFS+ feed. Essentially this is used as a way to
+     * determine whether any GTFS+ edits have been made to
+     */
     private static Long getGtfsPlusFileTimestamp(Request req, Response res) {
         String feedVersionId = req.params("versionid");
 
@@ -140,18 +141,13 @@ public class GtfsPlusController {
         File file = gtfsPlusStore.getFeed(feedVersionId);
         if (file == null) {
             FeedVersion feedVersion = Persistence.feedVersions.getById(feedVersionId);
-            if (feedVersion != null) {
-                file = feedVersion.retrieveGtfsFile();
-            } else {
+            if (feedVersion == null) {
                 logMessageAndHalt(req, 400, "Feed version ID is not valid");
+                return null;
             }
-        }
-
-        if (file != null) {
-            return file.lastModified();
+            return feedVersion.fileTimestamp;
         } else {
-            logMessageAndHalt(req, 404, "Feed version file not found");
-            return null;
+            return file.lastModified();
         }
     }
 
@@ -239,6 +235,8 @@ public class GtfsPlusController {
             logMessageAndHalt(req, 500, "GTFS input file must not be null");
             return null;
         }
+        newFeedVersion.originNamespace = feedVersion.namespace;
+        newFeedVersion.fileTimestamp = newGtfsFile.lastModified();
         newFeedVersion.fileSize = newGtfsFile.length();
         newFeedVersion.hash = HashUtils.hashFile(newGtfsFile);
 
@@ -252,20 +250,36 @@ public class GtfsPlusController {
     /**
      * HTTP endpoint that validates GTFS+ tables for a specific feed version (or its saved/edited GTFS+).
      */
-    private static Collection<ValidationIssue> getGtfsPlusValidation(Request req, Response res) {
+    private static GtfsPlusValidation getGtfsPlusValidation(Request req, Response res) {
         String feedVersionId = req.params("versionid");
-        List<ValidationIssue> issues = new LinkedList<>();
+        GtfsPlusValidation gtfsPlusValidation = null;
         try {
-            issues = validateGtfsPlus(feedVersionId);
+            gtfsPlusValidation = GtfsPlusValidation.validate(feedVersionId);
         } catch(IOException e) {
             logMessageAndHalt(req, 500, "Could not read GTFS+ zip file", e);
         }
-        return issues;
+        return gtfsPlusValidation;
+    }
+
+    /**
+     * HTTP endpoint to delete the GTFS+ specific edits made for a feed version. In other words, this will revert to
+     * referencing the original GTFS+ files for a feed version. Note: this will not delete the feed version itself.
+     */
+    private static String deleteGtfsPlusFile(Request req, Response res) {
+        String feedVersionId = req.params("versionid");
+        File file = gtfsPlusStore.getFeed(feedVersionId);
+        if (file == null) {
+            logMessageAndHalt(req, HttpStatus.NOT_FOUND_404, "No GTFS+ file found for feed version");
+            return null;
+        }
+        file.delete();
+        return SparkUtils.formatJSON("message", "GTFS+ edits deleted successfully.");
     }
 
     public static void register(String apiPrefix) {
         post(apiPrefix + "secure/gtfsplus/:versionid", GtfsPlusController::uploadGtfsPlusFile, JsonUtil.objectMapper::writeValueAsString);
         get(apiPrefix + "secure/gtfsplus/:versionid", GtfsPlusController::getGtfsPlusFile);
+        delete(apiPrefix + "secure/gtfsplus/:versionid", GtfsPlusController::deleteGtfsPlusFile);
         get(apiPrefix + "secure/gtfsplus/:versionid/timestamp", GtfsPlusController::getGtfsPlusFileTimestamp, JsonUtil.objectMapper::writeValueAsString);
         get(apiPrefix + "secure/gtfsplus/:versionid/validation", GtfsPlusController::getGtfsPlusValidation, JsonUtil.objectMapper::writeValueAsString);
         post(apiPrefix + "secure/gtfsplus/:versionid/publish", GtfsPlusController::publishGtfsPlusFile, JsonUtil.objectMapper::writeValueAsString);

--- a/src/main/java/com/conveyal/datatools/manager/gtfsplus/GtfsPlusValidation.java
+++ b/src/main/java/com/conveyal/datatools/manager/gtfsplus/GtfsPlusValidation.java
@@ -16,30 +16,47 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Date;
 import java.util.Enumeration;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
-public class GtfsPlusValidation {
-    public static final Logger LOG = LoggerFactory.getLogger(GtfsPlusValidation.class);
+/** Generates a GTFS+ validation report for a file. */
+public class GtfsPlusValidation implements Serializable {
+    private static final long serialVersionUID = 1L;
+    private static final Logger LOG = LoggerFactory.getLogger(GtfsPlusValidation.class);
     private static final FeedStore gtfsPlusStore = new FeedStore(DataManager.GTFS_PLUS_SUBDIR);
     private static final String NOT_FOUND = "not found in GTFS";
+
+    // Public fields to appear in validation JSON.
+    public final String feedVersionId;
+    /** Indicates whether GTFS+ validation applies to user-edited feed or original published GTFS feed */
+    public boolean published;
+    public long lastModified;
+    /** Issues found for this GTFS+ feed */
+    public List<ValidationIssue> issues = new LinkedList<>();
+
+    private GtfsPlusValidation (String feedVersionId) {
+        this.feedVersionId = feedVersionId;
+    }
 
     /**
      * Validate a GTFS+ feed and return a list of issues encountered.
      * FIXME: For now this uses the MapDB-backed GTFSFeed class. Which actually suggests that this might
      *   should be contained within a MonitorableJob.
      */
-    public static List<ValidationIssue> validateGtfsPlus (String feedVersionId) throws IOException {
+    public static GtfsPlusValidation validate(String feedVersionId) throws IOException {
+        GtfsPlusValidation validation = new GtfsPlusValidation(feedVersionId);
         if (!DataManager.isModuleEnabled("gtfsplus")) {
             throw new IllegalStateException("GTFS+ module must be enabled in server.yml to run GTFS+ validation.");
         }
-        List<ValidationIssue> issues = new LinkedList<>();
         LOG.info("Validating GTFS+ for " + feedVersionId);
+
         FeedVersion feedVersion = Persistence.feedVersions.getById(feedVersionId);
         // Load the main GTFS file.
         // FIXME: Swap MapDB-backed GTFSFeed for use of SQL data?
@@ -47,8 +64,12 @@ public class GtfsPlusValidation {
         // check for saved GTFS+ data
         File file = gtfsPlusStore.getFeed(feedVersionId);
         if (file == null) {
-            LOG.warn("GTFS+ file not found, loading from main version GTFS.");
+            validation.published = true;
+            LOG.warn("GTFS+ Validation -- Modified GTFS+ file not found, loading from main version GTFS.");
             file = feedVersion.retrieveGtfsFile();
+        } else {
+            validation.published = false;
+            LOG.info("GTFS+ Validation -- Validating user-saved GTFS+ data (unpublished)");
         }
         int gtfsPlusTableCount = 0;
         ZipFile zipFile = new ZipFile(file);
@@ -60,12 +81,12 @@ public class GtfsPlusValidation {
                 if (tableNode.get("name").asText().equals(entry.getName())) {
                     LOG.info("Validating GTFS+ table: " + entry.getName());
                     gtfsPlusTableCount++;
-                    validateTable(issues, tableNode, zipFile.getInputStream(entry), gtfsFeed);
+                    validateTable(validation.issues, tableNode, zipFile.getInputStream(entry), gtfsFeed);
                 }
             }
         }
         LOG.info("GTFS+ tables found: {}/{}", gtfsPlusTableCount, DataManager.gtfsPlusConfig.size());
-        return issues;
+        return validation;
     }
 
     /**
@@ -189,6 +210,31 @@ public class GtfsPlusValidation {
         }
 
     }
+
+//    public static long getGtfsPlusFileTimestamp(String feedVersionId) {
+//        // check for saved GTFS+ data
+//        File file = getGtfsPlusFile(feedVersionId);
+//        if (file != null) {
+//            LOG.info("Found modified GTFS+ timestamp");
+//            return file.lastModified();
+//        } else {
+//            throw new IllegalStateException("Feed version file not found");
+//        }
+//    }
+//
+//    public static File getGtfsPlusFile (String feedVersionId) {
+//        File file = gtfsPlusStore.getFeed(feedVersionId);
+//        if (file == null) {
+//            // If there is no edited/saved GTFS+ data, revert to original file.
+//            FeedVersion feedVersion = Persistence.feedVersions.getById(feedVersionId);
+//            if (feedVersion != null) {
+//                file = feedVersion.retrieveGtfsFile();
+//            } else {
+//                throw new IllegalArgumentException("Feed version ID is not valid");
+//            }
+//        }
+//        return file;
+//    }
 
     /** Construct missing ID text for validation issue description. */
     private static String missingIdText(String value, String entity) {

--- a/src/main/java/com/conveyal/datatools/manager/gtfsplus/GtfsPlusValidation.java
+++ b/src/main/java/com/conveyal/datatools/manager/gtfsplus/GtfsPlusValidation.java
@@ -211,31 +211,6 @@ public class GtfsPlusValidation implements Serializable {
 
     }
 
-//    public static long getGtfsPlusFileTimestamp(String feedVersionId) {
-//        // check for saved GTFS+ data
-//        File file = getGtfsPlusFile(feedVersionId);
-//        if (file != null) {
-//            LOG.info("Found modified GTFS+ timestamp");
-//            return file.lastModified();
-//        } else {
-//            throw new IllegalStateException("Feed version file not found");
-//        }
-//    }
-//
-//    public static File getGtfsPlusFile (String feedVersionId) {
-//        File file = gtfsPlusStore.getFeed(feedVersionId);
-//        if (file == null) {
-//            // If there is no edited/saved GTFS+ data, revert to original file.
-//            FeedVersion feedVersion = Persistence.feedVersions.getById(feedVersionId);
-//            if (feedVersion != null) {
-//                file = feedVersion.retrieveGtfsFile();
-//            } else {
-//                throw new IllegalArgumentException("Feed version ID is not valid");
-//            }
-//        }
-//        return file;
-//    }
-
     /** Construct missing ID text for validation issue description. */
     private static String missingIdText(String value, String entity) {
         return String.join(" ", entity, "ID", value, NOT_FOUND);

--- a/src/main/java/com/conveyal/datatools/manager/jobs/CreateFeedVersionFromSnapshotJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/CreateFeedVersionFromSnapshotJob.java
@@ -28,6 +28,7 @@ public class CreateFeedVersionFromSnapshotJob extends MonitorableJob {
     @Override
     public void jobLogic() {
         // Set feed version properties.
+        feedVersion.originNamespace = snapshot.namespace;
         feedVersion.retrievalMethod = FeedSource.FeedRetrievalMethod.PRODUCED_IN_HOUSE;
         feedVersion.name = snapshot.name + " Snapshot Export";
         // FIXME: This should probably just create a new snapshot, and then validate those tables.

--- a/src/main/java/com/conveyal/datatools/manager/models/FeedVersion.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/FeedVersion.java
@@ -191,6 +191,12 @@ public class FeedVersion extends Model implements Serializable {
     public String namespace;
 
     /**
+     * Indicates the namespace from which this version originated. For example, if it was published from a snapshot
+     * namespace or a GTFS+ feed, this field will reference that source namespace.
+     */
+    public String originNamespace;
+
+    /**
      * Indicates when a feed version was published to an external source. If null, the version has not been sent. This
      * field is currently in use only for the MTC extension and is reset to null after the published version has been
      * registered externally.

--- a/src/test/java/com/conveyal/datatools/manager/gtfsplus/GtfsPlusValidationTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/gtfsplus/GtfsPlusValidationTest.java
@@ -45,8 +45,8 @@ public class GtfsPlusValidationTest {
     @Test
     public void canValidateCleanGtfsPlus() throws IOException {
         LOG.info("Validation BART GTFS+");
-        List<ValidationIssue> issues = GtfsPlusValidation.validateGtfsPlus(bartVersion1.id);
+        GtfsPlusValidation validation = GtfsPlusValidation.validate(bartVersion1.id);
         // Expect issues to be zero.
-        assertThat("Issues count for clean BART feed is zero", issues.size(), equalTo(0));
+        assertThat("Issues count for clean BART feed is zero", validation.issues.size(), equalTo(0));
     }
 }


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR:
- adds the `originNamespace` field to FeedVersion to indicate where a given version originated (e.g., from a snapshot that has been published or GTFS+ edits).
- enhances the GTFS+ validation class a bit to include additional metadata (like when the feed was published)
- fixes an issue with feed merging where branding URL fields were showing up for MTC merges