### PR TITLE
Add osm extract url

### DIFF
--- a/src/main/java/com/conveyal/datatools/manager/models/Deployment.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/Deployment.java
@@ -147,8 +147,14 @@ public class Deployment extends Model implements Serializable {
         }
     }
 
-    // future use
-    public String osmFileId;
+    /**
+     * Public URL at which the OSM extract should be downloaded. This should be null if the extract should be downloaded
+     * from an extract server. Extract type should be a .pbf.
+     */
+    public String osmExtractUrl;
+
+    /** If true, OSM extract will be skipped entirely (extract will be fetched from neither extract server nor URL. */
+    public boolean skipOsmExtract;
 
     /**
      * The version (according to git describe) of OTP being used on this deployment This should default to


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Allow for downloading OSM file from a public URL instead of using the vex extract server. This
supports non-North American deployments and allows for the use of a stable OSM network for US
deployments (rather than using a new extract each time).

re ibi-group/datatools-ui#124
