### PR TITLE
Less aws requests

### DIFF
--- a/src/main/java/com/conveyal/datatools/manager/controllers/api/ProjectController.java
+++ b/src/main/java/com/conveyal/datatools/manager/controllers/api/ProjectController.java
@@ -343,7 +343,6 @@ public class ProjectController {
         // with a collection, massive performance issues will ensure (mainly due to multiple calls to AWS EC2).
         JsonManager<Project> slimJson = new JsonManager<>(Project.class, JsonViews.UserInterface.class);
         JsonManager<Project> fullJson = new JsonManager<>(Project.class, JsonViews.UserInterface.class);
-        slimJson.addMixin(Project.class, Project.ProjectWithoutOtpServers.class);
         fullJson.addMixin(Project.class, Project.ProjectWithOtpServers.class);
         fullJson.addMixin(OtpServer.class, OtpServer.OtpServerWithoutEc2Instances.class);
 

--- a/src/main/java/com/conveyal/datatools/manager/controllers/api/ProjectController.java
+++ b/src/main/java/com/conveyal/datatools/manager/controllers/api/ProjectController.java
@@ -13,6 +13,7 @@ import com.conveyal.datatools.manager.models.FeedRetrievalMethod;
 import com.conveyal.datatools.manager.models.FeedSource;
 import com.conveyal.datatools.manager.models.FeedVersion;
 import com.conveyal.datatools.manager.models.JsonViews;
+import com.conveyal.datatools.manager.models.OtpServer;
 import com.conveyal.datatools.manager.models.Project;
 import com.conveyal.datatools.manager.persistence.Persistence;
 import com.conveyal.datatools.manager.utils.json.JsonManager;
@@ -342,7 +343,9 @@ public class ProjectController {
         // with a collection, massive performance issues will ensure (mainly due to multiple calls to AWS EC2).
         JsonManager<Project> slimJson = new JsonManager<>(Project.class, JsonViews.UserInterface.class);
         JsonManager<Project> fullJson = new JsonManager<>(Project.class, JsonViews.UserInterface.class);
+        slimJson.addMixin(Project.class, Project.ProjectWithoutOtpServers.class);
         fullJson.addMixin(Project.class, Project.ProjectWithOtpServers.class);
+        fullJson.addMixin(OtpServer.class, OtpServer.OtpServerWithoutEc2Instances.class);
 
         get(apiPrefix + "secure/project/:id", ProjectController::getProject, fullJson::write);
         get(apiPrefix + "secure/project", ProjectController::getAllProjects, slimJson::write);

--- a/src/main/java/com/conveyal/datatools/manager/controllers/api/ServerController.java
+++ b/src/main/java/com/conveyal/datatools/manager/controllers/api/ServerController.java
@@ -39,7 +39,6 @@ import static spark.Spark.put;
  * These methods are mapped to API endpoints by Spark.
  */
 public class ServerController {
-    private static JsonManager<OtpServer> json = new JsonManager<>(OtpServer.class, JsonViews.UserInterface.class);
     private static final Logger LOG = LoggerFactory.getLogger(ServerController.class);
 
     /**
@@ -135,6 +134,25 @@ public class ServerController {
     }
 
     /**
+     * HTTP controller to fetch a single server.
+     */
+    private static OtpServer fetchServer (Request req, Response res) {
+        String serverId = req.params("id");
+        Auth0UserProfile userProfile = req.attribute("user");
+        OtpServer server = Persistence.servers.getById(serverId);
+        if (
+            server != null &&
+            server.projectId != null &&
+                !userProfile.canAdministerApplication() &&
+                !userProfile.canAdministerProject(server.projectId)
+        ) {
+            logMessageAndHalt(req, 403, "Not authorized to view this server");
+            return null;
+        }
+        return server;
+    }
+
+    /**
      * Update a single OTP server.
      */
     private static OtpServer updateServer(Request req, Response res) throws IOException, CheckedAWSException {
@@ -204,12 +222,20 @@ public class ServerController {
      * Register HTTP methods with handler methods.
      */
     public static void register (String apiPrefix) {
+        // Construct JSON managers which help serialize the response. Slim JSON is used for the fetchServers method
+        // while the Full JSON also contains the ec2Instances field. This is to make sure no unnecessary requests to AWS
+        // are made.
+        JsonManager<OtpServer> slimJson = new JsonManager<>(OtpServer.class, JsonViews.UserInterface.class);
+        JsonManager<OtpServer> fullJson = new JsonManager<>(OtpServer.class, JsonViews.UserInterface.class);
+        slimJson.addMixin(OtpServer.class, OtpServer.OtpServerWithoutEc2Instances.class);
+
         options(apiPrefix + "secure/servers", (q, s) -> "");
-        delete(apiPrefix + "secure/servers/:id", ServerController::deleteServer, json::write);
-        delete(apiPrefix + "secure/servers/:id/ec2", ServerController::terminateEC2InstancesForServer, json::write);
-        get(apiPrefix + "secure/servers", ServerController::fetchServers, json::write);
-        post(apiPrefix + "secure/servers", ServerController::createServer, json::write);
-        put(apiPrefix + "secure/servers/:id", ServerController::updateServer, json::write);
+        delete(apiPrefix + "secure/servers/:id", ServerController::deleteServer, fullJson::write);
+        delete(apiPrefix + "secure/servers/:id/ec2", ServerController::terminateEC2InstancesForServer, fullJson::write);
+        get(apiPrefix + "secure/servers", ServerController::fetchServers, slimJson::write);
+        get(apiPrefix + "secure/servers/:id", ServerController::fetchServer, fullJson::write);
+        post(apiPrefix + "secure/servers", ServerController::createServer, fullJson::write);
+        put(apiPrefix + "secure/servers/:id", ServerController::updateServer, fullJson::write);
     }
 
 }

--- a/src/main/java/com/conveyal/datatools/manager/jobs/MonitorServerStatusJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/MonitorServerStatusJob.java
@@ -235,7 +235,6 @@ public class MonitorServerStatusJob extends MonitorableJob {
      * job should be failed.
      */
     private void waitAndCheckInstanceHealth(String waitingFor) throws InstanceHealthException, InterruptedException {
-        checkInstanceHealth(1);
         LOG.info("Waiting {} seconds for {}", DELAY_SECONDS, waitingFor);
         Thread.sleep(1000 * DELAY_SECONDS);
         checkInstanceHealth(1);

--- a/src/main/java/com/conveyal/datatools/manager/models/OtpServer.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/OtpServer.java
@@ -436,8 +436,8 @@ public class OtpServer extends Model {
     }
 
     /**
-     * A MixIn to be applied to this OtpServer, for returning a single OtpServer, without EC2InstanceSummaries that
-     * don't need to be written in JSON output.
+     * A MixIn to be applied to this OtpServer that will not include EC2InstanceSummaries when they are not needed in
+     * the JSON output. This will avoid making unneeded AWS requests.
      *
      * Usually a mixin would be used on an external class, but since we are changing one thing about a single class, it
      * seemed unnecessary to define a new view.

--- a/src/main/java/com/conveyal/datatools/manager/models/OtpServer.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/OtpServer.java
@@ -37,6 +37,7 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
@@ -433,5 +434,18 @@ public class OtpServer extends Model {
         AmazonS3 client = S3Utils.getS3Client(role, getRegion());
         client.putObject(s3Bucket, key, File.createTempFile("test", ".zip"));
         client.deleteObject(s3Bucket, key);
+    }
+
+    /**
+     * A MixIn to be applied to this OtpServer, for returning a single OtpServer, without EC2InstanceSummaries that
+     * don't need to be written in JSON output.
+     *
+     * Usually a mixin would be used on an external class, but since we are changing one thing about a single class, it
+     * seemed unnecessary to define a new view.
+     */
+    public abstract static class OtpServerWithoutEc2Instances {
+
+        @JsonIgnore
+        public abstract List<EC2InstanceSummary> retrieveEC2InstanceSummaries();
     }
 }

--- a/src/main/java/com/conveyal/datatools/manager/models/OtpServer.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/OtpServer.java
@@ -37,7 +37,6 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;

--- a/src/main/java/com/conveyal/datatools/manager/models/Project.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/Project.java
@@ -130,17 +130,4 @@ public class Project extends Model {
         @JsonProperty("otpServers")
         public abstract Collection<OtpServer> availableOtpServers ();
     }
-
-    /**
-     * A MixIn to be applied to this project, for returning a single project, so that the list of otpServers is
-     * included in the JSON response.
-     *
-     * Usually a mixin would be used on an external class, but since we are changing one thing about a single class, it
-     * seemed unnecessary to define a new view.
-     */
-    public abstract static class ProjectWithoutOtpServers {
-
-        @JsonIgnore
-        public abstract Collection<OtpServer> availableOtpServers ();
-    }
 }

--- a/src/main/java/com/conveyal/datatools/manager/models/Project.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/Project.java
@@ -1,6 +1,7 @@
 package com.conveyal.datatools.manager.models;
 
 import com.conveyal.datatools.manager.persistence.Persistence;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.slf4j.Logger;
@@ -127,6 +128,19 @@ public class Project extends Model {
     public abstract static class ProjectWithOtpServers {
 
         @JsonProperty("otpServers")
+        public abstract Collection<OtpServer> availableOtpServers ();
+    }
+
+    /**
+     * A MixIn to be applied to this project, for returning a single project, so that the list of otpServers is
+     * included in the JSON response.
+     *
+     * Usually a mixin would be used on an external class, but since we are changing one thing about a single class, it
+     * seemed unnecessary to define a new view.
+     */
+    public abstract static class ProjectWithoutOtpServers {
+
+        @JsonIgnore
         public abstract Collection<OtpServer> availableOtpServers ();
     }
 }


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR is built on top of #341.

This PR does a few things to reduce the amount of AWS requests that are performed as follows:

- Don't include ec2 instance data with OtpServers in API calls to get a Project or Projects
- Don't include ec2 instance data with OtpServers in API calls to get all servers
- Add new endpoint for getting a single OtpServer
- During MonitorServerStatusJobs only check instance health after waiting for 4 seconds instead of both before and after

This PR has a companion PR for the UI here: https://github.com/ibi-group/datatools-ui/pull/615