### PR TITLE
Update geotools repo to new location

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -167,14 +167,13 @@
                 <updatePolicy>always</updatePolicy>
             </snapshots>
         </repository>
+        <!--  Repository for geotools (as of April 2020)  -->
         <repository>
             <id>osgeo</id>
-            <name>Open Source Geospatial Foundation Repository</name>
-            <url>https://download.osgeo.org/webdav/geotools/</url>
-            <snapshots>
-                <enabled>true</enabled>
-                <updatePolicy>always</updatePolicy>
-            </snapshots>
+            <name>OSGeo Release Repository</name>
+            <url>https://repo.osgeo.org/repository/release/</url>
+            <snapshots><enabled>false</enabled></snapshots>
+            <releases><enabled>true</enabled></releases>
         </repository>
         <repository>
             <id>sonatype</id>


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

On April 11, 2020, the geotools repo changed locations to repo.osgeo.org (see
https://web.archive.org/web/20200413163145/https://www.osgeo.org/foundation-news/new-osgeo-repo/).