### PR TITLE
Add preserve stop times flag to avoid normalizing stop_sequence

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -250,7 +250,7 @@
         <dependency>
             <groupId>com.conveyal</groupId>
             <artifactId>gtfs-lib</artifactId>
-            <version>6.0.1</version>
+            <version>6.0.2</version>
             <!-- Exclusions added in order to silence SLF4J warnings about multiple bindings:
                 http://www.slf4j.org/codes.html#multiple_bindings
             -->

--- a/src/main/java/com/conveyal/datatools/common/status/MonitorableJob.java
+++ b/src/main/java/com/conveyal/datatools/common/status/MonitorableJob.java
@@ -176,12 +176,13 @@ public abstract class MonitorableJob implements Runnable, Serializable {
                 // because the error presumably already occurred and has a better error message.
                 cancel(cancelMessage);
             }
-            // Run final steps of job pending completion or error. Note: any tasks that depend on job success should
-            // check job status to determine if final step should be executed (e.g., storing feed version in MongoDB).
-            // TODO: should we add separate hooks depending on state of job/sub-tasks (e.g., success, catch, finally)
             // Complete the job (as success if no errors encountered, as failure otherwise).
             if (!parentJobErrored && !subTaskErrored) status.completeSuccessfully("Job complete!");
             else status.complete(true);
+            // Run final steps of job pending completion or error. Note: any tasks that depend on job success should
+            // check job status in jobFinished to determine if final step should be executed (e.g., storing feed
+            // version in MongoDB).
+            // TODO: should we add separate hooks depending on state of job/sub-tasks (e.g., success, catch, finally)
             jobFinished();
 
             // We retain finished or errored jobs on the server until they are fetched via the API, which implies they

--- a/src/main/java/com/conveyal/datatools/editor/jobs/CreateSnapshotJob.java
+++ b/src/main/java/com/conveyal/datatools/editor/jobs/CreateSnapshotJob.java
@@ -87,7 +87,7 @@ public class CreateSnapshotJob extends MonitorableJob {
         Collection<Snapshot> existingSnapshots = feedSource.retrieveSnapshots();
         int version = existingSnapshots.size();
         status.update("Creating snapshot...", 20);
-        FeedLoadResult loadResult = makeSnapshot(namespace, DataManager.GTFS_DATA_SOURCE);
+        FeedLoadResult loadResult = makeSnapshot(namespace, DataManager.GTFS_DATA_SOURCE, !feedSource.preserveStopTimes);
         snapshot.version = version;
         snapshot.namespace = loadResult.uniqueIdentifier;
         snapshot.feedLoadResult = loadResult;

--- a/src/main/java/com/conveyal/datatools/editor/jobs/CreateSnapshotJob.java
+++ b/src/main/java/com/conveyal/datatools/editor/jobs/CreateSnapshotJob.java
@@ -87,7 +87,7 @@ public class CreateSnapshotJob extends MonitorableJob {
         Collection<Snapshot> existingSnapshots = feedSource.retrieveSnapshots();
         int version = existingSnapshots.size();
         status.update("Creating snapshot...", 20);
-        FeedLoadResult loadResult = makeSnapshot(namespace, DataManager.GTFS_DATA_SOURCE, !feedSource.preserveStopTimes);
+        FeedLoadResult loadResult = makeSnapshot(namespace, DataManager.GTFS_DATA_SOURCE, !feedSource.preserveStopTimesSequence);
         snapshot.version = version;
         snapshot.namespace = loadResult.uniqueIdentifier;
         snapshot.feedLoadResult = loadResult;

--- a/src/main/java/com/conveyal/datatools/editor/jobs/ExportSnapshotToGTFSJob.java
+++ b/src/main/java/com/conveyal/datatools/editor/jobs/ExportSnapshotToGTFSJob.java
@@ -21,6 +21,7 @@ public class ExportSnapshotToGTFSJob extends MonitorableJob {
     private static final Logger LOG = LoggerFactory.getLogger(ExportSnapshotToGTFSJob.class);
     private final Snapshot snapshot;
     private final String feedVersionId;
+    private File tempFile;
 
     public ExportSnapshotToGTFSJob(Auth0UserProfile owner, Snapshot snapshot, String feedVersionId) {
         super(owner, "Exporting snapshot " + snapshot.name, JobType.EXPORT_SNAPSHOT_TO_GTFS);
@@ -40,7 +41,6 @@ public class ExportSnapshotToGTFSJob extends MonitorableJob {
 
     @Override
     public void jobLogic() {
-        File tempFile;
         try {
             tempFile = File.createTempFile("snapshot", "zip");
         } catch (IOException e) {
@@ -72,12 +72,15 @@ public class ExportSnapshotToGTFSJob extends MonitorableJob {
                 status.fail(String.format("Could not store feed for snapshot %s", snapshot.id), e);
             }
         }
-        // Delete snapshot temp file.
-        tempFile.delete();
     }
 
     @Override
     public void jobFinished () {
         if (!status.error) status.completeSuccessfully("Export complete!");
+        // Delete snapshot temp file.
+        if (tempFile != null) {
+            LOG.info("Deleting temporary GTFS file for exported snapshot at {}", tempFile.getAbsolutePath());
+            tempFile.delete();
+        }
     }
 }

--- a/src/main/java/com/conveyal/datatools/editor/jobs/ExportSnapshotToGTFSJob.java
+++ b/src/main/java/com/conveyal/datatools/editor/jobs/ExportSnapshotToGTFSJob.java
@@ -52,6 +52,7 @@ public class ExportSnapshotToGTFSJob extends MonitorableJob {
         FeedLoadResult result = exporter.exportTables();
         if (result.fatalException != null) {
             status.fail(String.format("Error (%s) encountered while exporting database tables.", result.fatalException));
+            return;
         }
 
         // Override snapshot ID if exporting feed for use as new feed version.

--- a/src/main/java/com/conveyal/datatools/manager/models/FeedSource.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/FeedSource.java
@@ -56,7 +56,7 @@ public class FeedSource extends Model implements Cloneable {
      * stop_times or individual patterns. WARNING: enabling this flag for a feed and then attempting to edit patterns in
      * complicated ways (e.g., modifying the order of pattern stops) could have unexpected consequences.
      */
-    public boolean preserveStopTimes;
+    public boolean preserveStopTimesSequence;
 
     /**
      * Get the Project of which this feed is a part

--- a/src/main/java/com/conveyal/datatools/manager/models/FeedSource.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/FeedSource.java
@@ -54,7 +54,8 @@ public class FeedSource extends Model implements Cloneable {
      * zero-based and incrementing. This can muck with GTFS files that are linked to GTFS-rt feeds by stop_sequence, so
      * this override flag currently provides a workaround for feeds that need to be edited but do not need to edit
      * stop_times or individual patterns. WARNING: enabling this flag for a feed and then attempting to edit patterns in
-     * complicated ways (e.g., modifying the order of pattern stops) could have unexpected consequences.
+     * complicated ways (e.g., modifying the order of pattern stops) could have unexpected consequences. There is no UI
+     * setting for this and it is not recommended to do this unless absolutely necessary.
      */
     public boolean preserveStopTimesSequence;
 

--- a/src/main/java/com/conveyal/datatools/manager/models/FeedSource.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/FeedSource.java
@@ -47,8 +47,16 @@ public class FeedSource extends Model implements Cloneable {
     /**
      * The collection of which this feed is a part
      */
-    //@JsonView(JsonViews.DataDump.class)
     public String projectId;
+
+    /**
+     * When snapshotting a GTFS feed for editing, gtfs-lib currently defaults to normalize stop sequence values to be
+     * zero-based and incrementing. This can muck with GTFS files that are linked to GTFS-rt feeds by stop_sequence, so
+     * this override flag currently provides a workaround for feeds that need to be edited but do not need to edit
+     * stop_times or individual patterns. WARNING: enabling this flag for a feed and then attempting to edit patterns in
+     * complicated ways (e.g., modifying the order of pattern stops) could have unexpected consequences.
+     */
+    public boolean preserveStopTimes;
 
     /**
      * Get the Project of which this feed is a part


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR adds a `FeedSource#preserveStopTimes` flag to avoid the stop_sequence normalization that typically happens when making a snapshot for the editor.

re conveyal/gtfs-lib#283. 

**Note:** needs `pom.xml` updated to gtfs-lib@6.0.2 in order for build to pass (conveyal/gtfs-lib#285 needs to be merged and released first).

Note: there is no corresponding datatools-ui PR to set this flag (primarily just so that users don't "try this at home"). It must be done with a MongoDB update statement like: 
```json
db.getCollection('FeedSource').update({"_id": "YOUR_TEST_FEED_ID"}, {"preserveStopTimes": true})
```