### PR TITLE
Properly detect rows with incorrect number of fields

### DIFF
--- a/src/main/java/com/conveyal/datatools/manager/gtfsplus/GtfsPlusValidation.java
+++ b/src/main/java/com/conveyal/datatools/manager/gtfsplus/GtfsPlusValidation.java
@@ -8,6 +8,7 @@ import com.conveyal.datatools.manager.persistence.Persistence;
 import com.conveyal.gtfs.GTFSFeed;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
+import org.apache.commons.io.input.BOMInputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -100,7 +101,10 @@ public class GtfsPlusValidation implements Serializable {
                 if (tableNode.get("name").asText().equals(entry.getName())) {
                     LOG.info("Validating GTFS+ table: " + entry.getName());
                     gtfsPlusTableCount++;
-                    validateTable(validation.issues, tableNode, zipFile.getInputStream(entry), gtfsFeed);
+                    // Skip any byte order mark that may be present. Files must be UTF-8,
+                    // but the GTFS spec says that "files that include the UTF byte order mark are acceptable".
+                    InputStream bis = new BOMInputStream(zipFile.getInputStream(entry));
+                    validateTable(validation.issues, tableNode, bis, gtfsFeed);
                 }
             }
         }
@@ -124,7 +128,7 @@ public class GtfsPlusValidation implements Serializable {
         String line = in.readLine();
         String[] inputHeaders = line.split(",");
         List<String> fieldList = Arrays.asList(inputHeaders);
-        JsonNode[] fieldsFounds = new JsonNode[inputHeaders.length];
+        JsonNode[] fieldsFound = new JsonNode[inputHeaders.length];
         JsonNode specFields = specTable.get("fields");
         // Iterate over spec fields and check that there are no missing required fields.
         for (int i = 0; i < specFields.size(); i++) {
@@ -133,7 +137,7 @@ public class GtfsPlusValidation implements Serializable {
             int index = fieldList.indexOf(fieldName);
             if (index != -1) {
                 // Add spec field for each field found.
-                fieldsFounds[index] = specField;
+                fieldsFound[index] = specField;
             } else if (isRequired(specField)) {
                 // If spec field not found, check that missing field was not required.
                 issues.add(new ValidationIssue(tableId, fieldName, -1, "Required column missing."));
@@ -141,12 +145,25 @@ public class GtfsPlusValidation implements Serializable {
         }
         // Iterate over each row and validate each field value.
         int rowIndex = 0;
+        int rowsWithWrongNumberOfColumns = 0;
         while ((line = in.readLine()) != null) {
             String[] values = line.split(Consts.COLUMN_SPLIT, -1);
-            for (int v = 0; v < values.length; v++) {
-                validateTableValue(issues, tableId, rowIndex, values[v], fieldsFounds[v], gtfsFeed);
+            // First, check that row has the correct number of fields.
+            if (values.length != fieldsFound.length) {
+                rowsWithWrongNumberOfColumns++;
+            }
+            // Validate each value in row. Note: we iterate over the fields and not values because a row may be missing
+            // columns, but we still want to validate that missing value (e.g., if it is missing a required field).
+            for (int f = 0; f < fieldsFound.length; f++) {
+                // If value exists for index, use that. Otherwise, default to null to avoid out of bounds exception.
+                String val = f < values.length ? values[f] : null;
+                validateTableValue(issues, tableId, rowIndex, val, fieldsFound[f], gtfsFeed);
             }
             rowIndex++;
+        }
+        // Add issue for wrong number of columns after processing all rows.
+        if (rowsWithWrongNumberOfColumns > 0) {
+            issues.add(new ValidationIssue(tableId, null, -1, rowsWithWrongNumberOfColumns + " row(s) do not contain the same number of fields as there are headers. (File may need to be edited manually.)"));
         }
     }
 

--- a/src/main/java/com/conveyal/datatools/manager/gtfsplus/GtfsPlusValidation.java
+++ b/src/main/java/com/conveyal/datatools/manager/gtfsplus/GtfsPlusValidation.java
@@ -162,6 +162,12 @@ public class GtfsPlusValidation implements Serializable {
             rowIndex++;
         }
         // Add issue for wrong number of columns after processing all rows.
+        // Note: We considered adding an issue for each row, but opted for the single error approach because there's no
+        // concept of a row-level issue in the UI right now. So we would potentially need to add that to the UI
+        // somewhere. Also, there's the trouble of reporting the issue at the row level, but not really giving the user
+        // a great way to resolve the issue in the GTFS+ editor. Essentially, all of the rows with the wrong number of
+        // columns can be resolved simply by clicking the "Save and Revalidate" button -- so the resolution is more at
+        // the table level than the row level (like, for example, a bad value for a field would be).
         if (rowsWithWrongNumberOfColumns > 0) {
             issues.add(new ValidationIssue(tableId, null, -1, rowsWithWrongNumberOfColumns + " row(s) do not contain the same number of fields as there are headers. (File may need to be edited manually.)"));
         }

--- a/src/main/resources/gtfs/gtfsplus.yml
+++ b/src/main/resources/gtfs/gtfsplus.yml
@@ -100,7 +100,7 @@
   - name: realtime_trip_id
     required: true
     inputType: TEXT
-    maxLength: 15
+#    maxLength: 15
     columnWidth: 6
     helpContent: Corresponding trip_id provided in real-time feed for MTC.
 
@@ -324,7 +324,7 @@
   - name: service_description
     required: true
     inputType: TEXT
-    maxLength: 30
+    maxLength: 250
     helpContent: Description of the service, as it should appear on 511.org such as Weekdays, Sunday/Holiday
 
 - id: farezone_attributes


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Changes the GTFS+ validation so that it properly detects when files have rows that do not have the correct number of fields. E.g. 
[dumbarton_express_wrong_num_fields.zip](https://github.com/ibi-group/datatools-server/files/3456955/dumbarton_express_wrong_num_fields.zip)

This also fixes an issue where an input file had a BOM that was not being properly ignored: 
[SolTrans-20190716T195942Z-d2d170bb-18bc-44f7-8569-96d8a1de309b.zip](https://github.com/ibi-group/datatools-server/files/3456970/SolTrans-20190716T195942Z-d2d170bb-18bc-44f7-8569-96d8a1de309b.zip)
