### PR TITLE
jMeter updated URLs

### DIFF
--- a/jmeter/install-jmeter.sh
+++ b/jmeter/install-jmeter.sh
@@ -1,21 +1,23 @@
 #!/bin/bash
 
+version="5.2.1"
+
 # install jmeter
-wget https://archive.apache.org/dist/jmeter/binaries/apache-jmeter-5.2.1.zip
-unzip apache-jmeter-5.2.1.zip
-rm -rf apache-jmeter-5.2.1.zip
+wget https://archive.apache.org/dist/jmeter/binaries/apache-jmeter-$version.zip
+unzip apache-jmeter-$version.zip
+rm -rf apache-jmeter-$version.zip
 
 # install jmeter plugin manager
-wget -O apache-jmeter-5.2.1/lib/ext/jmeter-plugins-manager-0.16.jar https://jmeter-plugins.org/get/
+wget -O apache-jmeter-$version/lib/ext/jmeter-plugins-manager-0.16.jar https://jmeter-plugins.org/get/
 
 # install command line runner
-wget -O apache-jmeter-5.2.1/lib/cmdrunner-2.0.jar https://search.maven.org/remotecontent?filepath=kg/apc/cmdrunner/2.0/cmdrunner-2.0.jar
+wget -O apache-jmeter-$version/lib/cmdrunner-2.0.jar https://search.maven.org/remotecontent?filepath=kg/apc/cmdrunner/2.0/cmdrunner-2.0.jar
 
 # run jmeter to generate command line script
-java -cp apache-jmeter-5.2.1/lib/ext/jmeter-plugins-manager-0.16.jar org.jmeterplugins.repository.PluginManagerCMDInstaller
+java -cp apache-jmeter-$version/lib/ext/jmeter-plugins-manager-0.16.jar org.jmeterplugins.repository.PluginManagerCMDInstaller
 
 # install jpgc-json-2
-apache-jmeter-5.2.1/bin/PluginsManagerCMD.sh install jpgc-json
+apache-jmeter-$version/bin/PluginsManagerCMD.sh install jpgc-json
 
 # install jar file for commons csv
-wget -O apache-jmeter-5.2.1/lib/ext/commons-csv-1.5.jar https://repo1.maven.org/maven2/org/apache/commons/commons-csv/1.5/commons-csv-1.5.jar
+wget -O apache-jmeter-$version/lib/ext/commons-csv-1.5.jar https://repo1.maven.org/maven2/org/apache/commons/commons-csv/1.5/commons-csv-1.5.jar

--- a/jmeter/install-jmeter.sh
+++ b/jmeter/install-jmeter.sh
@@ -1,21 +1,21 @@
 #!/bin/bash
 
 # install jmeter
-wget https://archive.apache.org/dist/jmeter/binaries/apache-jmeter-3.3.zip
-unzip apache-jmeter-3.3.zip
-rm -rf apache-jmeter-3.3.zip
+wget https://archive.apache.org/dist/jmeter/binaries/apache-jmeter-5.2.1.zip
+unzip apache-jmeter-5.2.1.zip
+rm -rf apache-jmeter-5.2.1.zip
 
 # install jmeter plugin manager
-wget -O apache-jmeter-3.3/lib/ext/jmeter-plugins-manager-0.16.jar https://jmeter-plugins.org/get/
+wget -O apache-jmeter-5.2.1/lib/ext/jmeter-plugins-manager-0.16.jar https://jmeter-plugins.org/get/
 
 # install command line runner
-wget -O apache-jmeter-3.3/lib/cmdrunner-2.0.jar http://search.maven.org/remotecontent?filepath=kg/apc/cmdrunner/2.0/cmdrunner-2.0.jar
+wget -O apache-jmeter-5.2.1/lib/cmdrunner-2.0.jar https://search.maven.org/remotecontent?filepath=kg/apc/cmdrunner/2.0/cmdrunner-2.0.jar
 
 # run jmeter to generate command line script
-java -cp apache-jmeter-3.3/lib/ext/jmeter-plugins-manager-0.16.jar org.jmeterplugins.repository.PluginManagerCMDInstaller
+java -cp apache-jmeter-5.2.1/lib/ext/jmeter-plugins-manager-0.16.jar org.jmeterplugins.repository.PluginManagerCMDInstaller
 
 # install jpgc-json-2
-apache-jmeter-3.3/bin/PluginsManagerCMD.sh install jpgc-json
+apache-jmeter-5.2.1/bin/PluginsManagerCMD.sh install jpgc-json
 
 # install jar file for commons csv
-wget -O apache-jmeter-3.3/lib/ext/commons-csv-1.5.jar http://central.maven.org/maven2/org/apache/commons/commons-csv/1.5/commons-csv-1.5.jar
+wget -O apache-jmeter-5.2.1/lib/ext/commons-csv-1.5.jar https://repo1.maven.org/maven2/org/apache/commons/commons-csv/1.5/commons-csv-1.5.jar

--- a/jmeter/run-gui.sh
+++ b/jmeter/run-gui.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-apache-jmeter-3.3/bin/jmeter.sh -t test-script.jmx
+apache-jmeter-5.2.1/bin/jmeter.sh -t test-script.jmx


### PR DESCRIPTION
### Description

This PR updates outdated dependency URLs in the jMeter installation script, and updates the jMeter version from 3.3 to 5.2.1. 
