### PR TITLE
Stop code mtc fix

### DIFF
--- a/src/main/java/com/conveyal/datatools/manager/jobs/MergeFeedsJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/MergeFeedsJob.java
@@ -337,7 +337,7 @@ public class MergeFeedsJob extends MonitorableJob {
         int mergedLineNumber = 0;
         // Get the spec fields to export
         List<Field> specFields = table.specFields();
-        boolean stopCodeMissingFromFirstTable = false;
+        boolean stopCodeMissingFromFirstFeed = false;
         try {
             // Get shared fields between all feeds being merged. This is used to filter the spec fields so that only
             // fields found in the collection of feeds are included in the merged table.
@@ -493,6 +493,21 @@ public class MergeFeedsJob extends MonitorableJob {
                                     keyField = table.getKeyFieldName();
                                     keyFieldIndex = table.getKeyFieldIndex(fieldsFoundInZip);
                                     keyValue = csvReader.get(keyFieldIndex);
+                                    if (feedIndex == 0) {
+                                        stopCodeMissingFromFirstFeed = true;
+                                    }
+                                    if (feedIndex == 1 && !stopCodeMissingFromFirstFeed) {
+                                        mergeFeedsResult.failed = true;
+                                        mergeFeedsResult.errorCount++;
+                                        mergeFeedsResult.failureReasons.add(
+                                            String.format(
+                                                "If stop_code is provided for some stops (for those with location_type = " +
+                                                    "empty or 0), all stops must have stop_code values. The merge process " +
+                                                    "found %d stops that were incorrectly missing stop_code values.",
+                                                stopsMissingStopCodeCount
+                                            )
+                                        );
+                                    }
                                 } else if (stopsMissingStopCodeCount > 0) {
                                     // If some, but not all, stops are missing stop_code, the merge feeds job must fail.
                                     mergeFeedsResult.failed = true;
@@ -500,8 +515,8 @@ public class MergeFeedsJob extends MonitorableJob {
                                     mergeFeedsResult.failureReasons.add(
                                         String.format(
                                             "If stop_code is provided for some stops (for those with location_type = " +
-                                            "empty or 0), all stops must have stop_code values. The merge process " +
-                                            "found %d stops that were incorrectly missing stop_code values.",
+                                                "empty or 0), all stops must have stop_code values. The merge process " +
+                                                "found %d stops that were incorrectly missing stop_code values.",
                                             stopsMissingStopCodeCount
                                         )
                                     );

--- a/src/test/resources/com/conveyal/datatools/gtfs/fake-agency-with-calendar-and-calendar-dates-2/stops.txt
+++ b/src/test/resources/com/conveyal/datatools/gtfs/fake-agency-with-calendar-and-calendar-dates-2/stops.txt
@@ -1,6 +1,6 @@
 stop_id,stop_code,stop_name,stop_desc,stop_lat,stop_lon,zone_id,stop_url,location_type,parent_station,stop_timezone,wheelchair_boarding
-4u6g,,Butler Ln,,37.0612132,-122.0074332,,,0,,,
-johv,,Scotts Valley Dr & Victor Sq,,37.0590172,-122.0096058,,,0,,,
+4u6g,4u6g,Butler Ln,,37.0612132,-122.0074332,,,0,,,
+johv,johv,Scotts Valley Dr & Victor Sq,,37.0590172,-122.0096058,,,0,,,
 123,,Parent Station,,37.0666,-122.0777,,,1,,,
-1234,,Child Stop,,37.06662,-122.07772,,,0,123,,
-1234567,,Unused stop,,37.06668,-122.07781,,,0,123,,
+1234,1234,Child Stop,,37.06662,-122.07772,,,0,123,,
+1234567,1234567,Unused stop,,37.06668,-122.07781,,,0,123,,

--- a/src/test/resources/com/conveyal/datatools/gtfs/fake-agency-with-calendar-and-calendar-dates/stops.txt
+++ b/src/test/resources/com/conveyal/datatools/gtfs/fake-agency-with-calendar-and-calendar-dates/stops.txt
@@ -1,6 +1,6 @@
 stop_id,stop_code,stop_name,stop_desc,stop_lat,stop_lon,zone_id,stop_url,location_type,parent_station,stop_timezone,wheelchair_boarding
-4u6g,,Butler Ln,,37.0612132,-122.0074332,,,0,,,
-johv,,Scotts Valley Dr & Victor Sq,,37.0590172,-122.0096058,,,0,,,
+4u6g,4u6g,Butler Ln,,37.0612132,-122.0074332,,,0,,,
+johv,johv,Scotts Valley Dr & Victor Sq,,37.0590172,-122.0096058,,,0,,,
 123,,Parent Station,,37.0666,-122.0777,,,1,,,
-1234,,Child Stop,,37.06662,-122.07772,,,0,123,,
-1234567,,Unused stop,,37.06668,-122.07781,,,0,123,,
+1234,1234,Child Stop,,37.06662,-122.07772,,,0,123,,
+1234567,1234567,Unused stop,,37.06668,-122.07781,,,0,123,,

--- a/src/test/resources/com/conveyal/datatools/gtfs/fake-agency-with-only-calendar-dates/stops.txt
+++ b/src/test/resources/com/conveyal/datatools/gtfs/fake-agency-with-only-calendar-dates/stops.txt
@@ -1,6 +1,6 @@
 stop_id,stop_code,stop_name,stop_desc,stop_lat,stop_lon,zone_id,stop_url,location_type,parent_station,stop_timezone,wheelchair_boarding
-4u6g,,Butler Ln,,37.0612132,-122.0074332,,,0,,,
-johv,,Scotts Valley Dr & Victor Sq,,37.0590172,-122.0096058,,,0,,,
+4u6g,4u6g,Butler Ln,,37.0612132,-122.0074332,,,0,,,
+johv,johv,Scotts Valley Dr & Victor Sq,,37.0590172,-122.0096058,,,0,,,
 123,,Parent Station,,37.0666,-122.0777,,,1,,,
-1234,,Child Stop,,37.06662,-122.07772,,,0,123,,
-1234567,,Unused stop,,37.06668,-122.07781,,,0,123,,
+1234,1234,Child Stop,,37.06662,-122.07772,,,0,123,,
+1234567,1234567,Unused stop,,37.06668,-122.07781,,,0,123,,

--- a/src/test/resources/com/conveyal/datatools/gtfs/fake-agency-with-only-calendar/stops.txt
+++ b/src/test/resources/com/conveyal/datatools/gtfs/fake-agency-with-only-calendar/stops.txt
@@ -1,6 +1,6 @@
 stop_id,stop_code,stop_name,stop_desc,stop_lat,stop_lon,zone_id,stop_url,location_type,parent_station,stop_timezone,wheelchair_boarding
-4u6g,,Butler Ln,,37.0612132,-122.0074332,,,0,,,
-johv,,Scotts Valley Dr & Victor Sq,,37.0590172,-122.0096058,,,0,,,
+4u6g,4u6g,Butler Ln,,37.0612132,-122.0074332,,,0,,,
+johv,johv,Scotts Valley Dr & Victor Sq,,37.0590172,-122.0096058,,,0,,,
 123,,Parent Station,,37.0666,-122.0777,,,1,,,
-1234,,Child Stop,,37.06662,-122.07772,,,0,123,,
-1234567,,Unused stop,,37.06668,-122.07781,,,0,123,,
+1234,1234,Child Stop,,37.06662,-122.07772,,,0,123,,
+1234567,1234567,Unused stop,,37.06668,-122.07781,,,0,123,,


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Fix #317 with new stop_code handling logic:

Before reading any lines in stops.txt, first determine whether all records contain
properly filled stop_codes. The rules governing this logic are as follows (see item 4 in [updated docs](https://github.com/ibi-group/datatools-ui/blob/206e3380460350df4edb347e51e31c6636fbf8b3/docs/user/merging-feeds.md#merge-rules)):
1. Stops will be merged on stop_code or stop_id if stop_code is missing. However, some restrictions apply on when missing stop_code values are permitted:
    1. Stops with location_type greater than 0 (i.e., anything but 0 or empty) are permitted to have empty stop_codes (even if there are other stops in the feed that have stop_code values). This is because these location_types represent special entries that are either stations, entrances/exits, or generic nodes (e.g., for pathways.txt). The merge will happen on stop_code if provided, or fallback on stop_id.
    1. For regular stops (location_type = 0 or empty), all or none of the stops must contain stop_codes. Otherwise, the merge feeds job will be failed.
