### PR TITLE
Use solid-color favicon and cloudfront for js and css

### DIFF
--- a/configurations/default/server.yml.tmp
+++ b/configurations/default/server.yml.tmp
@@ -1,5 +1,6 @@
 application:
   assets_bucket: datatools-staging # dist directory
+  cloudfront_subdomain: abc123
   public_url: http://localhost:9966
   notifications_enabled: false
   port: 4000

--- a/src/main/java/com/conveyal/datatools/manager/DataManager.java
+++ b/src/main/java/com/conveyal/datatools/manager/DataManager.java
@@ -301,7 +301,7 @@ public class DataManager {
         });
         // load index.html
         final String index = resourceToString("/public/index.html")
-                .replace("${S3BUCKET}", getConfigPropertyAsText("application.assets_bucket"));
+                .replace("${CLOUDFRONT_SUBDOMAIN}", getConfigPropertyAsText("application.cloudfront_subdomain"));
         final String auth0html = resourceToString("/public/auth0-silent-callback.html");
 
         // auth0 silent callback

--- a/src/main/resources/public/index.html
+++ b/src/main/resources/public/index.html
@@ -5,11 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
 
     <title>Data Tools</title>
-    <link rel="shortcut icon" href="https://d2tyb7byn1fef9.cloudfront.net/ibi_group-128x128.png" type="image/x-icon">
-    <link href="https://${S3BUCKET}.s3.amazonaws.com/dist/index.css" rel="stylesheet">
+    <link rel="shortcut icon" href="https://d2tyb7byn1fef9.cloudfront.net/ibi-logo-original%402x.png" type="image/x-icon">
+    <link href="https://${CLOUDFRONT_SUBDOMAIN}.cloudfront.net/dist/index.css" rel="stylesheet">
   </head>
   <body>
     <div id="root"></div>
-    <script src="https://${S3BUCKET}.s3.amazonaws.com/dist/index.js"></script>
+    <script src="https://${CLOUDFRONT_SUBDOMAIN}.cloudfront.net/dist/index.js"></script>
   </body>
 </html>


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This changes some stuff in the HTML of datatools-server. It now uses a solid-color favicon and the index.js and index.css files are now loaded from a cloudfront url. Corresponding config changes are noted in server.yml.tmp and the proposed changes in our private configurations.