### PR TITLE
ci(e2e): disable e2e test because it has been broken for months

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,8 @@ before_install:
   #- sed -i.bak -e 's|https://nexus.codehaus.org/snapshots/|https://oss.sonatype.org/content/repositories/codehaus-snapshots/|g' ~/.m2/settings.xml
   # run a script to see if the e2e tests should be ran. This script will set the environment variable SHOULD_RUN_E2E
   # which is used in later travis commands.
-  - source ./scripts/check-if-e2e-tests-should-run-on-travis.sh
+  # FIXME: E2E is disabled because it has broken for months. PR to fix e2e should uncomment this line.
+  # - source ./scripts/check-if-e2e-tests-should-run-on-travis.sh
   # set region in AWS config for S3 setup
   # - mkdir ~/.aws && printf '%s\n' '[default]' 'aws_access_key_id=foo' 'aws_secret_access_key=bar' 'region=us-east-1' > ~/.aws/config
   # add aws credentials for datatools-server


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR disables E2E tests because they are broken and have not been fixed for months.