### PR TITLE
Increase timeout for building graphs

### DIFF
--- a/src/main/java/com/conveyal/datatools/manager/jobs/MonitorServerStatusJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/MonitorServerStatusJob.java
@@ -108,8 +108,8 @@ public class MonitorServerStatusJob extends MonitorableJob {
                 wait("bundle download check:" + bundleUrl);
                 bundleIsDownloaded = checkForSuccessfulRequest(bundleUrl);
                 // wait 20 minutes max for the bundle to download
-                long maxBundleDownloadTime = 20 * 60 * 1000;
-                if (taskHasTimedOut(bundleDownloadStartTime, maxBundleDownloadTime)) {
+                long maxBundleDownloadTimeMillis = 20 * 60 * 1000;
+                if (taskHasTimedOut(bundleDownloadStartTime, maxBundleDownloadTimeMillis)) {
                     failJob("Job timed out while checking for server bundle download status.");
                     return;
                 }
@@ -134,8 +134,8 @@ public class MonitorServerStatusJob extends MonitorableJob {
             wait("graph build/download check: " + graphStatusUrl);
             graphIsAvailable = checkForSuccessfulRequest(graphStatusUrl);
             // wait a maximum of 4 hours if building the graph, or 20 minutes if downloading a graph
-            long maxGraphBuildOrDownloadWaitTime = graphAlreadyBuilt ? 20 * 60 * 1000 : 4 * 60 * 60 * 1000;
-            if (taskHasTimedOut(graphBuildStartTime, maxGraphBuildOrDownloadWaitTime)) {
+            long maxGraphBuildOrDownloadWaitTimeMillis = graphAlreadyBuilt ? 20 * 60 * 1000 : 4 * 60 * 60 * 1000;
+            if (taskHasTimedOut(graphBuildStartTime, maxGraphBuildOrDownloadWaitTimeMillis)) {
                 failJob("Job timed out while waiting for graph build/download. If this was a graph building machine, it may have run out of memory.");
                 return;
             }
@@ -166,8 +166,8 @@ public class MonitorServerStatusJob extends MonitorableJob {
             wait("router to become available: " + routerUrl);
             routerIsAvailable = checkForSuccessfulRequest(routerUrl);
             // wait a maximum of 20 minutes to load the graph and for the server to start
-            long maxGraphLoadWaitTime = 20 * 60 * 1000;
-            if (taskHasTimedOut(graphLoadStartTime, maxGraphLoadWaitTime)) {
+            long maxGraphLoadWaitTimeMillis = 20 * 60 * 1000;
+            if (taskHasTimedOut(graphLoadStartTime, maxGraphLoadWaitTimeMillis)) {
                 failJob("Job timed out while waiting for trip planner to start up.");
                 return;
             }
@@ -211,9 +211,9 @@ public class MonitorServerStatusJob extends MonitorableJob {
     }
 
     /** Determine if a specific task has passed time limit for its run time. */
-    private boolean taskHasTimedOut(long startTime, long maxRunTime) {
-        long runTime = System.currentTimeMillis() - startTime;
-        return runTime > maxRunTime;
+    private boolean taskHasTimedOut(long startTime, long maxRunTimeMillis) {
+        long runTimeMillis = System.currentTimeMillis() - startTime;
+        return runTimeMillis > maxRunTimeMillis;
     }
 
     /**

--- a/src/main/java/com/conveyal/datatools/manager/jobs/MonitorServerStatusJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/MonitorServerStatusJob.java
@@ -49,8 +49,6 @@ public class MonitorServerStatusJob extends MonitorableJob {
     private final AWSStaticCredentialsProvider credentials;
     private final AmazonEC2 ec2;
     private final CloseableHttpClient httpClient = HttpClients.createDefault();
-    // If the job takes longer than XX seconds, fail the job.
-    private static final int TIMEOUT_MILLIS = 60 * 60 * 1000; // One hour
     // Delay checks by twenty seconds to give user-data script time to upload the instance's user data log if part of the
     // script fails (e.g., uploading or downloading a file).
     private static final int DELAY_SECONDS = 20;
@@ -109,7 +107,9 @@ public class MonitorServerStatusJob extends MonitorableJob {
                 // If the request is successful, the OTP instance has started.
                 wait("bundle download check:" + bundleUrl);
                 bundleIsDownloaded = checkForSuccessfulRequest(bundleUrl);
-                if (jobHasTimedOut()) {
+                // wait 20 minutes max for the bundle to download
+                long maxBundleDownloadTime = 20 * 60 * 1000;
+                if (taskHasTimedOut(bundleDownloadStartTime, maxBundleDownloadTime)) {
                     failJob("Job timed out while checking for server bundle download status.");
                     return;
                 }
@@ -133,7 +133,9 @@ public class MonitorServerStatusJob extends MonitorableJob {
             // If the request is successful, the OTP instance has started.
             wait("graph build/download check: " + graphStatusUrl);
             graphIsAvailable = checkForSuccessfulRequest(graphStatusUrl);
-            if (jobHasTimedOut()) {
+            // wait a maximum of 4 hours if building the graph, or 20 minutes if downloading a graph
+            long maxGraphBuildOrDownloadWaitTime = graphAlreadyBuilt ? 20 * 60 * 1000 : 4 * 60 * 60 * 1000;
+            if (taskHasTimedOut(graphBuildStartTime, maxGraphBuildOrDownloadWaitTime)) {
                 failJob("Job timed out while waiting for graph build/download. If this was a graph building machine, it may have run out of memory.");
                 return;
             }
@@ -157,12 +159,15 @@ public class MonitorServerStatusJob extends MonitorableJob {
         // Once this is confirmed, check for the existence of the router, which will indicate that the graph build is
         // complete.
         String routerUrl = String.join("/", ipUrl, "otp/routers/default");
+        long graphLoadStartTime = System.currentTimeMillis();
         while (!routerIsAvailable) {
             // If the request was successful, the graph build is complete!
             // TODO: Substitute in specific router ID? Or just default to... default.
             wait("router to become available: " + routerUrl);
             routerIsAvailable = checkForSuccessfulRequest(routerUrl);
-            if (jobHasTimedOut()) {
+            // wait a maximum of 20 minutes to load the graph and for the server to start
+            long maxGraphLoadWaitTime = 20 * 60 * 1000;
+            if (taskHasTimedOut(graphLoadStartTime, maxGraphLoadWaitTime)) {
                 failJob("Job timed out while waiting for trip planner to start up.");
                 return;
             }
@@ -205,10 +210,10 @@ public class MonitorServerStatusJob extends MonitorableJob {
         status.fail(String.format("%s Check logs at: %s", message, getUserDataLogS3Path()));
     }
 
-    /** Determine if job has passed time limit for its run time. */
-    private boolean jobHasTimedOut() {
+    /** Determine if a specific task has passed time limit for its run time. */
+    private boolean taskHasTimedOut(long startTime, long maxRunTime) {
         long runTime = System.currentTimeMillis() - startTime;
-        return runTime > TIMEOUT_MILLIS;
+        return runTime > maxRunTime;
     }
 
     /**


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This refactors the MonitorServerStatusJob so that it will wait longer than 1 hour for graph builds. It also waits less time for other tasks that shouldn't take that long.