### PR TITLE
Update env.yml with current MONGO_HOST instead of Mongo_URI

### DIFF
--- a/configurations/default/env.yml.tmp
+++ b/configurations/default/env.yml.tmp
@@ -15,5 +15,5 @@ SPARKPOST_EMAIL: email@example.com
 GTFS_DATABASE_URL: jdbc:postgresql://localhost/catalogue
 # GTFS_DATABASE_USER:
 # GTFS_DATABASE_PASSWORD:
-#MONGO_HOST: mongodb://mongo-host:27017
+#MONGO_HOST: mongo-host:27017
 MONGO_DB_NAME: catalogue

--- a/configurations/default/env.yml.tmp
+++ b/configurations/default/env.yml.tmp
@@ -15,5 +15,5 @@ SPARKPOST_EMAIL: email@example.com
 GTFS_DATABASE_URL: jdbc:postgresql://localhost/catalogue
 # GTFS_DATABASE_USER:
 # GTFS_DATABASE_PASSWORD:
-#MONGO_URI: mongodb://mongo-host:27017
+#MONGO_HOST: mongodb://mongo-host:27017
 MONGO_DB_NAME: catalogue


### PR DESCRIPTION
Fixes: #370

Based on comment of @landonreed

### Checklist

- [ ] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [ ] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [ ] The description lists all applicable issues this PR seeks to resolve
- [ ] The description lists any configuration setting(s) that differ from the default settings
- [ ] All tests and CI builds passing
- [ ] The description lists all relevant PRs included in this release _(remove this if not merging to master)_
- [ ] e2e tests are all passing _(remove this if not merging to master)_
- [ ] Code coverage improves or is at 100% _(remove this if not merging to master)_

### Description

In Issue #370 is a comment from @landonreed that the variable of the MONGO_URI is incorrect because in the code it is MONGO_HOST. This pull request will update the env.yml value.
