### PR TITLE
Remove associated trips when removing calendar_dates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,8 +36,8 @@ before_script:
   # Create dir for GTFS+ files (used during testing)
   - mkdir /tmp/gtfsplus
 script:
-  # run mvn package to make sure unit tests and packaging can work
-  - mvn package
+  # run mvn package (only print errors) to make sure unit tests and packaging can work
+  - mvn --errors package
   # Restart/clear MongoDB so that E2E tests run on clean DB.
   - ./scripts/restart-mongo-with-fresh-db.sh
   # recursively copy coverage results into another folder so the e2e tests don't overwrite them

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ before_script:
   - mkdir /tmp/gtfsplus
 script:
   # run mvn package (only print errors) to make sure unit tests and packaging can work
-  - mvn --errors package
+  - mvn -q package
   # Restart/clear MongoDB so that E2E tests run on clean DB.
   - ./scripts/restart-mongo-with-fresh-db.sh
   # recursively copy coverage results into another folder so the e2e tests don't overwrite them

--- a/pom.xml
+++ b/pom.xml
@@ -334,6 +334,8 @@
             <artifactId>gt-api</artifactId>
             <version>${geotools.version}</version>
         </dependency>
+        <!-- gt-epsg-hsql includes coordinate reference libraries that were removed from gtfs-lib in
+             https://github.com/conveyal/gtfs-lib/pull/290 -->
         <dependency>
             <groupId>org.geotools</groupId>
             <artifactId>gt-epsg-hsql</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -250,7 +250,7 @@
         <dependency>
             <groupId>com.conveyal</groupId>
             <artifactId>gtfs-lib</artifactId>
-            <version>6.0.3</version>
+            <version>6.0.4</version>
             <!-- Exclusions added in order to silence SLF4J warnings about multiple bindings:
                 http://www.slf4j.org/codes.html#multiple_bindings
             -->

--- a/pom.xml
+++ b/pom.xml
@@ -334,6 +334,11 @@
             <artifactId>gt-api</artifactId>
             <version>${geotools.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.geotools</groupId>
+            <artifactId>gt-epsg-hsql</artifactId>
+            <version>${geotools.version}</version>
+        </dependency>
 
         <!-- Error reporting -->
         <dependency>

--- a/src/test/java/com/conveyal/datatools/manager/jobs/MergeFeedsJobTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/jobs/MergeFeedsJobTest.java
@@ -557,6 +557,14 @@ public class MergeFeedsJobTest extends UnitTest {
             ),
             1
         );
+        // cal_to_remove service_id should be scoped for earlier feed version.
+        assertThatSqlCountQueryYieldsExpectedCount(
+            String.format(
+                "SELECT count(*) FROM %s.trips WHERE service_id='Fake_Agency4:cal_to_remove'",
+                mergedNamespace
+            ),
+            1
+        );
         // Amended calendar record from earlier feed version should also have a modified end date (one day before the
         // earliest start_date from the future feed).
         assertThatSqlCountQueryYieldsExpectedCount(

--- a/src/test/java/com/conveyal/datatools/manager/jobs/MergeFeedsJobTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/jobs/MergeFeedsJobTest.java
@@ -42,6 +42,7 @@ public class MergeFeedsJobTest extends UnitTest {
     private static FeedVersion napaVersion;
     private static FeedVersion bothCalendarFilesVersion;
     private static FeedVersion bothCalendarFilesVersion2;
+    private static FeedVersion bothCalendarFilesVersion3;
     private static FeedVersion onlyCalendarVersion;
     private static FeedVersion onlyCalendarDatesVersion;
 
@@ -92,6 +93,10 @@ public class MergeFeedsJobTest extends UnitTest {
         bothCalendarFilesVersion2 = createFeedVersion(
             fakeAgency,
             zipFolderFiles("fake-agency-with-calendar-and-calendar-dates-2")
+        );
+        bothCalendarFilesVersion3 = createFeedVersion(
+            fakeAgency,
+            zipFolderFiles("fake-agency-with-calendar-and-calendar-dates-3")
         );
     }
 
@@ -580,6 +585,60 @@ public class MergeFeedsJobTest extends UnitTest {
         assertThatSqlCountQueryYieldsExpectedCount(
             String.format(
                 "SELECT count(*) FROM %s.calendar_dates WHERE service_id='Fake_Agency4:cal_to_remove'",
+                mergedNamespace
+            ),
+            1
+        );
+    }
+
+    /**
+     * Tests whether a MTC feed merge of two feed versions correctly removes calendar records that have overlapping
+     * service but keeps calendar_dates records that share service_id with the removed calendar and trips that reference
+     * that service_id.
+     */
+    @Test
+    public void canMergeFeedsWithMTCForServiceIds4 () throws SQLException {
+        Set<FeedVersion> versions = new HashSet<>();
+        versions.add(bothCalendarFilesVersion);
+        versions.add(bothCalendarFilesVersion3);
+        MergeFeedsJob mergeFeedsJob = new MergeFeedsJob(user, versions, "merged_output", MergeFeedsType.SERVICE_PERIOD);
+        // Run the job in this thread (we're not concerned about concurrency here).
+        mergeFeedsJob.run();
+        assertFeedMergeSucceeded(mergeFeedsJob);
+        // assert service_ids have been feed scoped properly
+        String mergedNamespace = mergeFeedsJob.mergedVersion.namespace;
+        // - calendar table
+        // expect a total of 3 records in calendar table
+        assertThatSqlCountQueryYieldsExpectedCount(
+            String.format("SELECT count(*) FROM %s.calendar", mergedNamespace),
+            3
+        );
+        // - calendar_dates table
+        // expect 2 records in calendar_dates table (all records from future feed removed)
+        assertThatSqlCountQueryYieldsExpectedCount(
+            String.format("SELECT count(*) FROM %s.calendar_dates", mergedNamespace),
+            3
+        );
+
+        // - trips table
+        // expect 3 records in trips table
+        assertThatSqlCountQueryYieldsExpectedCount(
+            String.format("SELECT count(*) FROM %s.trips", mergedNamespace),
+            3
+        );
+        // common_id service_id should be scoped for earlier feed version.
+        assertThatSqlCountQueryYieldsExpectedCount(
+            String.format(
+                "SELECT count(*) FROM %s.trips WHERE service_id='Fake_Agency5:common_id'",
+                mergedNamespace
+            ),
+            1
+        );
+        // Amended calendar record from earlier feed version should also have a modified end date (one day before the
+        // earliest start_date from the future feed).
+        assertThatSqlCountQueryYieldsExpectedCount(
+            String.format(
+                "SELECT count(*) FROM %s.calendar WHERE service_id='Fake_Agency5:common_id' AND end_date='20170914'",
                 mergedNamespace
             ),
             1

--- a/src/test/resources/com/conveyal/datatools/gtfs/fake-agency-with-calendar-and-calendar-dates-3/agency.txt
+++ b/src/test/resources/com/conveyal/datatools/gtfs/fake-agency-with-calendar-and-calendar-dates-3/agency.txt
@@ -1,0 +1,2 @@
+agency_id,agency_name,agency_url,agency_lang,agency_phone,agency_email,agency_timezone,agency_fare_url,agency_branding_url
+1,Fake Transit,,,,,America/Los_Angeles,,

--- a/src/test/resources/com/conveyal/datatools/gtfs/fake-agency-with-calendar-and-calendar-dates-3/calendar.txt
+++ b/src/test/resources/com/conveyal/datatools/gtfs/fake-agency-with-calendar-and-calendar-dates-3/calendar.txt
@@ -1,0 +1,2 @@
+service_id,monday,tuesday,wednesday,thursday,friday,saturday,sunday,start_date,end_date
+common_id,1,1,1,1,1,1,1,20170913,20170916

--- a/src/test/resources/com/conveyal/datatools/gtfs/fake-agency-with-calendar-and-calendar-dates-3/calendar_dates.txt
+++ b/src/test/resources/com/conveyal/datatools/gtfs/fake-agency-with-calendar-and-calendar-dates-3/calendar_dates.txt
@@ -1,0 +1,5 @@
+service_id,date,exception_type
+common_id,20170916,2
+keep_one,20170915,2
+keep_one,20170913,2
+remove,20170916,2

--- a/src/test/resources/com/conveyal/datatools/gtfs/fake-agency-with-calendar-and-calendar-dates-3/feed_info.txt
+++ b/src/test/resources/com/conveyal/datatools/gtfs/fake-agency-with-calendar-and-calendar-dates-3/feed_info.txt
@@ -1,0 +1,2 @@
+feed_id,feed_publisher_name,feed_publisher_url,feed_lang,feed_version
+fake_transit,Conveyal,http://www.conveyal.com,en,1.0

--- a/src/test/resources/com/conveyal/datatools/gtfs/fake-agency-with-calendar-and-calendar-dates-3/routes.txt
+++ b/src/test/resources/com/conveyal/datatools/gtfs/fake-agency-with-calendar-and-calendar-dates-3/routes.txt
@@ -1,0 +1,2 @@
+agency_id,route_id,route_short_name,route_long_name,route_desc,route_type,route_url,route_color,route_text_color,route_branding_url
+1,1,1,Route 1,,3,,7CE6E7,FFFFFF,

--- a/src/test/resources/com/conveyal/datatools/gtfs/fake-agency-with-calendar-and-calendar-dates-3/stop_times.txt
+++ b/src/test/resources/com/conveyal/datatools/gtfs/fake-agency-with-calendar-and-calendar-dates-3/stop_times.txt
@@ -1,0 +1,7 @@
+trip_id,arrival_time,departure_time,stop_id,stop_sequence,stop_headsign,pickup_type,drop_off_type,shape_dist_traveled,timepoint
+trip1,07:00:00,07:00:00,4u6g,1,,0,0,0.0000000,
+trip1,07:01:00,07:01:00,johv,2,,0,0,341.4491961,
+trip2,07:00:00,07:00:00,4u6g,1,,0,0,0.0000000,
+trip2,07:01:00,07:01:00,johv,2,,0,0,341.4491961,
+trip3,07:00:00,07:00:00,4u6g,1,,0,0,0.0000000,
+trip3,07:01:00,07:01:00,johv,2,,0,0,341.4491961,

--- a/src/test/resources/com/conveyal/datatools/gtfs/fake-agency-with-calendar-and-calendar-dates-3/stops.txt
+++ b/src/test/resources/com/conveyal/datatools/gtfs/fake-agency-with-calendar-and-calendar-dates-3/stops.txt
@@ -1,0 +1,6 @@
+stop_id,stop_code,stop_name,stop_desc,stop_lat,stop_lon,zone_id,stop_url,location_type,parent_station,stop_timezone,wheelchair_boarding
+4u6g,4u6g,Butler Ln,,37.0612132,-122.0074332,,,0,,,
+johv,johv,Scotts Valley Dr & Victor Sq,,37.0590172,-122.0096058,,,0,,,
+123,,Parent Station,,37.0666,-122.0777,,,1,,,
+1234,1234,Child Stop,,37.06662,-122.07772,,,0,123,,
+1234567,1234567,Unused stop,,37.06668,-122.07781,,,0,123,,

--- a/src/test/resources/com/conveyal/datatools/gtfs/fake-agency-with-calendar-and-calendar-dates-3/trips.txt
+++ b/src/test/resources/com/conveyal/datatools/gtfs/fake-agency-with-calendar-and-calendar-dates-3/trips.txt
@@ -1,0 +1,4 @@
+route_id,trip_id,trip_headsign,trip_short_name,direction_id,block_id,shape_id,bikes_allowed,wheelchair_accessible,service_id
+1,trip1,,,0,,,0,0,common_id
+1,trip2,,,0,,,0,0,keep_one
+1,trip3,,,0,,,0,0,remove


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR fixes #339 by checking if a service_id exists in the merge feed result and skipping trips if no ref is found. It also fixes some embedded issues with checking the correct variable (`valueToWrite` vs `value`).

Note: there is some clumsiness around the serviceIdMissing check and the subsequent check that it is not missing. I'm open to suggestions about improving this: https://github.com/ibi-group/datatools-server/pull/340/files#diff-b601a83ada6de294158d19894ceefe57R872-R883

