### PR TITLE
Exclude sfl4j from gtfs-lib dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -217,7 +217,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.1.3</version>
+            <version>1.2.3</version>
         </dependency>
 
         <!-- Used to connect to and import legacy editor MapDBs -->
@@ -250,6 +250,15 @@
             <groupId>com.conveyal</groupId>
             <artifactId>gtfs-lib</artifactId>
             <version>5.0.2</version>
+            <!-- Exclusions added in order to silence SLF4J warnings about multiple bindings:
+                http://www.slf4j.org/codes.html#multiple_bindings
+            -->
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-simple</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Used for data-tools application database -->


### PR DESCRIPTION
This silences warnings about multiple bindings: http://www.slf4j.org/codes.html#multiple_bindings

### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This excludes a logging dependency from gtfs-lib, which silences slf4j warnings at runtime. Refs #107