### PR TITLE
Add public config yaml to app info endpoint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ dist: trusty # jdk 8 not available on xenial
 language: java
 java:
   - oraclejdk8
-install: true
 sudo: false
 # Install mongoDB to perform persistence tests
 services:
@@ -14,21 +13,25 @@ cache:
   directories:
     - $HOME/.m2
     - $HOME/.cache/yarn
+before_install:
+  # install node 12
+  - nvm install 12
+  #- sed -i.bak -e 's|https://nexus.codehaus.org/snapshots/|https://oss.sonatype.org/content/repositories/codehaus-snapshots/|g' ~/.m2/settings.xml
+  # set region in AWS config for S3 setup
+  - mkdir ~/.aws && printf '%s\n' '[default]' 'aws_access_key_id=foo' 'aws_secret_access_key=bar' 'region=us-east-1' > ~/.aws/config
+  - cp configurations/default/server.yml.tmp configurations/default/server.yml
+  # create database for tests
+  - psql -U postgres -c 'CREATE DATABASE catalogue;'
+# Skip the install step (mvn install).
+install: true
 # Install semantic-release
 before_script:
   - yarn global add @conveyal/maven-semantic-release semantic-release@15
   # Create dir for GTFS+ files (used during testing)
   - mkdir /tmp/gtfsplus
-before_install:
-#- sed -i.bak -e 's|https://nexus.codehaus.org/snapshots/|https://oss.sonatype.org/content/repositories/codehaus-snapshots/|g' ~/.m2/settings.xml
-# set region in AWS config for S3 setup
-- mkdir ~/.aws && printf '%s\n' '[default]' 'aws_access_key_id=foo' 'aws_secret_access_key=bar' 'region=us-east-1' > ~/.aws/config
-- cp configurations/default/server.yml.tmp configurations/default/server.yml
-# create database for tests
-- psql -U postgres -c 'CREATE DATABASE catalogue;'
 script:
-# package jar
-- mvn package
+  # package jar
+  - mvn package
 after_success:
   # this first codecov run will upload a report associated with the commit set through Travis CI environment variables
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ cache:
     - $HOME/.m2
     - $HOME/.cache/yarn
 before_install:
-  # install node 12
+  # Install node 12 (needed for maven-semantic-release).
   - nvm install 12
   #- sed -i.bak -e 's|https://nexus.codehaus.org/snapshots/|https://oss.sonatype.org/content/repositories/codehaus-snapshots/|g' ~/.m2/settings.xml
   # set region in AWS config for S3 setup

--- a/src/main/java/com/conveyal/datatools/manager/DataManager.java
+++ b/src/main/java/com/conveyal/datatools/manager/DataManager.java
@@ -364,6 +364,10 @@ public class DataManager {
         return node != null;
     }
 
+    /**
+     * Public getter method for the config file that does not contain any sensitive information. On the contrary, the
+     * {@link #envConfig} file should NOT be shared outside of this class and certainly not shared with the client.
+     */
     public static JsonNode getPublicConfig() {
         return serverConfig;
     }

--- a/src/main/java/com/conveyal/datatools/manager/DataManager.java
+++ b/src/main/java/com/conveyal/datatools/manager/DataManager.java
@@ -364,6 +364,10 @@ public class DataManager {
         return node != null;
     }
 
+    public static JsonNode getPublicConfig() {
+        return serverConfig;
+    }
+
     /**
      * Convenience function to get a config property (nested fields defined by dot notation "data.use_s3_storage") as
      * JsonNode. Checks server.yml, then env.yml, and finally returns null if property is not found.

--- a/src/main/java/com/conveyal/datatools/manager/controllers/api/AppInfoController.java
+++ b/src/main/java/com/conveyal/datatools/manager/controllers/api/AppInfoController.java
@@ -1,27 +1,35 @@
 package com.conveyal.datatools.manager.controllers.api;
 
+import com.conveyal.datatools.manager.DataManager;
 import com.conveyal.datatools.manager.utils.json.JsonUtil;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import spark.Request;
 import spark.Response;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import static com.conveyal.datatools.manager.DataManager.commit;
 import static com.conveyal.datatools.manager.DataManager.repoUrl;
 import static spark.Spark.get;
 
+/**
+ * Controller that provides information about the application being run on the server.
+ */
 public class AppInfoController {
     public static final Logger LOG = LoggerFactory.getLogger(AppInfoController.class);
 
-    public static Map<String, String> getInfo(Request req, Response res) {
-        // TODO: convert into a POJO if more stuff is needed here
-        Map<String, String> json = new HashMap<>();
-        json.put("repoUrl", repoUrl);
-        json.put("commit", commit);
-        return json;
+    /**
+     * HTTP endpoint that provides commit hash for the version of the server being run as well as
+     * shared configuration variables (e.g., the modules or extensions that are enabled).
+     */
+    private static ObjectNode getInfo(Request req, Response res) {
+        // TODO: convert into a POJO if more stuff is needed here. Although there would need to be an accommodation for
+        //  the config field, which has a structure that is dependent on whatever is included in server.yml.
+        return JsonUtil.objectMapper.createObjectNode()
+            .put("repoUrl", repoUrl)
+            .put("commit", commit)
+            // Add config variables. NOTE: this uses server.yml, which is not intended to have any secure information.
+            .putPOJO("config", DataManager.getPublicConfig());
     }
 
     public static void register (String apiPrefix) {

--- a/src/main/java/com/conveyal/datatools/manager/extensions/transitfeeds/TransitFeedsFeedResource.java
+++ b/src/main/java/com/conveyal/datatools/manager/extensions/transitfeeds/TransitFeedsFeedResource.java
@@ -7,8 +7,8 @@ import com.conveyal.datatools.manager.models.FeedSource;
 import com.conveyal.datatools.manager.models.FeedVersion;
 import com.conveyal.datatools.manager.models.Project;
 import com.conveyal.datatools.manager.persistence.Persistence;
+import com.conveyal.datatools.manager.utils.json.JsonUtil;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,11 +28,11 @@ public class TransitFeedsFeedResource implements ExternalFeedResource {
 
     public static final Logger LOG = LoggerFactory.getLogger(TransitFeedsFeedResource.class);
 
-    private String api, apiKey;
+    private static final String api = "http://api.transitfeeds.com/v1/getFeeds";
+    private String apiKey;
 
     public TransitFeedsFeedResource () {
-        api = DataManager.getConfigPropertyAsText("extensions.transitfeeds.api");
-        apiKey = DataManager.getConfigPropertyAsText("extensions.transitfeeds.key");
+        apiKey = DataManager.getConfigPropertyAsText("TRANSITFEEDS_KEY");
     }
 
     @Override
@@ -45,9 +45,8 @@ public class TransitFeedsFeedResource implements ExternalFeedResource {
         LOG.info("Importing feeds from TransitFeeds");
 
         URL url;
-        ObjectMapper mapper = new ObjectMapper();
         // multiple pages for transitfeeds because of 100 feed limit per page
-        Boolean nextPage = true;
+        boolean nextPage = true;
         int count = 1;
 
         do {
@@ -90,7 +89,7 @@ public class TransitFeedsFeedResource implements ExternalFeedResource {
             String json = response.toString();
             JsonNode transitFeedNode = null;
             try {
-                transitFeedNode = mapper.readTree(json);
+                transitFeedNode = JsonUtil.objectMapper.readTree(json);
             } catch (IOException ex) {
                 LOG.error("Error parsing TransitFeeds JSON response");
                 throw ex;

--- a/src/test/java/com/conveyal/datatools/EndToEndTest.java
+++ b/src/test/java/com/conveyal/datatools/EndToEndTest.java
@@ -42,9 +42,7 @@ public class EndToEndTest {
             // clone dev datatools-ui
             runCommand(
                 String.format(
-                    // temporarily clone e2e-coverage branch until that gets merged into dev
-                    "git clone -b e2e-coverage https://github.com/conveyal/datatools-ui.git %s",
-//                    "git clone https://github.com/conveyal/datatools-ui.git %s",
+                    "git clone https://github.com/ibi-group/datatools-ui.git %s",
                     datatoolsUiPath
                 )
             );


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Add public config info to app info endpoint in order to consolidate common server/UI configuration settings into a single location. Refs ibi-group/datatools-ui#367

Note: this also contains some minor clean up for the transitfeeds extension (touched in the process of cleaning up configuration settings).