### PR TITLE
Create job for recreating graph build image

### DIFF
--- a/src/main/java/com/conveyal/datatools/common/status/MonitorableJob.java
+++ b/src/main/java/com/conveyal/datatools/common/status/MonitorableJob.java
@@ -66,7 +66,8 @@ public abstract class MonitorableJob implements Runnable, Serializable {
         CONVERT_EDITOR_MAPDB_TO_SQL,
         VALIDATE_ALL_FEEDS,
         MONITOR_SERVER_STATUS,
-        MERGE_FEED_VERSIONS
+        MERGE_FEED_VERSIONS,
+        RECREATE_BUILD_IMAGE
     }
 
     public MonitorableJob(Auth0UserProfile owner, String name, JobType type) {

--- a/src/main/java/com/conveyal/datatools/manager/controllers/api/ServerController.java
+++ b/src/main/java/com/conveyal/datatools/manager/controllers/api/ServerController.java
@@ -349,33 +349,16 @@ public class ServerController {
         validationTasks.add(() -> validateAmiId(server.ec2Info.buildAmiId, ec2Client));
         validationTasks.add(() -> validateGraphBuildReplacementAmiName(server.ec2Info, ec2Client));
         // add the load balancer task to the end since it can produce aggregate messages
-        validationTasks.add(() -> validateTargetGrouptLoadBalancerSubnetIdAndSecurityGroup(
+        validationTasks.add(() -> validateTargetGroupLoadBalancerSubnetIdAndSecurityGroup(
             server.ec2Info,
             credentials,
             ec2Client
         ));
 
-        // execute all tasks asynchronously in unique threads
-        ExecutorService pool = Executors.newFixedThreadPool(validationTasks.size());
-
-        // compile overall result
-        EC2ValidationResult result = new EC2ValidationResult();
-        // check each individual task result
-        for (Future<EC2ValidationResult> ec2ValidationResultFuture : pool.invokeAll(validationTasks)) {
-            EC2ValidationResult taskValidationResult = ec2ValidationResultFuture.get();
-            // check if task yielded a valid result
-            if (!taskValidationResult.isValid()) {
-                // task had an invalid result, check if overall validation result has been changed to false yet
-                if (result.isValid()) {
-                    // first invalid result. Write a header message.
-                    result.setInvalid("Invalid EC2 config for the following reasons!\n", new Exception());
-                }
-                // add to list of messages and exceptions
-                result.appendResult(taskValidationResult);
-            }
-        }
-        pool.shutdown();
-        return result;
+        return executeValidationTasks(
+            validationTasks,
+            "Invalid EC2 config for the following reasons!\n"
+        );
     }
 
     /**
@@ -639,7 +622,7 @@ public class ServerController {
      * Validate that ELB target group exists and is not empty and return associated load balancer for validating related
      * fields.
      */
-    private static EC2ValidationResult validateTargetGrouptLoadBalancerSubnetIdAndSecurityGroup(
+    private static EC2ValidationResult validateTargetGroupLoadBalancerSubnetIdAndSecurityGroup(
         EC2Info ec2Info,
         AWSStaticCredentialsProvider credentials,
         AmazonEC2 ec2Client
@@ -661,18 +644,36 @@ public class ServerController {
         List<Callable<EC2ValidationResult>> loadBalancerValidationTasks = new ArrayList<>();
         loadBalancerValidationTasks.add(() -> validateSubnetId(loadBalancer, ec2Info, ec2Client));
         loadBalancerValidationTasks.add(() -> validateSecurityGroupId(loadBalancer, ec2Info));
-        ExecutorService pool = Executors.newFixedThreadPool(loadBalancerValidationTasks.size());
-        for (Future<EC2ValidationResult> ec2ValidationResultFuture : pool.invokeAll(loadBalancerValidationTasks)) {
-            EC2ValidationResult loadBalancerValidationTaskResult = ec2ValidationResultFuture.get();
+
+        return executeValidationTasks(
+            loadBalancerValidationTasks,
+            "Invalid EC2 load balancer config for the following reasons:\n"
+        );
+    }
+
+    private static EC2ValidationResult executeValidationTasks(
+        List<Callable<EC2ValidationResult>> validationTasks,
+        String overallInvalidMessage
+    ) throws ExecutionException, InterruptedException {
+        // create overall result
+        EC2ValidationResult result = new EC2ValidationResult();
+
+        // Create a thread pool that is the size of the total number of validation tasks so each task gets its own
+        // thread
+        ExecutorService pool = Executors.newFixedThreadPool(validationTasks.size());
+
+        // Execute all tasks
+        for (Future<EC2ValidationResult> resultFuture : pool.invokeAll(validationTasks)) {
+            EC2ValidationResult taskResult = resultFuture.get();
             // check if task yielded a valid result
-            if (!loadBalancerValidationTaskResult.isValid()) {
+            if (!taskResult.isValid()) {
                 // task had an invalid result, check if overall validation result has been changed to false yet
                 if (result.isValid()) {
                     // first invalid result. Write a header message.
-                    result.setInvalid("Invalid EC2 load balancer config for the following reasons:\n", new Exception());
+                    result.setInvalid(overallInvalidMessage);
                 }
                 // add to list of messages and exceptions
-                result.appendResult(loadBalancerValidationTaskResult);
+                result.appendResult(taskResult);
             }
         }
         pool.shutdown();

--- a/src/main/java/com/conveyal/datatools/manager/jobs/DeployJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/DeployJob.java
@@ -524,6 +524,8 @@ public class DeployJob extends MonitorableJob {
             status.fail("An error occurred while validating the ec2 configuration", e);
             return;
         }
+        ExecutorService recreateBuildImageExecutor = null;
+        RecreateBuildImageJob recreateBuildImageJob = null;
         try {
             // Track any previous instances running for the server we're deploying to in order to de-register and
             // terminate them later.
@@ -570,13 +572,14 @@ public class DeployJob extends MonitorableJob {
                 // Check if a new image of the instance with the completed graph build should be created.
                 if (otpServer.ec2Info.recreateBuildImage) {
                     // Begin a new job to create a graph build image so that can happen asynchronously
-                    RecreateBuildImageJob recreateBuildImageJob = new RecreateBuildImageJob(
+                    recreateBuildImageJob = new RecreateBuildImageJob(
                         owner,
                         graphBuildingInstances,
                         otpServer,
                         ec2
                     );
-                    DataManager.heavyExecutor.execute(recreateBuildImageJob);
+                    recreateBuildImageExecutor = Executors.newSingleThreadExecutor();
+                    recreateBuildImageExecutor.execute(recreateBuildImageJob);
                 }
                 // Check whether the graph build instance type or AMI ID is different from the non-graph building type.
                 // If so, terminate the graph building instance. If not, add the graph building instance to the list
@@ -654,6 +657,21 @@ public class DeployJob extends MonitorableJob {
                         finalMessage = String.format("Server setup is complete! (WARNING: Could not terminate previous EC2 instances: %s", previousInstanceIds);
                     }
                 }
+            }
+            // Wait for a recreate graph build job to complete if one was started
+            if (recreateBuildImageExecutor != null) {
+                status.update("Waiting for recreate graph building image job to complete", 95);
+                while (!recreateBuildImageJob.status.completed) {
+                    try {
+                        // wait 1 second
+                        Thread.sleep(1000);
+                    } catch (InterruptedException e) {
+                        recreateBuildImageExecutor.shutdown();
+                        status.fail("An error occurred while waiting for the graph build image to be recreated", e);
+                        return;
+                    }
+                }
+                recreateBuildImageExecutor.shutdown();
             }
             // Job is complete.
             status.completeSuccessfully(finalMessage);

--- a/src/main/java/com/conveyal/datatools/manager/jobs/DeployJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/DeployJob.java
@@ -658,15 +658,17 @@ public class DeployJob extends MonitorableJob {
                     .filter(instance -> "running".equals(instance.state.getName()))
                     .map(instance -> instance.instanceId)
                     .collect(Collectors.toList());
+                // If there were previous instances assigned to the server, deregister/terminate them (now that the new
+                // instances are up and running).
                 if (previousInstanceIds.size() > 0) {
-                    boolean success = ServerController.deRegisterAndTerminateInstances(
+                    boolean previousInstancesTerminated = ServerController.deRegisterAndTerminateInstances(
                         credentials,
                         otpServer.ec2Info.targetGroupArn,
                         customRegion,
                         previousInstanceIds
                     );
                     // If there was a problem during de-registration/termination, notify via status message.
-                    if (!success) {
+                    if (!previousInstancesTerminated) {
                         finalMessage = String.format("Server setup is complete! (WARNING: Could not terminate previous EC2 instances: %s", previousInstanceIds);
                     }
                 }

--- a/src/main/java/com/conveyal/datatools/manager/jobs/RecreateBuildImageJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/RecreateBuildImageJob.java
@@ -16,6 +16,7 @@ import com.conveyal.datatools.manager.models.OtpServer;
 import com.conveyal.datatools.manager.persistence.Persistence;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import static com.conveyal.datatools.manager.models.EC2Info.AMI_CONFIG_PATH;
 
@@ -63,9 +64,9 @@ public class RecreateBuildImageJob extends MonitorableJob {
                     // See https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/ec2/model/ImageState.html
                     String imageState = image.getState().toLowerCase();
                     if (imageState.equals("pending")) {
-                        if (System.currentTimeMillis() - status.startTime > 60 * 60 * 1000) {
+                        if (System.currentTimeMillis() - status.startTime > TimeUnit.HOURS.toMillis(1)) {
                             terminateInstanceAndFailWithMessage(
-                                "It has taken over an hour for the graph build image to be created! Check the AWS console to see if the image ended up being created successfully"
+                                "It has taken over an hour for the graph build image to be created! Check the AWS console to see if the image was created successfully."
                             );
                             return;
                         }

--- a/src/main/java/com/conveyal/datatools/manager/jobs/RecreateBuildImageJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/RecreateBuildImageJob.java
@@ -1,0 +1,107 @@
+package com.conveyal.datatools.manager.jobs;
+
+import com.amazonaws.services.ec2.AmazonEC2;
+import com.amazonaws.services.ec2.model.CreateImageRequest;
+import com.amazonaws.services.ec2.model.CreateImageResult;
+import com.amazonaws.services.ec2.model.DeregisterImageRequest;
+import com.amazonaws.services.ec2.model.DescribeImagesRequest;
+import com.amazonaws.services.ec2.model.DescribeImagesResult;
+import com.amazonaws.services.ec2.model.Image;
+import com.amazonaws.services.ec2.model.Instance;
+import com.conveyal.datatools.common.status.MonitorableJob;
+import com.conveyal.datatools.manager.DataManager;
+import com.conveyal.datatools.manager.auth.Auth0UserProfile;
+import com.conveyal.datatools.manager.controllers.api.ServerController;
+import com.conveyal.datatools.manager.models.OtpServer;
+import com.conveyal.datatools.manager.persistence.Persistence;
+
+import java.util.List;
+
+import static com.conveyal.datatools.manager.models.EC2Info.AMI_CONFIG_PATH;
+
+/**
+ * Job that is dispatched during a {@link DeployJob} that spins up EC2 instances. This handles waiting for a graph build
+ * image to be created after a graph build has completed.
+ */
+public class RecreateBuildImageJob extends MonitorableJob {
+    private final AmazonEC2 ec2;
+    private final List<Instance> graphBuildingInstances;
+    private final OtpServer otpServer;
+
+    public RecreateBuildImageJob(
+        Auth0UserProfile owner,
+        List<Instance> graphBuildingInstances,
+        OtpServer otpServer,
+        AmazonEC2 ec2
+    ) {
+        super(owner, String.format("Recreating build image for %s", otpServer.name), JobType.RECREATE_BUILD_IMAGE);
+        this.graphBuildingInstances = graphBuildingInstances;
+        this.otpServer = otpServer;
+        this.ec2 = ec2;
+    }
+
+    @Override
+    public void jobLogic() throws Exception {
+        status.update("Creating build image", 5);
+        // Create a new image of this instance.
+        CreateImageRequest createImageRequest = new CreateImageRequest()
+            .withInstanceId(graphBuildingInstances.get(0).getInstanceId())
+            .withName(otpServer.ec2Info.buildImageName)
+            .withDescription(otpServer.ec2Info.buildImageDescription);
+        CreateImageResult createImageResult = ec2.createImage(createImageRequest);
+        // Wait for image creation to complete
+        String createdImageId = createImageResult.getImageId();
+        status.update("Waiting for graph build image to be created...", 25);
+        boolean imageCreated = false;
+        DescribeImagesRequest describeImagesRequest = new DescribeImagesRequest()
+            .withImageIds(createdImageId);
+        while (!imageCreated) {
+            DescribeImagesResult describeImagesResult = ec2.describeImages(describeImagesRequest);
+            for (Image image : describeImagesResult.getImages()) {
+                if (image.getImageId().equals(createdImageId)) {
+                    // obtain the image state.
+                    // See https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/ec2/model/ImageState.html
+                    String imageState = image.getState().toLowerCase();
+                    if (imageState.equals("pending")) {
+                        // wait 2.5 seconds before making next request
+                        Thread.sleep(2500);
+                    } else if (imageState.equals("available")) {
+                        // success! Set imageCreated to true.
+                        imageCreated = true;
+                    } else {
+                        // Any other image state is assumed to be a failure
+                        status.fail(
+                            String.format("Graph build image creation failed! Image state became `%s`", imageState)
+                        );
+                        return;
+                    }
+                }
+            }
+        }
+        status.update("Graph build image successfully created!", 70);
+        // Deregister old image if it exists and is not the default datatools AMI ID and is not the server AMI ID
+        String graphBuildAmiId = otpServer.ec2Info.buildAmiId;
+        if (
+            graphBuildAmiId != null &&
+                !DataManager.getConfigPropertyAsText(AMI_CONFIG_PATH).equals(graphBuildAmiId) &&
+                !graphBuildAmiId.equals(otpServer.ec2Info.amiId)
+        ) {
+            status.message = "Deregistering old build image";
+            DeregisterImageRequest deregisterImageRequest = new DeregisterImageRequest()
+                .withImageId(graphBuildAmiId);
+            ec2.deregisterImage(deregisterImageRequest);
+        }
+        status.update("Updating Server build AMI info", 80);
+        // Update OTP Server info
+        otpServer.ec2Info.buildAmiId = createdImageId;
+        otpServer.ec2Info.recreateBuildImage = false;
+        Persistence.servers.replace(otpServer.id, otpServer);
+        status.update("Server build AMI info updated", 90);
+        // terminate graph building instance if needed
+        if (otpServer.ec2Info.hasSeparateGraphBuildConfig()) {
+            status.message = "Terminating graph building instance";
+            ServerController.terminateInstances(ec2, graphBuildingInstances);
+        }
+        status.completeSuccessfully("Graph build image successfully created!");
+    }
+}

--- a/src/main/java/com/conveyal/datatools/manager/jobs/RecreateBuildImageJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/RecreateBuildImageJob.java
@@ -63,14 +63,28 @@ public class RecreateBuildImageJob extends MonitorableJob {
                     // See https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/ec2/model/ImageState.html
                     String imageState = image.getState().toLowerCase();
                     if (imageState.equals("pending")) {
+                        if (System.currentTimeMillis() - status.startTime > 60 * 60 * 1000) {
+                            terminateInstanceAndFailWithMessage(
+                                "It has taken over an hour for the graph build image to be created! Check the AWS console to see if the image ended up being created successfully"
+                            );
+                            return;
+                        }
                         // wait 2.5 seconds before making next request
-                        Thread.sleep(2500);
+                        try {
+                            Thread.sleep(2500);
+                        } catch (InterruptedException e) {
+                            terminateInstanceAndFailWithMessage(
+                                "Failed while waiting for graph build image creation to complete!",
+                                e
+                            );
+                            return;
+                        }
                     } else if (imageState.equals("available")) {
                         // success! Set imageCreated to true.
                         imageCreated = true;
                     } else {
                         // Any other image state is assumed to be a failure
-                        status.fail(
+                        terminateInstanceAndFailWithMessage(
                             String.format("Graph build image creation failed! Image state became `%s`", imageState)
                         );
                         return;
@@ -103,5 +117,17 @@ public class RecreateBuildImageJob extends MonitorableJob {
             ServerController.terminateInstances(ec2, graphBuildingInstances);
         }
         status.completeSuccessfully("Graph build image successfully created!");
+    }
+
+    private void terminateInstanceAndFailWithMessage(String message) {
+        terminateInstanceAndFailWithMessage(message, null);
+    }
+
+    /**
+     * Terminates the graph building instance and fails with the given message and Exception.
+     */
+    private void terminateInstanceAndFailWithMessage(String message, Exception e) {
+        ServerController.terminateInstances(ec2, graphBuildingInstances);
+        status.fail(message, e);
     }
 }

--- a/src/main/java/com/conveyal/datatools/manager/jobs/RecreateBuildImageJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/RecreateBuildImageJob.java
@@ -49,7 +49,7 @@ public class RecreateBuildImageJob extends MonitorableJob {
             .withName(otpServer.ec2Info.buildImageName)
             .withDescription(otpServer.ec2Info.buildImageDescription);
         CreateImageResult createImageResult = ec2.createImage(createImageRequest);
-        // Wait for image creation to complete
+        // Wait for image creation to complete (it can take a few minutes)
         String createdImageId = createImageResult.getImageId();
         status.update("Waiting for graph build image to be created...", 25);
         boolean imageCreated = false;


### PR DESCRIPTION
also parallelize ec2 validation checks

### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [ ] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR does the following:

- refactors the validation of ec2 config to be parallelized and accessible from other classes
- adds a validation check to make sure the graph build instance name that should be recreated has a unique name
- adds a validation check to AMI IDs to make sure they have an `available` state
- adds validation of ec2 config to the beginning of a deploy job
- adds a new job of `RecreateBuildImageJob` that happens asynchronously from the rest of the deploy job