### PR TITLE
fix(merge): omit agency_id field from routes in mtc merges

### DIFF
--- a/src/main/java/com/conveyal/datatools/manager/jobs/MergeFeedsJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/MergeFeedsJob.java
@@ -811,9 +811,13 @@ public class MergeFeedsJob extends MonitorableJob {
             if (routeRows.size() > 0) {
                 if (shouldWriteAgencyIdInRoutesTable) {
                     // agency_id should be written, proceed with all fields
+                    LOG.info("writing route table with agency_id");
                     writeZipEntryWithHeaders(out, writer, table, specFields);
-                    writer.write(routeRows);
+                    for (String[] routeRow : routeRows) {
+                        writer.write(routeRow);
+                    }
                 } else {
+                    LOG.info("writing route table without agency_id");
                     // agency_id should not be written
                     // write headers without agency_id
                     List<Field> specFieldsWithoutAgencyId = specFields.stream()


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

From the email forwarded to me, it seems that MTC wants to never have the _agency_id_ field included in the _routes.txt_ file. So I made some code that does just that. 

Fixes #233. 