### PR TITLE
otp-runner deployment

### DIFF
--- a/src/main/java/com/conveyal/datatools/manager/jobs/MonitorServerStatusJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/MonitorServerStatusJob.java
@@ -36,8 +36,6 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.Collections;
 
-import static com.conveyal.datatools.manager.jobs.DeployJob.BUNDLE_DOWNLOAD_COMPLETE_FILE;
-import static com.conveyal.datatools.manager.jobs.DeployJob.GRAPH_STATUS_FILE;
 import static com.conveyal.datatools.manager.jobs.DeployJob.OTP_RUNNER_STATUS_FILE;
 
 /**
@@ -143,7 +141,7 @@ public class MonitorServerStatusJob extends MonitorableJob {
             // consider this job done.
             if (isBuildOnlyServer()) {
                 status.completeSuccessfully(message);
-                LOG.info("View logs at {}", getUserDataLogS3Path());
+                LOG.info("View logs at {}", getOtpRunnerLogS3Path());
                 return;
             }
             // Once this is confirmed, check for the availability of the router, which will indicate that the graph
@@ -198,7 +196,7 @@ public class MonitorServerStatusJob extends MonitorableJob {
                     routerUrl
                 )
             );
-            LOG.info("View logs at {}", getUserDataLogS3Path());
+            LOG.info("View logs at {}", getOtpRunnerLogS3Path());
             deployJob.incrementCompletedServers();
         } catch (InstanceHealthException e) {
             // If at any point during the job, an instance health check indicates that the EC2 instance being monitored
@@ -217,8 +215,8 @@ public class MonitorServerStatusJob extends MonitorableJob {
     /**
      * Gets the expected path to the user data logs that get uploaded to s3
      */
-    private String getUserDataLogS3Path() {
-        return String.format("%s/%s.log", deployJob.getS3FolderURI(), instance.getInstanceId());
+    private String getOtpRunnerLogS3Path() {
+        return String.format("%s/%s-otp-runner.log", deployJob.getS3FolderURI(), instance.getInstanceId());
     }
 
     /**
@@ -226,7 +224,7 @@ public class MonitorServerStatusJob extends MonitorableJob {
      */
     private void failJob(String message) {
         LOG.error(message);
-        status.fail(String.format("%s Check logs at: %s", message, getUserDataLogS3Path()));
+        status.fail(String.format("%s Check logs at: %s", message, getOtpRunnerLogS3Path()));
     }
 
     /** Determine if a specific task has passed time limit for its run time. */

--- a/src/main/java/com/conveyal/datatools/manager/jobs/OtpRunnerManifest.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/OtpRunnerManifest.java
@@ -12,6 +12,7 @@ public class OtpRunnerManifest {
     public String jarFile;
     public String jarUrl;
     public String otpRunnerLogFile;
+    public boolean prefixLogUploadsWithInstanceId;
     public String routerConfigJSON;
     public String routerName;
     public boolean runServer;

--- a/src/main/java/com/conveyal/datatools/manager/jobs/OtpRunnerManifest.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/OtpRunnerManifest.java
@@ -2,6 +2,10 @@ package com.conveyal.datatools.manager.jobs;
 
 import java.util.List;
 
+/**
+ * A mapping of the possible values of an otp-runner manifest. For further documentation please see otp-runner docs at
+ * https://github.com/ibi-group/otp-runner#manifestjson-values
+ */
 public class OtpRunnerManifest {
     public String buildConfigJSON;
     public boolean buildGraph;
@@ -16,7 +20,7 @@ public class OtpRunnerManifest {
     public String routerConfigJSON;
     public String routerName;
     public boolean runServer;
-    public String s3UploadBucket;
+    public String s3UploadPath;
     public String serverLogFile;
     public int serverStartupTimeoutSeconds;
     public String statusFileLocation;

--- a/src/main/java/com/conveyal/datatools/manager/jobs/OtpRunnerManifest.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/OtpRunnerManifest.java
@@ -1,0 +1,27 @@
+package com.conveyal.datatools.manager.jobs;
+
+import java.util.List;
+
+public class OtpRunnerManifest {
+    public String buildConfigJSON;
+    public boolean buildGraph;
+    public String buildLogFile;
+    public String graphObjUrl;
+    public String graphsFolder;
+    public List<String> gtfsAndOsmUrls;
+    public String jarFile;
+    public String jarUrl;
+    public String otpRunnerLogFile;
+    public String routerConfigJSON;
+    public String routerName;
+    public boolean runServer;
+    public String s3UploadBucket;
+    public String serverLogFile;
+    public int serverStartupTimeoutSeconds;
+    public String statusFileLocation;
+    public boolean uploadGraphBuildLogs;
+    public boolean uploadGraphBuildReport;
+    public boolean uploadGraph;
+    public boolean uploadOtpRunnerLogs;
+    public boolean uploadServerStartupLogs;
+}

--- a/src/main/java/com/conveyal/datatools/manager/jobs/OtpRunnerStatus.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/OtpRunnerStatus.java
@@ -1,5 +1,9 @@
 package com.conveyal.datatools.manager.jobs;
 
+/**
+ * A mapping of the fields and values that otp-runner writes to a status file. See otp-runner documentation for more
+ * info: https://github.com/ibi-group/otp-runner#statusjson
+ */
 public class OtpRunnerStatus {
     public boolean error;
     public boolean graphBuilt;

--- a/src/main/java/com/conveyal/datatools/manager/jobs/OtpRunnerStatus.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/OtpRunnerStatus.java
@@ -1,0 +1,12 @@
+package com.conveyal.datatools.manager.jobs;
+
+public class OtpRunnerStatus {
+    public boolean error;
+    public boolean graphBuilt;
+    public boolean graphUploaded;
+    public boolean serverStarted;
+    public String message;
+    public int numFilesDownloaded;
+    public double pctProgress;
+    public int totalFilesToDownload;
+}

--- a/src/main/java/com/conveyal/datatools/manager/models/Deployment.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/Deployment.java
@@ -37,8 +37,10 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
@@ -439,6 +441,9 @@ public class Deployment extends Model implements Serializable {
         return conn.getInputStream();
     }
 
+    /**
+     * Gets the URL for downloading an OSM PBF file from the osm vex server for the desired bounding box.
+     */
     public static URL getVexUrl (Rectangle2D rectangle2D) throws MalformedURLException {
         Bounds bounds = new Bounds(rectangle2D);
         if (!bounds.areValid()) {
@@ -539,15 +544,19 @@ public class Deployment extends Model implements Serializable {
         return Persistence.deployments.removeById(this.id);
     }
 
+    /**
+     * Creates a list of all of the download URLs for all of the OSM and GTFS files that would be needed to build an OTP
+     * graph.
+     */
     public List<String> generateGtfsAndOsmUrls() throws MalformedURLException {
-        List<String> urls = new ArrayList();
+        Set<String> urls = new HashSet<>();
         // add OSM data
         urls.add(getVexUrl(retrieveProjectBounds()).toString());
         // add GTFS files
         for (String feedVersionId : feedVersionIds) {
             urls.add(feedStore.getS3FeedPath(feedVersionId));
         }
-        return urls;
+        return new ArrayList<>(urls);
     }
 
     /**

--- a/src/main/java/com/conveyal/datatools/manager/persistence/FeedStore.java
+++ b/src/main/java/com/conveyal/datatools/manager/persistence/FeedStore.java
@@ -206,6 +206,10 @@ public class FeedStore {
         return null;
     }
 
+    public String getS3FeedPath (String id) {
+        return String.format("s3://%s/%s", s3Bucket, getS3Key(id));
+    }
+
     /**
      * Store GTFS file locally. This method is used when a new feed version or generated GTFS file
      * (e.g., the product of merging multiple GTFS files from a project) needs to be stored locally for


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve (fixes https://github.com/ibi-group/datatools-server/issues/289)
- [ ] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR changes ec2 deployments to use [otp-runner](https://github.com/ibi-group/otp-runner) instead of completely bash-inlined in java for ec2 startup scripts. Also, the logic to create bundles and upload them has been moved to otp-runner. This has a number of advantages:

1. Since the bundles are now created on a separate machine, datatools-server won't crash if multiple large deployments are initiated at the same time.
2. The asynchronous execution of commands from otp-runner should result in a shorter time before graph building starts
3. otp-runner is able to easily write a full JSON status file and keep track of many other items that would be much more difficult to do with bash
4. otp-runner is thoroughly tested, whereas the bash-in-java had zero testing.

In order to run this, the ec2 images need node.js and yarn installed.