### PR TITLE
Bump jackson databind to 2.9.10 to address vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -290,11 +290,11 @@
             <artifactId>jackson-dataformat-yaml</artifactId>
             <version>${jackson.version}</version>
         </dependency>
-        <!-- This version does not use ${jackson.version} because v2.9.9.1 does not exist for jackson-annotations. -->
+        <!-- This version does not use ${jackson.version} because v2.9.10 does not exist for jackson-annotations. -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.9.1</version>
+            <version>2.9.10</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <url>https://github.com/ibi-group/datatools-server.git</url>
     </scm>
     <properties>
-        <jackson.version>2.9.9</jackson.version>
+        <jackson.version>2.9.10</jackson.version>
         <!-- Using the latest version of geotools (e.g, 20) seems to cause issues with the shapefile
         plugin where the_geom for each feature is null. -->
         <geotools.version>17.5</geotools.version>
@@ -290,11 +290,10 @@
             <artifactId>jackson-dataformat-yaml</artifactId>
             <version>${jackson.version}</version>
         </dependency>
-        <!-- This version does not use ${jackson.version} because v2.9.10 does not exist for jackson-annotations. -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.10</version>
+            <version>${jackson.version}</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Addresses https://nvd.nist.gov/vuln/detail/CVE-2019-16335 and https://nvd.nist.gov/vuln/detail/CVE-2019-14540