### PR TITLE
Auth0 User Management API upgrade to v2

### DIFF
--- a/configurations/default/env.yml.tmp
+++ b/configurations/default/env.yml.tmp
@@ -1,10 +1,13 @@
+# This client ID refers to the UI client in Auth0.
 AUTH0_CLIENT_ID: your-auth0-client-id
 AUTH0_DOMAIN: your-auth0-domain
 # Note: One of AUTH0_SECRET or AUTH0_PUBLIC_KEY should be used depending on the signing algorithm set on the client.
 # It seems that newer Auth0 accounts (2017 and later) might default to RS256 (public key).
 AUTH0_SECRET: your-auth0-secret # uses HS256 signing algorithm
 # AUTH0_PUBLIC_KEY: /path/to/auth0.pem # uses RS256 signing algorithm
-AUTH0_TOKEN: your-auth0-token
+# This client/secret pair refer to a machine-to-machine Auth0 application used to access the Management API.
+AUTH0_API_CLIENT: your-api-client-id
+AUTH0_API_SECRET: your-api-secret-id
 DISABLE_AUTH: false
 OSM_VEX: http://localhost:1000
 SPARKPOST_KEY: your-sparkpost-key

--- a/pom.xml
+++ b/pom.xml
@@ -16,39 +16,27 @@
     </licenses>
 
     <!-- Developer entries are provided for primary developers.
-   For other contributors, see https://github.com/conveyal/datatools-server/graphs/contributors -->
+   For other contributors, see https://github.com/ibi-group/datatools-server/graphs/contributors -->
     <developers>
         <developer>
             <name>Landon Reed</name>
-            <email>lreed@conveyal.com</email>
-            <organization>Conveyal</organization>
-            <organizationUrl>http://conveyal.com/</organizationUrl>
-        </developer>
-        <developer>
-            <name>Andrew Byrd</name>
-            <email>abyrd@conveyal.com</email>
-            <organization>Conveyal</organization>
-            <organizationUrl>http://conveyal.com/</organizationUrl>
-        </developer>
-        <developer>
-            <name>David Emory</name>
-            <email>demory@conveyal.com</email>
-            <organization>Conveyal</organization>
-            <organizationUrl>http://conveyal.com/</organizationUrl>
+            <email>landon.reed@ibigroup.com</email>
+            <organization>IBI Group</organization>
+            <organizationUrl>https://ibigroup.com/</organizationUrl>
         </developer>
         <developer>
             <name>Evan Siroky</name>
-            <email>esiroky@conveyal.com</email>
-            <organization>Conveyal</organization>
-            <organizationUrl>http://conveyal.com/</organizationUrl>
+            <email>evan.siroky@ibigroup.com</email>
+            <organization>IBI Group</organization>
+            <organizationUrl>https://ibigroup.com/</organizationUrl>
         </developer>
     </developers>
 
     <!-- Define where the source code for project lives -->
     <scm>
-        <connection>scm:git:https://github.com/conveyal/datatools-server.git</connection>
-        <developerConnection>scm:git:ssh://git@github.com/conveyal/datatools-server.git</developerConnection>
-        <url>https://github.com/conveyal/datatools-server.git</url>
+        <connection>scm:git:https://github.com/ibi-group/datatools-server.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com/ibi-group/datatools-server.git</developerConnection>
+        <url>https://github.com/ibi-group/datatools-server.git</url>
     </scm>
     <properties>
         <jackson.version>2.9.9</jackson.version>

--- a/src/main/java/com/conveyal/datatools/manager/auth/Auth0AccessToken.java
+++ b/src/main/java/com/conveyal/datatools/manager/auth/Auth0AccessToken.java
@@ -1,0 +1,31 @@
+package com.conveyal.datatools.manager.auth;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.Date;
+
+/**
+ * This represents the Auth0 API access token that is needed for requests to the v2 Management API. This token can be
+ * retrieved by sending a request to the oauth token endpoint: https://auth0.com/docs/api/management/v2/get-access-tokens-for-production
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Auth0AccessToken {
+    public String access_token;
+    /** Seconds until token expires. */
+    public int expires_in;
+    public String scope;
+    public String token_type;
+    /**
+     * Time when the object was instantiated. This is used in conjunction with expires_in to determine if a token is
+     * still valid.
+     */
+    @JsonIgnore
+    public long creation_time = new Date().getTime();
+
+    /** Helper method to determine the time in milliseconds since epoch that this token expires. */
+    @JsonIgnore
+    public long getExpirationTime() {
+        return this.expires_in * 1000 + this.creation_time;
+    }
+}

--- a/src/main/java/com/conveyal/datatools/manager/auth/Auth0Users.java
+++ b/src/main/java/com/conveyal/datatools/manager/auth/Auth0Users.java
@@ -91,8 +91,8 @@ public class Auth0Users {
 
         HttpClient client = HttpClientBuilder.create().build();
         HttpGet request = new HttpGet(uri);
-
-        request.addHeader("Authorization", "Bearer " + getApiToken());
+        String apiToken = inTestMode() ? "test-token" : getApiToken();
+        request.addHeader("Authorization", "Bearer " + apiToken);
         request.setHeader("Accept-Charset", charset);
         HttpResponse response;
 
@@ -228,7 +228,7 @@ public class Auth0Users {
      */
     private static URIBuilder getURIBuilder() {
         URIBuilder builder = new URIBuilder();
-        if (AUTH0_DOMAIN.equals("your-auth0-domain")) {
+        if (inTestMode()) {
             // set items for testing purposes assuming use of a Wiremock server
             builder.setScheme("http");
             builder.setPort(8089);
@@ -239,6 +239,11 @@ public class Auth0Users {
             builder.setHost(AUTH0_DOMAIN);
         }
         return builder;
+    }
+
+    /** Helper method to determine if app is running tests or in dev/production. */
+    private static boolean inTestMode() {
+        return AUTH0_DOMAIN.equals("your-auth0-domain");
     }
 
     /**

--- a/src/main/java/com/conveyal/datatools/manager/auth/Auth0Users.java
+++ b/src/main/java/com/conveyal/datatools/manager/auth/Auth0Users.java
@@ -91,8 +91,8 @@ public class Auth0Users {
 
         HttpClient client = HttpClientBuilder.create().build();
         HttpGet request = new HttpGet(uri);
-        String apiToken = inTestMode() ? "test-token" : getApiToken();
-        request.addHeader("Authorization", "Bearer " + apiToken);
+
+        request.addHeader("Authorization", "Bearer " + getApiToken());
         request.setHeader("Accept-Charset", charset);
         HttpResponse response;
 
@@ -228,7 +228,7 @@ public class Auth0Users {
      */
     private static URIBuilder getURIBuilder() {
         URIBuilder builder = new URIBuilder();
-        if (inTestMode()) {
+        if (AUTH0_DOMAIN.equals("your-auth0-domain")) {
             // set items for testing purposes assuming use of a Wiremock server
             builder.setScheme("http");
             builder.setPort(8089);
@@ -239,11 +239,6 @@ public class Auth0Users {
             builder.setHost(AUTH0_DOMAIN);
         }
         return builder;
-    }
-
-    /** Helper method to determine if app is running tests or in dev/production. */
-    private static boolean inTestMode() {
-        return AUTH0_DOMAIN.equals("your-auth0-domain");
     }
 
     /**

--- a/src/main/java/com/conveyal/datatools/manager/auth/Auth0Users.java
+++ b/src/main/java/com/conveyal/datatools/manager/auth/Auth0Users.java
@@ -4,10 +4,14 @@ import com.conveyal.datatools.manager.DataManager;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.http.HttpResponse;
+import org.apache.http.NameValuePair;
 import org.apache.http.client.HttpClient;
+import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.util.EntityUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -15,7 +19,10 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Date;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -24,8 +31,17 @@ import java.util.Set;
  */
 public class Auth0Users {
     private static final String AUTH0_DOMAIN = DataManager.getConfigPropertyAsText("AUTH0_DOMAIN");
-    private static final String AUTH0_API_TOKEN = DataManager.getConfigPropertyAsText("AUTH0_TOKEN");
+    // This client/secret pair is for making requests for an API access token used with the Management API.
+    private static final String AUTH0_API_CLIENT = DataManager.getConfigPropertyAsText("AUTH0_API_CLIENT");
+    private static final String AUTH0_API_SECRET = DataManager.getConfigPropertyAsText("AUTH0_API_SECRET");
+    // This is the UI client ID which is currently used to synchronize the user permissions object between server and UI.
     private static final String clientId = DataManager.getConfigPropertyAsText("AUTH0_CLIENT_ID");
+    private static final String MANAGEMENT_API_VERSION = "v2";
+    private static final String SEARCH_API_VERSION = "v3";
+    private static final String API_PATH = "/api/" + MANAGEMENT_API_VERSION;
+    private static final String USERS_API_PATH = API_PATH + "/users";
+    // Cached API token so that we do not have to request a new one each time a Management API request is made.
+    private static Auth0AccessToken cachedToken = null;
     private static final ObjectMapper mapper = new ObjectMapper();
     private static final Logger LOG = LoggerFactory.getLogger(Auth0Users.class);
 
@@ -41,31 +57,29 @@ public class Auth0Users {
         // always filter users by datatools client_id
         String defaultQuery = "app_metadata.datatools.client_id:" + clientId;
         URIBuilder builder = getURIBuilder();
-        builder.setPath("/api/v2/users");
+        builder.setPath(USERS_API_PATH);
         builder.setParameter("sort", "email:1");
         builder.setParameter("per_page", Integer.toString(perPage));
         builder.setParameter("page", Integer.toString(page));
         builder.setParameter("include_totals", Boolean.toString(includeTotals));
         if (searchQuery != null) {
-            builder.setParameter("search_engine", "v3");
+            builder.setParameter("search_engine", SEARCH_API_VERSION);
             builder.setParameter("q", searchQuery + " AND " + defaultQuery);
         }
         else {
-            builder.setParameter("search_engine", "v3");
+            builder.setParameter("search_engine", SEARCH_API_VERSION);
             builder.setParameter("q", defaultQuery);
         }
 
-        URI uri = null;
+        URI uri;
 
         try {
             uri = builder.build();
-
+            return uri;
         } catch (URISyntaxException e) {
             e.printStackTrace();
             return null;
         }
-
-        return uri;
     }
 
     /**
@@ -78,7 +92,7 @@ public class Auth0Users {
         HttpClient client = HttpClientBuilder.create().build();
         HttpGet request = new HttpGet(uri);
 
-        request.addHeader("Authorization", "Bearer " + AUTH0_API_TOKEN);
+        request.addHeader("Authorization", "Bearer " + getApiToken());
         request.setHeader("Accept-Charset", charset);
         HttpResponse response;
 
@@ -120,6 +134,54 @@ public class Auth0Users {
     }
 
     /**
+     * Gets an Auth0 API access token for authenticating requests to the Auth0 Management API. This will either create
+     * a new token using the oauth token endpoint or grab a cached token that it has already created (if it has not
+     * expired). More information on setting this up is here: https://auth0.com/docs/api/management/v2/get-access-tokens-for-production
+     */
+    private static String getApiToken() {
+        long nowInMillis = new Date().getTime();
+        // If cached token has not expired, use it instead of requesting a new one.
+        if (cachedToken != null && cachedToken.getExpirationTime() > nowInMillis) {
+            long minutesToExpiration = (cachedToken.getExpirationTime() - nowInMillis) / 1000 / 60;
+            LOG.info("Using cached token (expires in {} minutes)", minutesToExpiration);
+            return cachedToken.access_token;
+        }
+        LOG.info("Getting new Auth0 API access token (cached token does not exist or has expired).");
+        // Create client and build URL.
+        HttpClient client = HttpClientBuilder.create().build();
+        URIBuilder builder = getURIBuilder();
+        try {
+            // First get base url for use in audience URL param. (Trailing slash required.)
+            final String audienceUrl = builder.setPath(API_PATH + "/").build().toString();
+            URI uri = builder.setPath("/oauth/token").build();
+            LOG.info(uri.toString());
+            LOG.info(audienceUrl);
+            HttpPost post = new HttpPost(uri);
+            post.setHeader("content-type", "application/x-www-form-urlencoded");
+            List<NameValuePair> urlParameters = new ArrayList<>();
+            urlParameters.add(new BasicNameValuePair("grant_type", "client_credentials"));
+            urlParameters.add(new BasicNameValuePair("client_id", AUTH0_API_CLIENT));
+            urlParameters.add(new BasicNameValuePair("client_secret", AUTH0_API_SECRET));
+            urlParameters.add(new BasicNameValuePair("audience", audienceUrl));
+            post.setEntity(new UrlEncodedFormEntity(urlParameters));
+            HttpResponse response = client.execute(post);
+            int code = response.getStatusLine().getStatusCode();
+            if (code >= 300) LOG.error("Could not get Auth0 API token");
+            String token = EntityUtils.toString(response.getEntity());
+            LOG.info(token);
+            Auth0AccessToken auth0AccessToken = mapper.readValue(token, Auth0AccessToken.class);
+            LOG.info("Scope: {}", auth0AccessToken.scope);
+            LOG.info("Token type: {}", auth0AccessToken.token_type);
+            // Cache token for later use.
+            cachedToken = auth0AccessToken;
+            return cachedToken.access_token;
+        } catch (IllegalStateException | URISyntaxException | IOException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+    /**
      * Wrapper method for performing user search with default per page count.
      * @return JSON string of users matching search query
      */
@@ -141,7 +203,7 @@ public class Auth0Users {
      */
     public static Auth0UserProfile getUserById(String id) {
         URIBuilder builder = getURIBuilder();
-        builder.setPath("/api/v2/users/" + id);
+        builder.setPath(String.join("/", USERS_API_PATH, id));
         URI uri = null;
         try {
             uri = builder.build();

--- a/src/main/java/com/conveyal/datatools/manager/auth/Auth0Users.java
+++ b/src/main/java/com/conveyal/datatools/manager/auth/Auth0Users.java
@@ -39,7 +39,7 @@ public class Auth0Users {
     private static final String MANAGEMENT_API_VERSION = "v2";
     private static final String SEARCH_API_VERSION = "v3";
     private static final String API_PATH = "/api/" + MANAGEMENT_API_VERSION;
-    private static final String USERS_API_PATH = API_PATH + "/users";
+    public static final String USERS_API_PATH = API_PATH + "/users";
     // Cached API token so that we do not have to request a new one each time a Management API request is made.
     private static Auth0AccessToken cachedToken = null;
     private static final ObjectMapper mapper = new ObjectMapper();

--- a/src/main/java/com/conveyal/datatools/manager/controllers/api/UserController.java
+++ b/src/main/java/com/conveyal/datatools/manager/controllers/api/UserController.java
@@ -42,6 +42,7 @@ import java.util.List;
 import java.util.Map;
 
 import static com.conveyal.datatools.common.utils.SparkUtils.logMessageAndHalt;
+import static com.conveyal.datatools.manager.auth.Auth0Users.USERS_API_PATH;
 import static com.conveyal.datatools.manager.auth.Auth0Users.getUserById;
 import static spark.Spark.delete;
 import static spark.Spark.get;
@@ -61,8 +62,7 @@ public class UserController {
     private static Logger LOG = LoggerFactory.getLogger(UserController.class);
     private static ObjectMapper mapper = new ObjectMapper();
     private static final String UTF_8 = "UTF-8";
-    static final String USERS_PATH = "/api/v2/users";
-    static final String DEFAULT_BASE_USERS_URL = "https://" + AUTH0_DOMAIN  + USERS_PATH;
+    static final String DEFAULT_BASE_USERS_URL = "https://" + AUTH0_DOMAIN  + USERS_API_PATH;
     /** Users URL uses Auth0 domain by default, but can be overridden with {@link #setBaseUsersUrl(String)} for testing. */
     private static String baseUsersUrl = DEFAULT_BASE_USERS_URL;
     private static final JsonManager<Project> json = new JsonManager<>(Project.class, JsonViews.UserInterface.class);

--- a/src/main/java/com/conveyal/datatools/manager/controllers/api/UserController.java
+++ b/src/main/java/com/conveyal/datatools/manager/controllers/api/UserController.java
@@ -71,9 +71,9 @@ public class UserController {
      * Auth0 API (get user) than the other get methods (user search query).
      */
     private static String getUser(Request req, Response res) {
-        HttpGet request = new HttpGet(getUserIdUrl(req));
-        setHeaders(req, request);
-        return executeRequestAndGetResult(request, req);
+        HttpGet getUserRequest = new HttpGet(getUserIdUrl(req));
+        setHeaders(req, getUserRequest);
+        return executeRequestAndGetResult(getUserRequest, req);
     }
 
     /**
@@ -145,8 +145,8 @@ public class UserController {
      * injecting permissions somehow into the create user request.
      */
     private static String createPublicUser(Request req, Response res) {
-        HttpPost request = new HttpPost(baseUsersUrl);
-        setHeaders(req, request);
+        HttpPost createUserRequest = new HttpPost(baseUsersUrl);
+        setHeaders(req, createUserRequest);
 
         JsonNode jsonNode = parseJsonFromBody(req);
         String json = String.format("{" +
@@ -155,17 +155,17 @@ public class UserController {
                 "\"password\": %s," +
                 "\"app_metadata\": {\"datatools\": [{\"permissions\": [], \"projects\": [], \"subscriptions\": [], \"client_id\": \"%s\" }] } }",
                 jsonNode.get("email"), jsonNode.get("password"), AUTH0_CLIENT_ID);
-        setRequestEntityUsingJson(request, json, req);
+        setRequestEntityUsingJson(createUserRequest, json, req);
 
-        return executeRequestAndGetResult(request, req);
+        return executeRequestAndGetResult(createUserRequest, req);
     }
 
     /**
      * HTTP endpoint to create new Auth0 user for the application.
      */
     private static String createUser(Request req, Response res) {
-        HttpPost request = new HttpPost(baseUsersUrl);
-        setHeaders(req, request);
+        HttpPost createUserRequest = new HttpPost(baseUsersUrl);
+        setHeaders(req, createUserRequest);
 
         JsonNode jsonNode = parseJsonFromBody(req);
         String json = String.format("{" +
@@ -174,9 +174,9 @@ public class UserController {
                 "\"password\": %s," +
                 "\"app_metadata\": {\"datatools\": [%s] } }"
                 , jsonNode.get("email"), jsonNode.get("password"), jsonNode.get("permissions"));
-        setRequestEntityUsingJson(request, json, req);
+        setRequestEntityUsingJson(createUserRequest, json, req);
 
-        return executeRequestAndGetResult(request, req);
+        return executeRequestAndGetResult(createUserRequest, req);
     }
 
     private static String updateUser(Request req, Response res) {
@@ -193,8 +193,8 @@ public class UserController {
 
         LOG.info("Updating user {}", user.getEmail());
 
-        HttpPatch request = new HttpPatch(getUserIdUrl(req));
-        setHeaders(req, request);
+        HttpPatch updateUserRequest = new HttpPatch(getUserIdUrl(req));
+        setHeaders(req, updateUserRequest);
 
         JsonNode jsonNode = parseJsonFromBody(req);
 
@@ -210,15 +210,15 @@ public class UserController {
 //        }
         String json = "{ \"app_metadata\": { \"datatools\" : " + data + " }}";
 
-        setRequestEntityUsingJson(request, json, req);
+        setRequestEntityUsingJson(updateUserRequest, json, req);
 
-        return executeRequestAndGetResult(request, req);
+        return executeRequestAndGetResult(updateUserRequest, req);
     }
 
     private static Object deleteUser(Request req, Response res) {
-        HttpDelete request = new HttpDelete(getUserIdUrl(req));
-        setHeaders(req, request);
-        executeRequestAndGetResult(request, req);
+        HttpDelete deleteUserRequest = new HttpDelete(getUserIdUrl(req));
+        setHeaders(req, deleteUserRequest);
+        executeRequestAndGetResult(deleteUserRequest, req);
         return true;
     }
 

--- a/src/test/java/com/conveyal/datatools/manager/controllers/api/AppInfoControllerTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/controllers/api/AppInfoControllerTest.java
@@ -33,7 +33,7 @@ public class AppInfoControllerTest {
             .get("/api/manager/public/appinfo")
         .then()
             // make sure the repoUrl matches what is found in the pom.xml
-            .body("repoUrl", equalTo("https://github.com/ibi-transit/datatools-server.git"))
+            .body("repoUrl", equalTo("https://github.com/ibi-group/datatools-server.git"))
             .extract().response().asString();
 
         // parse the json and make sure the commit is the length of characters that a commit hash would be

--- a/src/test/java/com/conveyal/datatools/manager/controllers/api/AppInfoControllerTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/controllers/api/AppInfoControllerTest.java
@@ -33,7 +33,7 @@ public class AppInfoControllerTest {
             .get("/api/manager/public/appinfo")
         .then()
             // make sure the repoUrl matches what is found in the pom.xml
-            .body("repoUrl", equalTo("https://github.com/conveyal/datatools-server.git"))
+            .body("repoUrl", equalTo("https://github.com/ibi-transit/datatools-server.git"))
             .extract().response().asString();
 
         // parse the json and make sure the commit is the length of characters that a commit hash would be

--- a/src/test/java/com/conveyal/datatools/manager/controllers/api/UserControllerTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/controllers/api/UserControllerTest.java
@@ -3,7 +3,6 @@ package com.conveyal.datatools.manager.controllers.api;
 import com.conveyal.datatools.DatatoolsTest;
 import com.conveyal.datatools.manager.DataManager;
 import com.conveyal.datatools.manager.auth.Auth0Users;
-import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;

--- a/src/test/resources/com/conveyal/datatools/auth0-mock-responses/__files/getAccessToken.json
+++ b/src/test/resources/com/conveyal/datatools/auth0-mock-responses/__files/getAccessToken.json
@@ -1,0 +1,6 @@
+{
+  "access_token" : "test.token",
+  "expires_in" : 86400,
+  "token_type" : "Bearer",
+  "scope" : "read:users update:users delete:users create:users read:users_app_metadata update:users_app_metadata delete:users_app_metadata create:users_app_metadata"
+}

--- a/src/test/resources/com/conveyal/datatools/auth0-mock-responses/__files/getAccessTokenWithInvalidScope.json
+++ b/src/test/resources/com/conveyal/datatools/auth0-mock-responses/__files/getAccessTokenWithInvalidScope.json
@@ -1,0 +1,6 @@
+{
+  "access_token" : "test.token",
+  "expires_in" : 86400,
+  "token_type" : "Bearer",
+  "scope" : null
+}

--- a/src/test/resources/snapshots/com/conveyal/datatools/manager/controllers/api/UserControllerTest/updateUserFailsWhenApiTokenInvalid-0.json
+++ b/src/test/resources/snapshots/com/conveyal/datatools/manager/controllers/api/UserControllerTest/updateUserFailsWhenApiTokenInvalid-0.json
@@ -1,0 +1,5 @@
+{
+  "code" : 404,
+  "message" : "Could not update user: User with id auth0|test-existing-user not found (or there are issues with the Auth0 configuration)",
+  "result" : "ERR"
+}


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR migrates the Auth0 Management API from v1 to v2. Instead of using a static token defined in the config, this instead uses a machine-to-machine client/secret pair to request a new token (or use a cached token) every time it needs to make a request to the Management API. Fixes #183