### PR TITLE
Add OtpServer#role field for assuming role

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -410,6 +410,13 @@
             <artifactId>aws-java-sdk-elasticloadbalancingv2</artifactId>
             <version>${awsjavasdk.version}</version>
         </dependency>
+        <!-- AWS STS allows Data Tools to assume other roles in order to deploy OTP to other AWS accounts. -->
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-sts</artifactId>
+            <version>${awsjavasdk.version}</version>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/src/main/java/com/conveyal/datatools/common/utils/AWSUtils.java
+++ b/src/main/java/com/conveyal/datatools/common/utils/AWSUtils.java
@@ -125,15 +125,19 @@ public class AWSUtils {
     }
 
     /**
-     * Create credentials for a new session for the provided IAM role. The primary AWS account for the Data Tools
-     * application must be able to assume this role (e.g., through delegating access via an account IAM role
+     * Create credentials for a new session for the provided IAM role and session name. The primary AWS account for the
+     * Data Tools application must be able to assume this role (e.g., through delegating access via an account IAM role
      * https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html). The credentials can be
      * then used for creating a temporary S3 or EC2 client.
      */
     public static AWSStaticCredentialsProvider getCredentialsForRole(String role, String sessionName) {
+        String roleSessionName = "data-tools-session";
         if (role == null) return null;
-        STSAssumeRoleSessionCredentialsProvider.Builder builder = new STSAssumeRoleSessionCredentialsProvider.Builder(role, "test");
-        STSAssumeRoleSessionCredentialsProvider sessionProvider = builder.build();
+        if (sessionName != null) roleSessionName = String.join("-", roleSessionName, sessionName);
+        STSAssumeRoleSessionCredentialsProvider sessionProvider = new STSAssumeRoleSessionCredentialsProvider.Builder(
+            role,
+            roleSessionName
+        ).build();
         AWSSessionCredentials credentials = sessionProvider.getCredentials();
         return new AWSStaticCredentialsProvider(new BasicSessionCredentials(
             credentials.getAWSAccessKeyId(), credentials.getAWSSecretKey(),
@@ -145,8 +149,8 @@ public class AWSUtils {
      * will be used.
      */
     public static AmazonEC2 getEC2ClientForRole (String role) {
-        AWSStaticCredentialsProvider credentials = getCredentialsForRole(role, "ec2 client");
-        return AmazonEC2Client.builder().withCredentials(credentials).build();
+        AWSStaticCredentialsProvider credentials = getCredentialsForRole(role, "ec2-client");
+        return getEC2ClientForCredentials(credentials);
     }
 
     /**
@@ -172,7 +176,7 @@ public class AWSUtils {
      * will be used. Similarly, if the region is null, it will be omitted while building the S3 client.
      */
     public static AmazonS3 getS3ClientForRole(String role, String region) {
-        AWSStaticCredentialsProvider credentials = getCredentialsForRole(role, "s3 client");
+        AWSStaticCredentialsProvider credentials = getCredentialsForRole(role, "s3-client");
         return getS3ClientForCredentials(credentials, region);
     }
 

--- a/src/main/java/com/conveyal/datatools/common/utils/AWSUtils.java
+++ b/src/main/java/com/conveyal/datatools/common/utils/AWSUtils.java
@@ -169,10 +169,15 @@ public class AWSUtils {
 
     /**
      * Shorthand method to obtain an S3 client for the provided role ARN. If role is null, the default EC2 credentials
-     * will be used.
+     * will be used. Similarly, if the region is null, it will be omitted while building the S3 client.
      */
     public static AmazonS3 getS3ClientForRole(String role, String region) {
         AWSStaticCredentialsProvider credentials = getCredentialsForRole(role, "s3 client");
         return getS3ClientForCredentials(credentials, region);
+    }
+
+    /** Shorthand method to obtain an S3 client for the provided role ARN. */
+    public static AmazonS3 getS3ClientForRole(String role) {
+        return getS3ClientForRole(role, null);
     }
 }

--- a/src/main/java/com/conveyal/datatools/editor/controllers/api/EditorController.java
+++ b/src/main/java/com/conveyal/datatools/editor/controllers/api/EditorController.java
@@ -1,6 +1,6 @@
 package com.conveyal.datatools.editor.controllers.api;
 
-import com.conveyal.datatools.common.utils.S3Utils;
+import com.conveyal.datatools.common.utils.AWSUtils;
 import com.conveyal.datatools.common.utils.SparkUtils;
 import com.conveyal.datatools.editor.controllers.EditorLockController;
 import com.conveyal.datatools.manager.auth.Auth0UserProfile;
@@ -335,7 +335,7 @@ public abstract class EditorController<T extends Entity> {
         int id = getIdFromRequest(req);
         String url;
         try {
-            url = S3Utils.uploadBranding(req, String.format("%s_%d", classToLowercase, id));
+            url = AWSUtils.uploadBranding(req, String.format("%s_%d", classToLowercase, id));
         } catch (HaltException e) {
             // Do not re-catch halts thrown for exceptions that have already been caught.
             throw e;

--- a/src/main/java/com/conveyal/datatools/editor/controllers/api/SnapshotController.java
+++ b/src/main/java/com/conveyal/datatools/editor/controllers/api/SnapshotController.java
@@ -24,7 +24,7 @@ import spark.Response;
 import java.io.IOException;
 import java.util.Collection;
 
-import static com.conveyal.datatools.common.utils.S3Utils.downloadFromS3;
+import static com.conveyal.datatools.common.utils.AWSUtils.downloadFromS3;
 import static com.conveyal.datatools.common.utils.SparkUtils.downloadFile;
 import static com.conveyal.datatools.common.utils.SparkUtils.formatJobMessage;
 import static com.conveyal.datatools.common.utils.SparkUtils.logMessageAndHalt;

--- a/src/main/java/com/conveyal/datatools/manager/controllers/api/DeploymentController.java
+++ b/src/main/java/com/conveyal/datatools/manager/controllers/api/DeploymentController.java
@@ -355,7 +355,7 @@ public class DeploymentController {
             latest = deployment.latest();
             targetGroupArn = latest.ec2Info.targetGroupArn;
             // Also, get credentials for role (if exists), which are needed to terminate instances in external AWS account.
-            credentials = AWSUtils.getCredentialsForRole(latest.role, "deregister and terminate instances");
+            credentials = AWSUtils.getCredentialsForRole(latest.role, "deregister-instances");
         } catch (Exception e) {
             logMessageAndHalt(req, 400, "Latest deploy job does not exist or is missing target group ARN.");
             return false;

--- a/src/main/java/com/conveyal/datatools/manager/controllers/api/DeploymentController.java
+++ b/src/main/java/com/conveyal/datatools/manager/controllers/api/DeploymentController.java
@@ -1,5 +1,6 @@
 package com.conveyal.datatools.manager.controllers.api;
 
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.services.ec2.AmazonEC2;
 import com.amazonaws.services.ec2.AmazonEC2Client;
 import com.amazonaws.services.ec2.model.DescribeInstancesRequest;
@@ -9,6 +10,7 @@ import com.amazonaws.services.ec2.model.Instance;
 import com.amazonaws.services.ec2.model.Reservation;
 import com.amazonaws.services.s3.AmazonS3URI;
 import com.conveyal.datatools.common.status.MonitorableJob;
+import com.conveyal.datatools.common.utils.AWSUtils;
 import com.conveyal.datatools.common.utils.SparkUtils;
 import com.conveyal.datatools.manager.DataManager;
 import com.conveyal.datatools.manager.auth.Auth0UserProfile;
@@ -42,7 +44,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static com.conveyal.datatools.common.utils.S3Utils.downloadFromS3;
+import static com.conveyal.datatools.common.utils.AWSUtils.downloadFromS3;
 import static com.conveyal.datatools.common.utils.SparkUtils.logMessageAndHalt;
 import static spark.Spark.delete;
 import static spark.Spark.get;
@@ -340,8 +342,13 @@ public class DeploymentController {
         // Get the target group ARN from the latest deployment. Surround in a try/catch in case of NPEs.
         // TODO: Perhaps provide some other way to provide the target group ARN.
         String targetGroupArn;
+        DeployJob.DeploySummary latest;
+        AWSStaticCredentialsProvider credentials;
         try {
-            targetGroupArn = deployment.latest().ec2Info.targetGroupArn;
+            latest = deployment.latest();
+            targetGroupArn = latest.ec2Info.targetGroupArn;
+            OtpServer server = Persistence.servers.getById(latest.serverId);
+            credentials = AWSUtils.getCredentialsForRole(server.role, "deregister and terminate instances");
         } catch (Exception e) {
             logMessageAndHalt(req, 400, "Latest deploy job does not exist or is missing target group ARN.");
             return false;
@@ -359,7 +366,7 @@ public class DeploymentController {
             }
         }
         // If checks are ok, terminate instances.
-        boolean success = ServerController.deRegisterAndTerminateInstances(targetGroupArn, idsToTerminate);
+        boolean success = ServerController.deRegisterAndTerminateInstances(credentials, targetGroupArn, idsToTerminate);
         if (!success) {
             logMessageAndHalt(req, 400, "Could not complete termination request");
             return false;
@@ -378,17 +385,18 @@ public class DeploymentController {
     /**
      * Fetches list of {@link EC2InstanceSummary} for all instances matching the provided filters.
      */
-    public static List<EC2InstanceSummary> fetchEC2InstanceSummaries(Filter... filters) {
-        return fetchEC2Instances(filters).stream().map(EC2InstanceSummary::new).collect(Collectors.toList());
+    public static List<EC2InstanceSummary> fetchEC2InstanceSummaries(AmazonEC2 ec2Client, Filter... filters) {
+        return fetchEC2Instances(ec2Client, filters).stream().map(EC2InstanceSummary::new).collect(Collectors.toList());
     }
 
     /**
      * Fetch EC2 instances from AWS that match the provided set of filters (e.g., tags, instance ID, or other properties).
      */
-    public static List<Instance> fetchEC2Instances(Filter... filters) {
+    public static List<Instance> fetchEC2Instances(AmazonEC2 ec2Client, Filter... filters) {
+        if (ec2Client == null) ec2Client = ec2;
         List<Instance> instances = new ArrayList<>();
         DescribeInstancesRequest request = new DescribeInstancesRequest().withFilters(filters);
-        DescribeInstancesResult result = ec2.describeInstances(request);
+        DescribeInstancesResult result = ec2Client.describeInstances(request);
         for (Reservation reservation : result.getReservations()) {
             instances.addAll(reservation.getInstances());
         }

--- a/src/main/java/com/conveyal/datatools/manager/controllers/api/FeedVersionController.java
+++ b/src/main/java/com/conveyal/datatools/manager/controllers/api/FeedVersionController.java
@@ -35,7 +35,7 @@ import java.util.List;
 import java.util.HashSet;
 import java.util.Set;
 
-import static com.conveyal.datatools.common.utils.S3Utils.downloadFromS3;
+import static com.conveyal.datatools.common.utils.AWSUtils.downloadFromS3;
 import static com.conveyal.datatools.common.utils.SparkUtils.copyRequestStreamIntoFile;
 import static com.conveyal.datatools.common.utils.SparkUtils.downloadFile;
 import static com.conveyal.datatools.common.utils.SparkUtils.formatJobMessage;

--- a/src/main/java/com/conveyal/datatools/manager/controllers/api/ProjectController.java
+++ b/src/main/java/com/conveyal/datatools/manager/controllers/api/ProjectController.java
@@ -26,7 +26,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static com.conveyal.datatools.common.utils.S3Utils.downloadFromS3;
+import static com.conveyal.datatools.common.utils.AWSUtils.downloadFromS3;
 import static com.conveyal.datatools.common.utils.SparkUtils.downloadFile;
 import static com.conveyal.datatools.common.utils.SparkUtils.formatJobMessage;
 import static com.conveyal.datatools.common.utils.SparkUtils.logMessageAndHalt;

--- a/src/main/java/com/conveyal/datatools/manager/controllers/api/ServerController.java
+++ b/src/main/java/com/conveyal/datatools/manager/controllers/api/ServerController.java
@@ -247,7 +247,7 @@ public class ServerController {
         AmazonS3 s3Client = FeedStore.s3Client;
         try {
             // Construct credentials if role is provided.
-            AWSStaticCredentialsProvider credentials = AWSUtils.getCredentialsForRole(server.role, "test");
+            AWSStaticCredentialsProvider credentials = AWSUtils.getCredentialsForRole(server.role, "validate");
             // If alternative credentials exist, override the default AWS clients.
             if (credentials != null) {
                 ec2Client = AmazonEC2Client.builder().withCredentials(credentials).build();
@@ -452,8 +452,8 @@ public class ServerController {
         // If alternative credentials exist, use them to assume the role. Otherwise, use default ELB client.
         AmazonElasticLoadBalancing elbClient = credentials != null
             ? AmazonElasticLoadBalancingClient.builder()
-            .withCredentials(credentials)
-            .build()
+                .withCredentials(credentials)
+                .build()
             : elb;
         try {
             DescribeTargetGroupsRequest targetGroupsRequest = new DescribeTargetGroupsRequest()

--- a/src/main/java/com/conveyal/datatools/manager/jobs/DeployJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/DeployJob.java
@@ -474,7 +474,7 @@ public class DeployJob extends MonitorableJob {
             LOG.info("Updating deployment target and deploy time.");
             deployment.deployedTo = otpServer.id;
             long durationMinutes = TimeUnit.MILLISECONDS.toMinutes(status.duration);
-            message = String.format("Deployment %s successfully deployed to %s in %s minutes.", deployment.name, otpServer.publicUrl, durationMinutes);
+            message = String.format("%s successfully deployed %s to %s in %s minutes.", owner.getEmail(), deployment.name, otpServer.publicUrl, durationMinutes);
         } else {
             message = String.format("WARNING: Deployment %s failed to deploy to %s. Error: %s", deployment.name, otpServer.publicUrl, status.message);
         }
@@ -937,6 +937,7 @@ public class DeployJob extends MonitorableJob {
         public String buildArtifactsFolder;
         public String otpVersion;
         public EC2Info ec2Info;
+        public String role;
         public long finishTime = System.currentTimeMillis();
 
         /** Empty constructor for serialization */
@@ -947,6 +948,7 @@ public class DeployJob extends MonitorableJob {
             this.ec2Info = job.otpServer.ec2Info;
             this.otpVersion = job.deployment.otpVersion;
             this.jobId = job.jobId;
+            this.role = job.otpServer.role;
             this.s3Bucket = job.s3Bucket;
             this.status = job.status;
             this.buildArtifactsFolder = job.getS3FolderURI().toString();

--- a/src/main/java/com/conveyal/datatools/manager/jobs/DeployJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/DeployJob.java
@@ -1,24 +1,18 @@
 package com.conveyal.datatools.manager.jobs;
 
 import com.amazonaws.AmazonClientException;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.event.ProgressListener;
 import com.amazonaws.services.ec2.AmazonEC2;
-import com.amazonaws.services.ec2.AmazonEC2Client;
-import com.amazonaws.services.ec2.model.AmazonEC2Exception;
 import com.amazonaws.services.ec2.model.CreateTagsRequest;
 import com.amazonaws.services.ec2.model.DescribeInstanceStatusRequest;
-import com.amazonaws.services.ec2.model.DescribeInstancesRequest;
 import com.amazonaws.services.ec2.model.Filter;
 import com.amazonaws.services.ec2.model.IamInstanceProfileSpecification;
 import com.amazonaws.services.ec2.model.Instance;
 import com.amazonaws.services.ec2.model.InstanceNetworkInterfaceSpecification;
-import com.amazonaws.services.ec2.model.Reservation;
 import com.amazonaws.services.ec2.model.RunInstancesRequest;
 import com.amazonaws.services.ec2.model.Tag;
-import com.amazonaws.services.elasticloadbalancingv2.AmazonElasticLoadBalancing;
-import com.amazonaws.services.elasticloadbalancingv2.AmazonElasticLoadBalancingClient;
-import com.amazonaws.services.elasticloadbalancingv2.model.DeregisterTargetsRequest;
-import com.amazonaws.services.elasticloadbalancingv2.model.TargetDescription;
+import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3URI;
 import com.amazonaws.services.s3.model.CopyObjectRequest;
 import com.amazonaws.services.s3.transfer.TransferManager;
@@ -42,10 +36,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Scanner;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
@@ -56,6 +48,7 @@ import java.util.stream.Collectors;
 import com.amazonaws.waiters.Waiter;
 import com.amazonaws.waiters.WaiterParameters;
 import com.conveyal.datatools.common.status.MonitorableJob;
+import com.conveyal.datatools.common.utils.AWSUtils;
 import com.conveyal.datatools.manager.DataManager;
 import com.conveyal.datatools.manager.auth.Auth0UserProfile;
 import com.conveyal.datatools.manager.controllers.api.DeploymentController;
@@ -64,7 +57,6 @@ import com.conveyal.datatools.manager.models.Deployment;
 import com.conveyal.datatools.manager.models.EC2Info;
 import com.conveyal.datatools.manager.models.EC2InstanceSummary;
 import com.conveyal.datatools.manager.models.OtpServer;
-import com.conveyal.datatools.manager.persistence.FeedStore;
 import com.conveyal.datatools.manager.persistence.Persistence;
 import com.conveyal.datatools.manager.utils.StringUtils;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -111,10 +103,12 @@ public class DeployJob extends MonitorableJob {
     private final String s3Bucket;
     private final int targetCount;
     private final DeployType deployType;
+    private final AWSStaticCredentialsProvider credentials;
     private int tasksCompleted = 0;
     private int totalTasks;
 
     private AmazonEC2 ec2;
+    private AmazonS3 s3Client;
     private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss z");
 
     /** The deployment to deploy */
@@ -190,9 +184,12 @@ public class DeployJob extends MonitorableJob {
             // deployment using either a specified bundle or Graph.obj.
             setJobRelativePath(bundlePath);
         }
-        // CONNECT TO EC2
+        // CONNECT TO EC2/S3
         // FIXME Should this ec2 client be longlived?
-        ec2 = AmazonEC2Client.builder().build();
+        credentials = AWSUtils.getCredentialsForRole(otpServer.role, this.jobId);
+        ec2 = AWSUtils.getEC2ClientForCredentials(credentials);
+        s3Client = AWSUtils.getS3ClientForCredentials(credentials, null);
+
     }
 
     public void jobLogic () {
@@ -283,7 +280,7 @@ public class DeployJob extends MonitorableJob {
         status.message = "Uploading bundle to " + getS3BundleURI();
         status.uploadingS3 = true;
         LOG.info("Uploading deployment {} to {}", deployment.name, uri.toString());
-        TransferManager tx = TransferManagerBuilder.standard().withS3Client(FeedStore.s3Client).build();
+        TransferManager tx = TransferManagerBuilder.standard().withS3Client(s3Client).build();
         final Upload upload = tx.upload(bucket, uri.getKey(), deploymentTempFile);
 
         upload.addProgressListener(
@@ -300,7 +297,7 @@ public class DeployJob extends MonitorableJob {
         // copy to [name]-latest.zip
         String copyKey = getLatestS3BundleKey();
         CopyObjectRequest copyObjRequest = new CopyObjectRequest(bucket, uri.getKey(), uri.getBucket(), copyKey);
-        FeedStore.s3Client.copyObject(copyObjRequest);
+        s3Client.copyObject(copyObjRequest);
         LOG.info("Copied to s3://{}/{}", bucket, copyKey);
         LOG.info("Uploaded to {}", getS3BundleURI());
         status.update("Upload to S3 complete.", status.percentComplete + 10);
@@ -506,7 +503,7 @@ public class DeployJob extends MonitorableJob {
                  instances.addAll(startEC2Instances(1, false));
                 // Exit if an error was encountered.
                 if (status.error || instances.size() == 0) {
-                    ServerController.terminateInstances(instances);
+                    ServerController.terminateInstances(ec2, instances);
                     return;
                 }
                 status.message = "Waiting for graph build to complete...";
@@ -529,7 +526,7 @@ public class DeployJob extends MonitorableJob {
                     statusMessage = "Error encountered while building graph. Inspect build logs.";
                     LOG.error(statusMessage);
                     status.fail(statusMessage);
-                    ServerController.terminateInstances(instances);
+                    ServerController.terminateInstances(ec2, instances);
                     return;
                 }
             }
@@ -542,7 +539,7 @@ public class DeployJob extends MonitorableJob {
                 status.message = String.format("Spinning up remaining %d instance(s).", status.numServersRemaining);
                 remainingInstances.addAll(startEC2Instances(status.numServersRemaining, true));
                 if (remainingInstances.size() == 0 || status.error) {
-                    ServerController.terminateInstances(remainingInstances);
+                    ServerController.terminateInstances(ec2, remainingInstances);
                     return;
                 }
                 // Create new thread pool to monitor server setup so that the servers are monitored in parallel.
@@ -564,7 +561,7 @@ public class DeployJob extends MonitorableJob {
                     String id = job.getInstanceId();
                     LOG.warn("Error encountered while monitoring server {}. Terminating.", id);
                     remainingInstances.removeIf(instance -> instance.getInstanceId().equals(id));
-                    ServerController.terminateInstances(id);
+                    ServerController.terminateInstances(ec2, id);
                 }
             }
             // Add all servers that did not encounter issues to list for registration with ELB.
@@ -577,7 +574,11 @@ public class DeployJob extends MonitorableJob {
                     .map(instance -> instance.instanceId)
                     .collect(Collectors.toList());
                 if (previousInstanceIds.size() > 0) {
-                    boolean success = ServerController.deRegisterAndTerminateInstances(otpServer.ec2Info.targetGroupArn, previousInstanceIds);
+                    boolean success = ServerController.deRegisterAndTerminateInstances(
+                        credentials,
+                        otpServer.ec2Info.targetGroupArn,
+                        previousInstanceIds
+                    );
                     // If there was a problem during de-registration/termination, notify via status message.
                     if (!success) {
                         finalMessage = String.format("Server setup is complete! (WARNING: Could not terminate previous EC2 instances: %s", previousInstanceIds);
@@ -625,7 +626,7 @@ public class DeployJob extends MonitorableJob {
         if (amiId == null) {
             amiId = DEFAULT_AMI_ID;
             // Verify that AMI is correctly defined.
-            if (amiId == null || !ServerController.amiExists(amiId)) {
+            if (amiId == null || !ServerController.amiExists(amiId, ec2)) {
                 statusMessage = String.format(
                     "Default AMI ID (%s) is missing or bad. Should be provided in config at %s",
                     amiId,
@@ -692,7 +693,7 @@ public class DeployJob extends MonitorableJob {
         while (instanceIpAddresses.size() < instances.size()) {
             LOG.info("Checking that public IP addresses have initialized for EC2 instances.");
             // Check that all of the instances have public IPs.
-            List<Instance> instancesWithIps = DeploymentController.fetchEC2Instances(instanceIdFilter);
+            List<Instance> instancesWithIps = DeploymentController.fetchEC2Instances(ec2, instanceIdFilter);
             for (Instance instance : instancesWithIps) {
                 String publicIp = instance.getPublicIpAddress();
                 // If IP has been found, store the updated instance and IP.

--- a/src/main/java/com/conveyal/datatools/manager/jobs/MonitorServerStatusJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/MonitorServerStatusJob.java
@@ -68,7 +68,7 @@ public class MonitorServerStatusJob extends MonitorableJob {
         this.graphAlreadyBuilt = graphAlreadyBuilt;
         status.message = "Checking server status...";
         startTime = System.currentTimeMillis();
-        credentials = AWSUtils.getCredentialsForRole(otpServer.role, "Monitor " + instance.getInstanceId());
+        credentials = AWSUtils.getCredentialsForRole(otpServer.role, "monitor-" + instance.getInstanceId());
         ec2 = AWSUtils.getEC2ClientForCredentials(credentials);
     }
 

--- a/src/main/java/com/conveyal/datatools/manager/persistence/FeedStore.java
+++ b/src/main/java/com/conveyal/datatools/manager/persistence/FeedStore.java
@@ -6,7 +6,6 @@ import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.auth.profile.ProfileCredentialsProvider;
 import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.amazonaws.services.s3.model.CopyObjectRequest;
 import com.amazonaws.services.s3.model.GetObjectRequest;
 import com.amazonaws.services.s3.model.PutObjectRequest;
@@ -14,6 +13,7 @@ import com.amazonaws.services.s3.model.S3Object;
 import com.amazonaws.services.s3.transfer.TransferManager;
 import com.amazonaws.services.s3.transfer.TransferManagerBuilder;
 import com.amazonaws.services.s3.transfer.Upload;
+import com.conveyal.datatools.common.utils.AWSUtils;
 import com.conveyal.datatools.manager.DataManager;
 import com.conveyal.datatools.manager.models.FeedSource;
 import gnu.trove.list.TLongList;
@@ -76,19 +76,11 @@ public class FeedStore {
         // s3 storage
         if (DataManager.useS3 || hasConfigProperty("modules.gtfsapi.use_extension")){
             s3Bucket = DataManager.getConfigPropertyAsText("application.data.gtfs_s3_bucket");
-            AmazonS3ClientBuilder builder = AmazonS3ClientBuilder.standard()
-                    .withCredentials(getAWSCreds());
-
-            // if region configuration string is provided, use that
-            // otherwise default to ~/.aws/config
-            // NOTE: if this is missing
-            String s3Region = DataManager.getConfigPropertyAsText("application.data.s3_region");
-            if (s3Region != null) {
-                LOG.info("Using S3 region {}", s3Region);
-                builder.withRegion(s3Region);
-            }
             try {
-                s3Client = builder.build();
+                // If region configuration string is provided, use that.
+                // Otherwise defaults to value provided in ~/.aws/config
+                String region = DataManager.getConfigPropertyAsText("application.data.s3_region");
+                s3Client = AWSUtils.getS3ClientForCredentials(getAWSCreds(), region);
             } catch (Exception e) {
                 LOG.error("S3 client not initialized correctly.  Must provide config property application.data.s3_region or specify region in ~/.aws/config", e);
             }

--- a/src/test/java/com/conveyal/datatools/manager/jobs/DeployJobTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/jobs/DeployJobTest.java
@@ -2,6 +2,7 @@ package com.conveyal.datatools.manager.jobs;
 
 import com.amazonaws.services.ec2.model.Instance;
 import com.conveyal.datatools.DatatoolsTest;
+import com.conveyal.datatools.common.utils.AWSUtils;
 import com.conveyal.datatools.manager.auth.Auth0UserProfile;
 import com.conveyal.datatools.manager.models.Deployment;
 import com.conveyal.datatools.manager.models.EC2Info;
@@ -96,7 +97,7 @@ public class DeployJobTest {
     public static void cleanUp() {
         List<Instance> instances = server.retrieveEC2Instances();
         List<String> ids = getIds(instances);
-        terminateInstances(ids);
+        terminateInstances(AWSUtils.getEC2ClientForRole(server.role), ids);
     }
 
 }


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Fix #272. This PR adds a `role` field to `OtpServer`. A number of changes in the deployment process must account for this new role field, which the application will assume in order to write to s3 and spin up ec2 servers in the third party account.

Check out this code running (with successful deployment to third party AWS account) here: https://gtfs-dev.ibi-transit.com/project/09620e51-8e38-4c5a-bd19-29604ed597db/deployments/34e14bc2-0d43-4f59-9b18-a94efdb89147