### PR TITLE
Return summarized project info on collection get api routes

### DIFF
--- a/src/main/java/com/conveyal/datatools/manager/controllers/api/ProjectController.java
+++ b/src/main/java/com/conveyal/datatools/manager/controllers/api/ProjectController.java
@@ -44,9 +44,6 @@ import static spark.Spark.put;
  */
 @SuppressWarnings({"unused", "ThrowableNotThrown"})
 public class ProjectController {
-
-    // TODO We can probably replace this with something from Mongo so we use one JSON serializer / deserializer throughout
-    private static JsonManager<Project> json = new JsonManager<>(Project.class, JsonViews.UserInterface.class);
     private static final Logger LOG = LoggerFactory.getLogger(ProjectController.class);
 
     /**
@@ -316,20 +313,28 @@ public class ProjectController {
      * A bit too static/global for an OO language, but that's how Spark works.
      */
     public static void register (String apiPrefix) {
-        get(apiPrefix + "secure/project/:id", ProjectController::getProject, json::write);
-        get(apiPrefix + "secure/project", ProjectController::getAllProjects, json::write);
-        post(apiPrefix + "secure/project", ProjectController::createProject, json::write);
-        put(apiPrefix + "secure/project/:id", ProjectController::updateProject, json::write);
-        delete(apiPrefix + "secure/project/:id", ProjectController::deleteProject, json::write);
-        get(apiPrefix + "secure/project/:id/thirdPartySync/:type", ProjectController::thirdPartySync, json::write);
-        post(apiPrefix + "secure/project/:id/fetch", ProjectController::fetch, json::write);
-        post(apiPrefix + "secure/project/:id/deployPublic", ProjectController::publishPublicFeeds, json::write);
+        // Construct JSON managers which help serialize the response. Slim JSON is the generic JSON view. Full JSON
+        // contains additional fields (at the moment just #otpServers) and should only be used when the controller
+        // returns a single project (slimJson is better suited for a collection). If fullJson is attempted for use
+        // with a collection, massive performance issues will ensure (mainly due to multiple calls to AWS EC2).
+        JsonManager<Project> slimJson = new JsonManager<>(Project.class, JsonViews.UserInterface.class);
+        JsonManager<Project> fullJson = new JsonManager<>(Project.class, JsonViews.UserInterface.class);
+        fullJson.addMixin(Project.class, Project.ProjectWithOtpServers.class);
+
+        get(apiPrefix + "secure/project/:id", ProjectController::getProject, fullJson::write);
+        get(apiPrefix + "secure/project", ProjectController::getAllProjects, slimJson::write);
+        post(apiPrefix + "secure/project", ProjectController::createProject, fullJson::write);
+        put(apiPrefix + "secure/project/:id", ProjectController::updateProject, fullJson::write);
+        delete(apiPrefix + "secure/project/:id", ProjectController::deleteProject, fullJson::write);
+        get(apiPrefix + "secure/project/:id/thirdPartySync/:type", ProjectController::thirdPartySync, fullJson::write);
+        post(apiPrefix + "secure/project/:id/fetch", ProjectController::fetch, fullJson::write);
+        post(apiPrefix + "secure/project/:id/deployPublic", ProjectController::publishPublicFeeds, fullJson::write);
 
         get(apiPrefix + "secure/project/:id/download", ProjectController::mergeProjectFeeds);
-        get(apiPrefix + "secure/project/:id/downloadtoken", ProjectController::getFeedDownloadCredentials, json::write);
+        get(apiPrefix + "secure/project/:id/downloadtoken", ProjectController::getFeedDownloadCredentials, fullJson::write);
 
-        get(apiPrefix + "public/project/:id", ProjectController::getProject, json::write);
-        get(apiPrefix + "public/project", ProjectController::getAllProjects, json::write);
+        get(apiPrefix + "public/project/:id", ProjectController::getProject, fullJson::write);
+        get(apiPrefix + "public/project", ProjectController::getAllProjects, slimJson::write);
         get(apiPrefix + "downloadprojectfeed/:token", ProjectController::downloadMergedFeedWithToken);
     }
 

--- a/src/main/java/com/conveyal/datatools/manager/models/Project.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/Project.java
@@ -43,7 +43,6 @@ public class Project extends Model {
      * project as well as those that belong to no project.
      * @return
      */
-    @JsonProperty("otpServers")
     public List<OtpServer> availableOtpServers() {
         return Persistence.servers.getFiltered(or(
             eq("projectId", this.id),
@@ -110,5 +109,18 @@ public class Project extends Model {
         retrieveDeployments().forEach(Deployment::delete);
         // Finally, delete the project.
         Persistence.projects.removeById(this.id);
+    }
+
+    /**
+     * A MixIn to be applied to this deployment, for returning a single deployment, so that the list of ec2Instances is
+     * included in the JSON response.
+     *
+     * Usually a mixin would be used on an external class, but since we are changing one thing about a single class, it seemed
+     * unnecessary to define a new view.
+     */
+    public abstract static class ProjectWithOtpServers {
+
+        @JsonProperty("otpServers")
+        public abstract Collection<OtpServer> availableOtpServers ();
     }
 }


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Requests for a list of projects were becoming painfully slow on my local instance. It turns out that not returning the `otpServers` in each project when returning a list of projects dramatically speeds things up.