### PR TITLE
Bump gtfs-lib to 5.0.1 for GTFSFeed NPE fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -249,7 +249,7 @@
         <dependency>
             <groupId>com.conveyal</groupId>
             <artifactId>gtfs-lib</artifactId>
-            <version>5.0.0</version>
+            <version>5.0.1</version>
         </dependency>
 
         <!-- Used for data-tools application database -->

--- a/src/main/java/com/conveyal/datatools/manager/gtfsplus/GtfsPlusValidation.java
+++ b/src/main/java/com/conveyal/datatools/manager/gtfsplus/GtfsPlusValidation.java
@@ -73,12 +73,8 @@ public class GtfsPlusValidation implements Serializable {
         } catch (Exception e) {
             LOG.error("MapDB file for GTFSFeed appears to be corrupted. Deleting and trying to load from zip file.", e);
             // Error loading MapDB file. Delete and try to reload.
-            String[] extensions = {".db", ".db.p"};
-            // delete local cache files (including zip) when feed removed from cache
-            for (String type : extensions) {
-                File file = new File(gtfsPlusStore.getPathToFeed(feedVersionId + type));
-                file.delete();
-            }
+            new File(gtfsFeedDbFilePath).delete();
+            new File(gtfsFeedDbFilePath + ".p").delete();
             LOG.info("Attempt #2 to load GTFS file into new MapDB file (.db).");
             gtfsFeed = new GTFSFeed(gtfsFeedDbFilePath);
             gtfsFeed.loadFromFile(new ZipFile(feedVersion.retrieveGtfsFile().getAbsolutePath()));

--- a/src/main/resources/public/index.html
+++ b/src/main/resources/public/index.html
@@ -4,8 +4,8 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
 
-    <title>Catalogue</title>
-    <link rel="shortcut icon" href="https://d2f1n6ed3ipuic.cloudfront.net/conveyal-128x128.png" type="image/x-icon">
+    <title>Data Tools</title>
+    <link rel="shortcut icon" href="https://d2tyb7byn1fef9.cloudfront.net/ibi_group-128x128.png" type="image/x-icon">
     <link href="https://${S3BUCKET}.s3.amazonaws.com/dist/index.css" rel="stylesheet">
   </head>
   <body>


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

- Bumps gtfs-lib to [5.0.1](https://github.com/conveyal/gtfs-lib/releases/tag/v5.0.1)
- Changes favicon logo to IBI
- Simplifies some code that handles corrupt MapDB file deletion.