### PR TITLE
JUnit Upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -159,6 +159,11 @@
                     </execution>
                 </executions>
             </plugin>
+            <!-- maven-surefire-plugin is needed to run unit tests. -->
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
+            </plugin>
         </plugins>
     </build>
     <repositories>
@@ -245,9 +250,9 @@
 
         <!-- Used for testing (note: this should match the version in gtfs-lib). -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.1</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.7.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/test/java/com/conveyal/datatools/DatatoolsTest.java
+++ b/src/test/java/com/conveyal/datatools/DatatoolsTest.java
@@ -1,7 +1,7 @@
 package com.conveyal.datatools;
 
 import com.conveyal.datatools.manager.DataManager;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeAll;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.yaml.snakeyaml.Yaml;
@@ -25,7 +25,7 @@ public abstract class DatatoolsTest {
     private static boolean setUpIsDone = false;
     private static final Yaml yaml = new Yaml(); // needed for writing config files on CI for the e2e tests
 
-    @BeforeClass
+    @BeforeAll
     public static void setUp() throws RuntimeException, IOException {
         if (setUpIsDone) {
             return;

--- a/src/test/java/com/conveyal/datatools/EndToEndTest.java
+++ b/src/test/java/com/conveyal/datatools/EndToEndTest.java
@@ -1,7 +1,7 @@
 package com.conveyal.datatools;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -10,7 +10,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.file.Paths;
 
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
  * This test suite runs the datatools-ui end-to-end tests in an effort to collect code coverage on
@@ -22,7 +22,7 @@ public class EndToEndTest {
     private static final String datatoolsUiPath =
         Paths.get("").toAbsolutePath().resolveSibling("datatools-ui").toString();
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeAll () throws Exception {
         // make sure the RUN_E2E environment variable is set to true.  Otherwise, this test should
         // be skipped and the overall build should not depend on this test passing in order to save

--- a/src/test/java/com/conveyal/datatools/LoadFeedTest.java
+++ b/src/test/java/com/conveyal/datatools/LoadFeedTest.java
@@ -2,7 +2,7 @@ package com.conveyal.datatools;
 
 import com.conveyal.datatools.manager.models.FeedSource;
 import com.conveyal.datatools.manager.models.FeedVersion;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeAll;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -14,7 +14,7 @@ public abstract class LoadFeedTest {
     public static FeedSource source;
     public static FeedVersion version;
 
-    @BeforeClass
+    @BeforeAll
     public void setUp() throws Exception {
         DatatoolsTest.setUp();
         LOG.info("ProcessGtfsSnapshotMergeTest setup");

--- a/src/test/java/com/conveyal/datatools/TestUtils.java
+++ b/src/test/java/com/conveyal/datatools/TestUtils.java
@@ -23,14 +23,13 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
 import static com.conveyal.datatools.manager.DataManager.GTFS_DATA_SOURCE;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertThat;
 
 public class TestUtils {
     private static final Logger LOG = LoggerFactory.getLogger(TestUtils.class);

--- a/src/test/java/com/conveyal/datatools/UnitTest.java
+++ b/src/test/java/com/conveyal/datatools/UnitTest.java
@@ -1,9 +1,8 @@
 package com.conveyal.datatools;
 
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeAll;
 
-import static com.conveyal.datatools.TestUtils.getBooleanEnvVar;
-import static org.junit.Assume.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 /**
  * This class is used by all unit tests to indicate that all test cases are not part of the end-to-end tests. This way,
@@ -11,7 +10,7 @@ import static org.junit.Assume.assumeFalse;
  * code coverage reports.
  */
 public abstract class UnitTest {
-    @BeforeClass
+    @BeforeAll
     public static void beforeAll () {
         // make sure the RUN_E2E environment variable is set to true.  Otherwise, this test suite should be skipped and
         // the overall build should not depend on inheriting test suites passing in order to save time.

--- a/src/test/java/com/conveyal/datatools/editor/controllers/api/EditorControllerTest.java
+++ b/src/test/java/com/conveyal/datatools/editor/controllers/api/EditorControllerTest.java
@@ -14,8 +14,8 @@ import com.conveyal.datatools.manager.persistence.Persistence;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import spark.utils.IOUtils;
@@ -23,7 +23,6 @@ import spark.utils.IOUtils;
 import java.io.IOException;
 import java.util.Date;
 
-import static com.conveyal.datatools.TestUtils.createFeedVersion;
 import static com.conveyal.datatools.TestUtils.createFeedVersionFromGtfsZip;
 import static com.conveyal.datatools.manager.auth.Auth0Users.USERS_API_PATH;
 import static com.conveyal.datatools.manager.controllers.api.UserController.TEST_AUTH0_DOMAIN;
@@ -41,7 +40,7 @@ public class EditorControllerTest extends UnitTest {
     /**
      * Prepare and start a testing-specific web server
      */
-    @BeforeClass
+    @BeforeAll
     public static void setUp() throws Exception {
         long startTime = System.currentTimeMillis();
         // start server if it isn't already running

--- a/src/test/java/com/conveyal/datatools/manager/controllers/api/AppInfoControllerTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/controllers/api/AppInfoControllerTest.java
@@ -5,8 +5,8 @@ import com.conveyal.datatools.UnitTest;
 import com.conveyal.datatools.manager.DataManager;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
@@ -18,7 +18,7 @@ public class AppInfoControllerTest extends UnitTest {
     /**
      * Prepare and start a testing-specific web server
      */
-    @BeforeClass
+    @BeforeAll
     public static void setUp() throws Exception {
         // start server if it isn't already running
         DatatoolsTest.setUp();

--- a/src/test/java/com/conveyal/datatools/manager/controllers/api/FeedSourceControllerTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/controllers/api/FeedSourceControllerTest.java
@@ -12,22 +12,23 @@ import com.conveyal.datatools.manager.persistence.Persistence;
 import com.conveyal.datatools.manager.utils.HttpUtils;
 import com.conveyal.datatools.manager.utils.json.JsonUtil;
 import org.apache.http.HttpResponse;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.net.URL;
 
 import static org.eclipse.jetty.http.HttpStatus.OK_200;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 
 public class FeedSourceControllerTest extends DatatoolsTest {
     private static Project project = null;
     private static FeedSource feedSourceWithUrl = null;
     private static FeedSource feedSourceWithNoUrl = null;
 
-    @BeforeClass
+    @BeforeAll
     public static void setUp() throws IOException {
         DatatoolsTest.setUp();
         Auth0Connection.setAuthDisabled(true);
@@ -39,7 +40,7 @@ public class FeedSourceControllerTest extends DatatoolsTest {
         feedSourceWithNoUrl = createFeedSource("FeedSourceTwo", null);
     }
 
-    @AfterClass
+    @AfterAll
     public static void tearDown() {
         Auth0Connection.setAuthDisabled(Auth0Connection.getDefaultAuthDisabled());
         if (project != null) {

--- a/src/test/java/com/conveyal/datatools/manager/controllers/api/UserControllerTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/controllers/api/UserControllerTest.java
@@ -54,6 +54,7 @@ public class UserControllerTest extends UnitTest {
         DatatoolsTest.setUp();
         // Set users URL to test domain used by wiremock.
         UserController.setBaseUsersUrl("http://" + TEST_AUTH0_DOMAIN + USERS_API_PATH);
+        // This sets up a mock server that accepts requests and sends predefined responses to mock an Auth0 server.
         wireMockServer = new WireMockServer(
             options()
                 .port(TEST_AUTH0_PORT)

--- a/src/test/java/com/conveyal/datatools/manager/gtfsplus/GtfsPlusValidationTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/gtfsplus/GtfsPlusValidationTest.java
@@ -7,8 +7,8 @@ import com.conveyal.datatools.manager.models.FeedSource;
 import com.conveyal.datatools.manager.models.FeedVersion;
 import com.conveyal.datatools.manager.models.Project;
 import com.conveyal.datatools.manager.persistence.Persistence;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,7 +28,7 @@ public class GtfsPlusValidationTest extends UnitTest {
     /**
      * Create feed version for GTFS+ validation test.
      */
-    @BeforeClass
+    @BeforeAll
     public static void setUp() throws IOException {
         // start server if it isn't already running
         DatatoolsTest.setUp();

--- a/src/test/java/com/conveyal/datatools/manager/jobs/ArbitraryTransformJobTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/jobs/ArbitraryTransformJobTest.java
@@ -5,21 +5,21 @@ import com.conveyal.datatools.UnitTest;
 import com.conveyal.datatools.manager.auth.Auth0UserProfile;
 import com.conveyal.datatools.manager.models.FeedRetrievalMethod;
 import com.conveyal.datatools.manager.models.FeedSource;
+import com.conveyal.datatools.manager.models.FeedVersion;
+import com.conveyal.datatools.manager.models.Project;
 import com.conveyal.datatools.manager.models.Snapshot;
 import com.conveyal.datatools.manager.models.transform.DeleteRecordsTransformation;
 import com.conveyal.datatools.manager.models.transform.FeedTransformRules;
 import com.conveyal.datatools.manager.models.transform.FeedTransformation;
-import com.conveyal.datatools.manager.models.FeedVersion;
-import com.conveyal.datatools.manager.models.Project;
 import com.conveyal.datatools.manager.models.transform.ReplaceFileFromStringTransformation;
 import com.conveyal.datatools.manager.models.transform.ReplaceFileFromVersionTransformation;
 import com.conveyal.datatools.manager.persistence.Persistence;
 import org.hamcrest.Matchers;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,8 +37,9 @@ import static com.conveyal.datatools.TestUtils.createFeedVersion;
 import static com.conveyal.datatools.TestUtils.zipFolderFiles;
 import static com.conveyal.datatools.manager.models.FeedRetrievalMethod.MANUALLY_UPLOADED;
 import static com.conveyal.datatools.manager.models.FeedRetrievalMethod.VERSION_CLONE;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class ArbitraryTransformJobTest extends UnitTest {
     private static final Logger LOG = LoggerFactory.getLogger(ArbitraryTransformJob.class);
@@ -51,7 +52,7 @@ public class ArbitraryTransformJobTest extends UnitTest {
     /**
      * Initialize Data Tools and set up a simple feed source and project.
      */
-    @BeforeClass
+    @BeforeAll
     public static void setUp() throws IOException {
         // start server if it isn't already running
         DatatoolsTest.setUp();
@@ -69,7 +70,7 @@ public class ArbitraryTransformJobTest extends UnitTest {
     /**
      * Clean up test database after tests finish.
      */
-    @AfterClass
+    @AfterAll
     public static void tearDown() {
         // Project delete cascades to feed sources.
         project.delete();
@@ -78,7 +79,7 @@ public class ArbitraryTransformJobTest extends UnitTest {
     /**
      * Run set up before each test. This just resets the feed source transformation properties.
      */
-    @Before
+    @BeforeEach
     public void setUpTest() {
         feedSource = Persistence.feedSources.getById(feedSource.id);
         feedSource.transformRules = new ArrayList<>();
@@ -88,7 +89,7 @@ public class ArbitraryTransformJobTest extends UnitTest {
     /**
      * Run tear down after each test. This just deletes the feed versions that were used in the test.
      */
-    @After
+    @AfterEach
     public void tearDownTest() {
         // Clean up
         if (sourceVersion != null) sourceVersion.delete();
@@ -120,7 +121,7 @@ public class ArbitraryTransformJobTest extends UnitTest {
         // Check that new version has stop_attributes file
         ZipFile zip = new ZipFile(targetVersion.retrieveGtfsFile());
         ZipEntry entry = zip.getEntry(table + ".txt");
-        assertThat(entry, Matchers.notNullValue());
+        assertNotNull(entry);
         // TODO Verify that stop_attributes file matches source file exactly?
     }
 
@@ -152,9 +153,9 @@ public class ArbitraryTransformJobTest extends UnitTest {
         // Grab the modified version and check that the trips count matches expectation.
         FeedVersion newVersion = feedSource.retrieveLatest();
         assertEquals(
-            "trips count for transformed feed should be decreased by the # of records matched by the query",
             sourceVersion.feedLoadResult.trips.rowCount - numberOfTripsForRoutes,
-            newVersion.feedLoadResult.trips.rowCount
+            newVersion.feedLoadResult.trips.rowCount,
+            "trips count for transformed feed should be decreased by the # of records matched by the query"
         );
     }
 
@@ -178,19 +179,19 @@ public class ArbitraryTransformJobTest extends UnitTest {
         targetVersion = feedSource.retrieveLatest();
         LOG.info("Checking canCloneZipFileAndTransform assertions.");
         assertEquals(
-            "Cloned version number should increment by one over original version.",
             sourceVersion.version + 1,
-            targetVersion.version
+            targetVersion.version,
+            "Cloned version number should increment by one over original version."
         );
         assertEquals(
-            "Cloned version retrieval method should be VERSION_CLONE",
             targetVersion.retrievalMethod,
-            VERSION_CLONE
+            VERSION_CLONE,
+            "Cloned version retrieval method should be VERSION_CLONE"
         );
         assertEquals(
-            "feed_info.txt row count should equal input csv data # of rows",
             2, // Magic number should match row count in string produced by generateFeedInfo
-            targetVersion.feedLoadResult.feedInfo.rowCount
+            targetVersion.feedLoadResult.feedInfo.rowCount,
+            "feed_info.txt row count should equal input csv data # of rows"
         );
         // Check for presence of new feedId in database (one record).
         assertThatSqlCountQueryYieldsExpectedCount(
@@ -244,9 +245,9 @@ public class ArbitraryTransformJobTest extends UnitTest {
         );
         LOG.info("Checking assertions.");
         assertEquals(
-            "feed_info.txt row count should equal input csv data # of rows",
             2, // Magic number should match row count in string produced by generateFeedInfo
-            targetVersion.feedLoadResult.feedInfo.rowCount
+            targetVersion.feedLoadResult.feedInfo.rowCount,
+            "feed_info.txt row count should equal input csv data # of rows"
         );
         // Check for presence of new feedId in database (one record).
         assertThatSqlCountQueryYieldsExpectedCount(

--- a/src/test/java/com/conveyal/datatools/manager/jobs/DeployJobTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/jobs/DeployJobTest.java
@@ -12,9 +12,9 @@ import com.conveyal.datatools.manager.models.EC2Info;
 import com.conveyal.datatools.manager.models.OtpServer;
 import com.conveyal.datatools.manager.models.Project;
 import com.conveyal.datatools.manager.persistence.Persistence;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -26,8 +26,8 @@ import java.util.List;
 import static com.conveyal.datatools.TestUtils.getBooleanEnvVar;
 import static com.zenika.snapshotmatcher.SnapshotMatcher.matchesSnapshot;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
  * This test suite contains various unit and integration tests to make sure the a DeployJob works properly. The unit
@@ -45,7 +45,7 @@ public class DeployJobTest extends UnitTest {
     /**
      * Add project, server, and deployment to prepare for tests.
      */
-    @BeforeClass
+    @BeforeAll
     public static void setUp() throws IOException {
         // start server if it isn't already running
         DatatoolsTest.setUp();
@@ -167,7 +167,7 @@ public class DeployJobTest extends UnitTest {
         DeployJob deployJob = new DeployJob(deployment, Auth0UserProfile.createTestAdminUser(), server, "test-deploy", DeployJob.DeployType.USE_PRELOADED_BUNDLE);
         deployJob.run();
         // FIXME: Deployment will succeed even if one of the clone servers does not start up properly.
-        assertFalse("Deployment did not fail.", deployJob.status.error);
+        assertFalse(deployJob.status.error, "Deployment did not fail.");
     }
 
     /**
@@ -182,7 +182,7 @@ public class DeployJobTest extends UnitTest {
         DeployJob deployJob = new DeployJob(deployment, Auth0UserProfile.createTestAdminUser(), server, "deploy-test", DeployJob.DeployType.USE_PREBUILT_GRAPH);
         deployJob.run();
         // FIXME: Deployment will succeed even if one of the clone servers does not start up properly.
-        assertFalse("Deployment did not fail.", deployJob.status.error);
+        assertFalse(deployJob.status.error, "Deployment did not fail.");
     }
 
     /**
@@ -191,7 +191,7 @@ public class DeployJobTest extends UnitTest {
      * Note: this requires changing server.yml#modules.deployment.ec2.enabled to true and also that the
      * RUN_AWS_DEPLOY_JOB_TESTS environment variable is set to "true"
      */
-    @AfterClass
+    @AfterAll
     public static void cleanUp() throws AmazonServiceException, CheckedAWSException {
         assumeTrue(getBooleanEnvVar("RUN_AWS_DEPLOY_JOB_TESTS"));
         List<Instance> instances = server.retrieveEC2Instances();

--- a/src/test/java/com/conveyal/datatools/manager/jobs/GisExportJobTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/jobs/GisExportJobTest.java
@@ -2,7 +2,6 @@ package com.conveyal.datatools.manager.jobs;
 
 import com.conveyal.datatools.DatatoolsTest;
 import com.conveyal.datatools.UnitTest;
-import com.conveyal.datatools.manager.DataManager;
 import com.conveyal.datatools.manager.auth.Auth0UserProfile;
 import com.conveyal.datatools.manager.models.FeedSource;
 import com.conveyal.datatools.manager.models.FeedVersion;
@@ -19,8 +18,8 @@ import org.geotools.data.FeatureSource;
 import org.geotools.feature.FeatureCollection;
 import org.geotools.feature.FeatureIterator;
 import org.geotools.referencing.CRS;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.opengis.feature.Feature;
 import org.opengis.feature.Property;
 import org.opengis.referencing.FactoryException;
@@ -32,8 +31,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Collection;
 import java.util.Date;
@@ -64,7 +61,7 @@ public class GisExportJobTest extends UnitTest {
     private static final double CALTRAIN_NORTH = 37.8499;
     private static final double CALTRAIN_SOUTH = 37.002;
 
-    @BeforeClass
+    @BeforeAll
     public static void setUp() throws IOException {
         DatatoolsTest.setUp();
         LOG.info("{} setup", GisExportJobTest.class.getSimpleName());

--- a/src/test/java/com/conveyal/datatools/manager/jobs/MergeFeedsJobTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/jobs/MergeFeedsJobTest.java
@@ -8,8 +8,8 @@ import com.conveyal.datatools.manager.models.FeedVersion;
 import com.conveyal.datatools.manager.models.Project;
 import com.conveyal.datatools.manager.persistence.Persistence;
 import com.conveyal.gtfs.error.NewGTFSErrorType;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,9 +25,9 @@ import static com.conveyal.datatools.TestUtils.createFeedVersion;
 import static com.conveyal.datatools.TestUtils.createFeedVersionFromGtfsZip;
 import static com.conveyal.datatools.TestUtils.zipFolderFiles;
 import static com.conveyal.datatools.manager.models.FeedRetrievalMethod.MANUALLY_UPLOADED;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Tests for the various {@link MergeFeedsJob} merge types.
@@ -49,7 +49,7 @@ public class MergeFeedsJobTest extends UnitTest {
     /**
      * Prepare and start a testing-specific web server
      */
-    @BeforeClass
+    @BeforeAll
     public static void setUp() throws IOException {
         // start server if it isn't already running
         DatatoolsTest.setUp();
@@ -114,39 +114,39 @@ public class MergeFeedsJobTest extends UnitTest {
 
         // Ensure the feed has the row counts we expect.
         assertEquals(
-            "trips count for merged feed should equal sum of trips for versions merged.",
             bartVersion1.feedLoadResult.trips.rowCount + calTrainVersion.feedLoadResult.trips.rowCount + napaVersion.feedLoadResult.trips.rowCount,
-            mergedVersion.feedLoadResult.trips.rowCount
+            mergedVersion.feedLoadResult.trips.rowCount,
+            "trips count for merged feed should equal sum of trips for versions merged."
         );
         assertEquals(
-            "routes count for merged feed should equal sum of routes for versions merged.",
             bartVersion1.feedLoadResult.routes.rowCount + calTrainVersion.feedLoadResult.routes.rowCount + napaVersion.feedLoadResult.routes.rowCount,
-            mergedVersion.feedLoadResult.routes.rowCount
+            mergedVersion.feedLoadResult.routes.rowCount,
+            "routes count for merged feed should equal sum of routes for versions merged."
             );
         assertEquals(
-            "stops count for merged feed should equal sum of stops for versions merged.",
             mergedVersion.feedLoadResult.stops.rowCount,
-            bartVersion1.feedLoadResult.stops.rowCount + calTrainVersion.feedLoadResult.stops.rowCount + napaVersion.feedLoadResult.stops.rowCount
+            bartVersion1.feedLoadResult.stops.rowCount + calTrainVersion.feedLoadResult.stops.rowCount + napaVersion.feedLoadResult.stops.rowCount,
+            "stops count for merged feed should equal sum of stops for versions merged."
         );
         assertEquals(
-            "agency count for merged feed should equal sum of agency for versions merged.",
             mergedVersion.feedLoadResult.agency.rowCount,
-            bartVersion1.feedLoadResult.agency.rowCount + calTrainVersion.feedLoadResult.agency.rowCount + napaVersion.feedLoadResult.agency.rowCount
+            bartVersion1.feedLoadResult.agency.rowCount + calTrainVersion.feedLoadResult.agency.rowCount + napaVersion.feedLoadResult.agency.rowCount,
+            "agency count for merged feed should equal sum of agency for versions merged."
         );
         assertEquals(
-            "stopTimes count for merged feed should equal sum of stopTimes for versions merged.",
             mergedVersion.feedLoadResult.stopTimes.rowCount,
-            bartVersion1.feedLoadResult.stopTimes.rowCount + calTrainVersion.feedLoadResult.stopTimes.rowCount + napaVersion.feedLoadResult.stopTimes.rowCount
+            bartVersion1.feedLoadResult.stopTimes.rowCount + calTrainVersion.feedLoadResult.stopTimes.rowCount + napaVersion.feedLoadResult.stopTimes.rowCount,
+            "stopTimes count for merged feed should equal sum of stopTimes for versions merged."
         );
         assertEquals(
-            "calendar count for merged feed should equal sum of calendar for versions merged.",
             mergedVersion.feedLoadResult.calendar.rowCount,
-            bartVersion1.feedLoadResult.calendar.rowCount + calTrainVersion.feedLoadResult.calendar.rowCount + napaVersion.feedLoadResult.calendar.rowCount
+            bartVersion1.feedLoadResult.calendar.rowCount + calTrainVersion.feedLoadResult.calendar.rowCount + napaVersion.feedLoadResult.calendar.rowCount,
+            "calendar count for merged feed should equal sum of calendar for versions merged."
         );
         assertEquals(
-            "calendarDates count for merged feed should equal sum of calendarDates for versions merged.",
             mergedVersion.feedLoadResult.calendarDates.rowCount,
-            bartVersion1.feedLoadResult.calendarDates.rowCount + calTrainVersion.feedLoadResult.calendarDates.rowCount + napaVersion.feedLoadResult.calendarDates.rowCount
+            bartVersion1.feedLoadResult.calendarDates.rowCount + calTrainVersion.feedLoadResult.calendarDates.rowCount + napaVersion.feedLoadResult.calendarDates.rowCount,
+            "calendarDates count for merged feed should equal sum of calendarDates for versions merged."
         );
         // Ensure there are no referential integrity errors, duplicate ID, or wrong number of
         // fields errors.
@@ -261,8 +261,8 @@ public class MergeFeedsJobTest extends UnitTest {
         mergeFeedsJob.run();
         // Result should fail.
         assertTrue(
-            "Merge feeds job should fail due to duplicate trip IDs.",
-            mergeFeedsJob.mergeFeedsResult.failed
+            mergeFeedsJob.mergeFeedsResult.failed,
+            "Merge feeds job should fail due to duplicate trip IDs."
         );
     }
 
@@ -284,40 +284,40 @@ public class MergeFeedsJobTest extends UnitTest {
         assertFeedMergeSucceeded(mergeFeedsJob);
         // Check GTFS+ line numbers.
         assertEquals(
-            "Merged directions count should equal expected value.",
             2, // Magic number represents expected number of lines after merge.
-            mergeFeedsJob.mergeFeedsResult.linesPerTable.get("directions").intValue()
+            mergeFeedsJob.mergeFeedsResult.linesPerTable.get("directions").intValue(),
+            "Merged directions count should equal expected value."
         );
         assertEquals(
-            "Merged feed stop_attributes count should equal expected value.",
             2, // Magic number represents the number of stop_attributes in the merged BART feed.
-            mergeFeedsJob.mergeFeedsResult.linesPerTable.get("stop_attributes").intValue()
+            mergeFeedsJob.mergeFeedsResult.linesPerTable.get("stop_attributes").intValue(),
+            "Merged feed stop_attributes count should equal expected value."
         );
         // Check GTFS file line numbers.
         assertEquals(
-            "Merged feed trip count should equal expected value.",
             4552, // Magic number represents the number of trips in the merged BART feed.
-            mergeFeedsJob.mergedVersion.feedLoadResult.trips.rowCount
+            mergeFeedsJob.mergedVersion.feedLoadResult.trips.rowCount,
+            "Merged feed trip count should equal expected value."
         );
         assertEquals(
-            "Merged feed route count should equal expected value.",
             9, // Magic number represents the number of routes in the merged BART feed.
-            mergeFeedsJob.mergedVersion.feedLoadResult.routes.rowCount
+            mergeFeedsJob.mergedVersion.feedLoadResult.routes.rowCount,
+            "Merged feed route count should equal expected value."
         );
         assertEquals(
-            "Merged feed shapes count should equal expected value.",
             // During merge, if identical shape_id is found in both feeds, active feed shape_id should be feed-scoped.
             bartVersion1.feedLoadResult.shapes.rowCount + bartVersion2.feedLoadResult.shapes.rowCount,
-            mergeFeedsJob.mergedVersion.feedLoadResult.shapes.rowCount
+            mergeFeedsJob.mergedVersion.feedLoadResult.shapes.rowCount,
+            "Merged feed shapes count should equal expected value."
         );
         // Expect that two calendar dates are excluded from the past feed (because they occur after the first date of
         // the future feed) .
         int expectedCalendarDatesCount = bartVersion1.feedLoadResult.calendarDates.rowCount + bartVersion2.feedLoadResult.calendarDates.rowCount - 2;
         assertEquals(
-            "Merged feed calendar_dates count should equal expected value.",
             // During merge, if identical shape_id is found in both feeds, active feed shape_id should be feed-scoped.
             expectedCalendarDatesCount,
-            mergeFeedsJob.mergedVersion.feedLoadResult.calendarDates.rowCount
+            mergeFeedsJob.mergedVersion.feedLoadResult.calendarDates.rowCount,
+            "Merged feed calendar_dates count should equal expected value."
         );
         // Ensure there are no referential integrity errors or duplicate ID errors.
         assertThatFeedHasNoErrorsOfType(

--- a/src/test/java/com/conveyal/datatools/manager/jobs/ProcessSingleFeedJobNotificationTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/jobs/ProcessSingleFeedJobNotificationTest.java
@@ -8,9 +8,9 @@ import com.conveyal.datatools.manager.models.FeedVersion;
 import com.conveyal.datatools.manager.models.Project;
 import com.conveyal.datatools.manager.persistence.Persistence;
 import com.conveyal.gtfs.validator.ValidationResult;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,7 +29,7 @@ public class ProcessSingleFeedJobNotificationTest extends DatatoolsTest {
     private static FeedSource mockFeedSource;
     private static Project project;
 
-    @BeforeClass
+    @BeforeAll
     public static void setUp() throws IOException {
         DatatoolsTest.setUp();
         LOG.info("{} setup", ProcessSingleFeedJobNotificationTest.class.getSimpleName());
@@ -47,7 +47,7 @@ public class ProcessSingleFeedJobNotificationTest extends DatatoolsTest {
         validationResult.lastCalendarDate = LocalDate.now();
     }
 
-    @AfterClass
+    @AfterAll
     public static void tearDown() {
         mockFeedSource.delete();
         project.delete();

--- a/src/test/java/com/conveyal/datatools/manager/models/FeedVersionTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/models/FeedVersionTest.java
@@ -3,8 +3,8 @@ package com.conveyal.datatools.manager.models;
 import com.conveyal.datatools.DatatoolsTest;
 import com.conveyal.datatools.UnitTest;
 import com.conveyal.datatools.manager.persistence.Persistence;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Date;
 
@@ -15,7 +15,7 @@ import static org.hamcrest.Matchers.not;
 public class FeedVersionTest extends UnitTest {
 
     /** Initialize application for tests to run. */
-    @BeforeClass
+    @BeforeAll
     public static void setUp() throws Exception {
         // start server if it isn't already running
         DatatoolsTest.setUp();

--- a/src/test/java/com/conveyal/datatools/manager/persistence/FeedStoreTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/persistence/FeedStoreTest.java
@@ -3,9 +3,8 @@ package com.conveyal.datatools.manager.persistence;
 import com.conveyal.datatools.DatatoolsTest;
 import com.conveyal.datatools.UnitTest;
 import com.conveyal.datatools.manager.models.FeedVersion;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -14,11 +13,12 @@ import java.io.FileInputStream;
 import java.io.IOException;
 
 import static com.conveyal.datatools.TestUtils.getGtfsResourcePath;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class FeedStoreTest extends UnitTest {
     private static final Logger LOG = LoggerFactory.getLogger(FeedStoreTest.class);
 
-    @BeforeClass
+    @BeforeAll
     public static void setUp() throws Exception {
         DatatoolsTest.setUp();
         LOG.info("{} setup", FeedStoreTest.class.getSimpleName());
@@ -34,6 +34,6 @@ public class FeedStoreTest extends UnitTest {
         FileInputStream fileInputStream = new FileInputStream(gtfsFile);
         File tempFile = FeedVersion.feedStore.createTempFile(gtfsFileName, fileInputStream);
         LOG.info("Feed store wrote temp file to: {}", tempFile.getAbsolutePath());
-        Assert.assertEquals(tempFile.getName(), gtfsFileName);
+        assertEquals(tempFile.getName(), gtfsFileName);
     }
 }

--- a/src/test/java/com/conveyal/datatools/manager/persistence/PersistenceTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/persistence/PersistenceTest.java
@@ -4,13 +4,13 @@ import com.conveyal.datatools.DatatoolsTest;
 import com.conveyal.datatools.UnitTest;
 import com.conveyal.datatools.manager.models.FeedSource;
 import com.conveyal.datatools.manager.models.Project;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Created by landon on 9/6/17.
@@ -20,7 +20,7 @@ public class PersistenceTest extends UnitTest {
     private static FeedSource feedSource;
     private static Project project;
 
-    @BeforeClass
+    @BeforeAll
     public static void setUp() throws Exception {
         DatatoolsTest.setUp();
         LOG.info("{} setup", PersistenceTest.class.getSimpleName());
@@ -28,7 +28,7 @@ public class PersistenceTest extends UnitTest {
         Persistence.initialize();
     }
 
-    @AfterClass
+    @AfterAll
     public static void tearDown() {
         if (feedSource != null) Persistence.feedSources.removeById(feedSource.id);
         if (project != null) Persistence.projects.removeById(project.id);
@@ -41,7 +41,10 @@ public class PersistenceTest extends UnitTest {
         Persistence.feedSources.create(feedSource);
         FeedSource feedSourceFromDB = Persistence.feedSources.getById(id);
         assertEquals(feedSource.fetchFrequency, feedSourceFromDB.fetchFrequency);
-        assertEquals("Found FeedSource ID should equal inserted ID.", id, feedSourceFromDB.id);
+        assertEquals(
+            id,
+            feedSourceFromDB.id,
+            "Found FeedSource ID should equal inserted ID.");
     }
 
 //    @Test
@@ -70,7 +73,10 @@ public class PersistenceTest extends UnitTest {
         String id = project.id;
         Persistence.projects.create(project);
         String retrievedId = Persistence.projects.getById(id).id;
-        assertEquals("Found Project ID should equal inserted ID.", id, retrievedId);
+        assertEquals(
+            id,
+            retrievedId,
+            "Found Project ID should equal inserted ID.");
     }
 //
 //    @Test


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR aims to update JUnit from version 4 to version 5. This includes updating all JUnit references (e.g. Test, BeforeClass, Before etc), updating deprecated classes (e.g. to the org.hamcrest package) and refactoring tests to use Wiremock without the deprecated @Rule annotation.

Fixes: ibi-group/datatools-server#362
