### PR TITLE
Fix performance issues with GTFS+ validation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -249,7 +249,7 @@
         <dependency>
             <groupId>com.conveyal</groupId>
             <artifactId>gtfs-lib</artifactId>
-            <version>4.3.6</version>
+            <version>5.0.0</version>
         </dependency>
 
         <!-- Used for data-tools application database -->

--- a/src/main/java/com/conveyal/datatools/manager/controllers/api/GtfsPlusController.java
+++ b/src/main/java/com/conveyal/datatools/manager/controllers/api/GtfsPlusController.java
@@ -255,7 +255,7 @@ public class GtfsPlusController {
         GtfsPlusValidation gtfsPlusValidation = null;
         try {
             gtfsPlusValidation = GtfsPlusValidation.validate(feedVersionId);
-        } catch(IOException e) {
+        } catch(Exception e) {
             logMessageAndHalt(req, 500, "Could not read GTFS+ zip file", e);
         }
         return gtfsPlusValidation;

--- a/src/main/java/com/conveyal/datatools/manager/gtfsplus/GtfsPlusValidation.java
+++ b/src/main/java/com/conveyal/datatools/manager/gtfsplus/GtfsPlusValidation.java
@@ -19,7 +19,6 @@ import java.io.InputStreamReader;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Date;
 import java.util.Enumeration;
 import java.util.LinkedList;
 import java.util.List;
@@ -50,7 +49,7 @@ public class GtfsPlusValidation implements Serializable {
      * FIXME: For now this uses the MapDB-backed GTFSFeed class. Which actually suggests that this might
      *   should be contained within a MonitorableJob.
      */
-    public static GtfsPlusValidation validate(String feedVersionId) throws IOException {
+    public static GtfsPlusValidation validate(String feedVersionId) throws Exception {
         GtfsPlusValidation validation = new GtfsPlusValidation(feedVersionId);
         if (!DataManager.isModuleEnabled("gtfsplus")) {
             throw new IllegalStateException("GTFS+ module must be enabled in server.yml to run GTFS+ validation.");
@@ -60,7 +59,15 @@ public class GtfsPlusValidation implements Serializable {
         FeedVersion feedVersion = Persistence.feedVersions.getById(feedVersionId);
         // Load the main GTFS file.
         // FIXME: Swap MapDB-backed GTFSFeed for use of SQL data?
-        GTFSFeed gtfsFeed = GTFSFeed.fromFile(feedVersion.retrieveGtfsFile().getAbsolutePath());
+        String gtfsFeedDbFilePath = gtfsPlusStore.getPathToFeed(feedVersionId + ".db");
+        // This check for existence must occur before GTFSFeed is instantiated (and the file must be discarded
+        // immediately).
+        boolean dbExists = new File(gtfsFeedDbFilePath).isFile();
+        GTFSFeed gtfsFeed = new GTFSFeed(gtfsFeedDbFilePath);
+        if (!dbExists) {
+            LOG.info("Loading GTFS file into new MapDB file (.db).");
+            gtfsFeed.loadFromFile(new ZipFile(feedVersion.retrieveGtfsFile().getAbsolutePath()));
+        }
         // check for saved GTFS+ data
         File file = gtfsPlusStore.getFeed(feedVersionId);
         if (file == null) {
@@ -85,6 +92,7 @@ public class GtfsPlusValidation implements Serializable {
                 }
             }
         }
+        gtfsFeed.close();
         LOG.info("GTFS+ tables found: {}/{}", gtfsPlusTableCount, DataManager.gtfsPlusConfig.size());
         return validation;
     }

--- a/src/test/java/com/conveyal/datatools/manager/gtfsplus/GtfsPlusValidationTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/gtfsplus/GtfsPlusValidationTest.java
@@ -43,7 +43,7 @@ public class GtfsPlusValidationTest {
     }
 
     @Test
-    public void canValidateCleanGtfsPlus() throws IOException {
+    public void canValidateCleanGtfsPlus() throws Exception {
         LOG.info("Validation BART GTFS+");
         GtfsPlusValidation validation = GtfsPlusValidation.validate(bartVersion1.id);
         // Expect issues to be zero.


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Opt for storing a file-backed MapDB database for reading GTFS entities to validate GTFS+. Otherwise, we're left reloading this file into memory each time the validate method is called which is bad news for large feeds.

NOTE: This PR is also waiting on changes in conveyal/gtfs-lib#240 (need to bump gtfs-lib version once that is released).
