### PR TITLE
Recreate build image

### DIFF
--- a/src/main/java/com/conveyal/datatools/manager/jobs/DeployJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/DeployJob.java
@@ -858,8 +858,9 @@ public class DeployJob extends MonitorableJob {
         // Get the total memory by grepping for MemTotal in meminfo file and removing non-numbers from the line
         // (leaving just the total mem in kb). This is used for starting up the OTP build/run processes.
         lines.add("TOTAL_MEM=`grep MemTotal /proc/meminfo | sed 's/[^0-9]//g'`");
-        // 2097152 kb is 2GB, leave that much for the OS
-        lines.add("MEM=`echo $(($TOTAL_MEM - 2097152))`");
+        // If on a low-memory instance (assuming around 2GB of RAM), allocate 1.5GB for java.
+        // Otherwise use as much as possible while leaving 2097152 kb (2GB) for the OS
+        lines.add("if [ \"2500000\" -gt \"$TOTAL_MEM\" ]; then MEM=1500000; else MEM=`echo $(($TOTAL_MEM - 2097152))`; fi");
         ////// 2. Configure some stuff for AWS CLI.
         // Note: too many threads/concurrent requests cause a lot of individual thread timeouts for some reason, which
         // ultimately causes the entire cp command to stall out.

--- a/src/main/java/com/conveyal/datatools/manager/jobs/DeployJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/DeployJob.java
@@ -842,6 +842,10 @@ public class DeployJob extends MonitorableJob {
         String graphPath = String.join("/", routerDir, OTP_GRAPH_FILENAME);
         //////////////// BEGIN USER DATA
         lines.add("#!/bin/bash");
+        ///// 0. Remove previous status files
+        lines.add("WEB_DIR=/usr/share/nginx/client");
+        lines.add(String.format("rm $WEB_DIR/%s || echo '' > /dev/null", BUNDLE_DOWNLOAD_COMPLETE_FILE));
+        lines.add(String.format("rm $WEB_DIR/%s || echo '' > /dev/null", GRAPH_STATUS_FILE));
         ///// 1. set some variables.
         // Send trip planner logs to LOGFILE
         lines.add(String.format("BUILDLOGFILE=/var/log/%s", getBuildLogFilename()));
@@ -880,7 +884,6 @@ public class DeployJob extends MonitorableJob {
         lines.add(String.format("mkdir -p %s", jarDir));
         // Add client static file directory for uploading deploy stage status files.
         // TODO: switch to AMI that uses /usr/share/nginx/html as static file dir so we don't have to create this new dir.
-        lines.add("WEB_DIR=/usr/share/nginx/client");
         lines.add("sudo mkdir $WEB_DIR");
         lines.add(String.format("wget %s -O %s/%s.jar", s3JarUrl, jarDir, jarName));
         if (graphAlreadyBuilt) {

--- a/src/main/java/com/conveyal/datatools/manager/jobs/DeployJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/DeployJob.java
@@ -981,6 +981,11 @@ public class DeployJob extends MonitorableJob {
         return String.join("/", pathList);
     }
 
+    @JsonIgnore
+    public AmazonS3 getS3Client() {
+        return s3Client;
+    }
+
     /**
      * Represents the current status of this job.
      */

--- a/src/main/java/com/conveyal/datatools/manager/jobs/MonitorServerStatusJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/MonitorServerStatusJob.java
@@ -13,6 +13,7 @@ import com.amazonaws.services.elasticloadbalancingv2.model.RegisterTargetsReques
 import com.amazonaws.services.elasticloadbalancingv2.model.TargetDescription;
 import com.amazonaws.services.s3.AmazonS3URI;
 import com.amazonaws.services.s3.model.AmazonS3Exception;
+import com.amazonaws.services.s3.model.S3Object;
 import com.conveyal.datatools.common.status.MonitorableJob;
 import com.conveyal.datatools.common.utils.AWSUtils;
 import com.conveyal.datatools.manager.auth.Auth0UserProfile;
@@ -219,8 +220,14 @@ public class MonitorServerStatusJob extends MonitorableJob {
         LOG.info("Checking for graph at {}", uri.toString());
         // Surround with try/catch (exception thrown if object does not exist).
         try {
-            return FeedStore.s3Client.doesObjectExist(uri.getBucket(), uri.getKey());
+            deployJob.getS3Client().getObject(uri.getBucket(), uri.getKey());
+            return true;
         } catch (AmazonS3Exception e) {
+            String errorCode = e.getErrorCode();
+            if (!errorCode.equals("NoSuchKey")) {
+                LOG.warn("Error encountered while checking for graph upload: {}", e);
+                return false;
+            }
             LOG.warn("Object not found for key " + uri.getKey(), e);
             return false;
         }

--- a/src/main/java/com/conveyal/datatools/manager/models/EC2Info.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/EC2Info.java
@@ -55,6 +55,16 @@ public class EC2Info implements Serializable {
     public String targetGroupArn;
     /** An optional custom AWS region (e.g., us-east-1) */
     public String region;
+    /**
+     * Informs the DeployJob that a new Image of the graph building machine should be created after graph building has
+     * finished. The previous Image associated with the buildAmiId will be deregistered. Then the buildAmiId will be
+     * updated with AMI ID associated with the newly created Image.
+     */
+    public boolean recreateBuildImage;
+    /** The name to give the newly created AMI if makeBuildImage is set to true */
+    public String buildImageName;
+    /** The description to give the newly created AMI if makeBuildImage is set to true */
+    public String buildImageDescription;
 
     /**
      * Returns true if the instance type or ami ids are set and are different for a graph build.


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

There's no issue for this, but this PR makes it possible to recreate the build AMI after the graph build phase of deployment is done. There are a few other little things:

- User data script now can
  - Deletes status files if they exist
  - Will set memory differently for low-memory instances
- An unused method that can check the graph upload status has been updated to work with the latest AWS APIs.