### PR TITLE
ci(travis): Make jar file name actually use BRANCH_CLEAN variable.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,7 +89,7 @@ before_deploy:
 - ls target/*.jar
   # Copy packaged jar over to deploy dir.
 - cp target/dt-*.jar deploy/
-- cp target/dt-*.jar "deploy/dt-latest-BRANCH_CLEAN.jar"
+- cp target/dt-*.jar "deploy/dt-latest-$BRANCH_CLEAN.jar"
 deploy:
   provider: s3
   skip_cleanup: true


### PR DESCRIPTION
### Checklist

- [X] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [NA] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [NA] The description lists all applicable issues this PR seeks to resolve
- [NA] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Build jars are including the branch variable name instead of using the branch name. This PR addresses that. (Found while setting up Travis for otp-middleware)