### PR TITLE
Add code to end auto-deployment in certain cases

### DIFF
--- a/src/main/java/com/conveyal/datatools/manager/jobs/AutoDeployJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/AutoDeployJob.java
@@ -18,6 +18,7 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Auto deploy the latest feed versions associated with a deployment to an OTP server if these conditions are met:
@@ -107,23 +108,27 @@ public class AutoDeployJob extends MonitorableJob {
             // Analyze and update feed versions in deployment.
             Collection<String> updatedFeedVersionIds = new LinkedList<>();
             List<FeedVersion> latestVersionsWithCriticalErrors = new LinkedList<>();
+            List<Deployment.SummarizedFeedVersion> previousFeedVersions = deployment.retrieveFeedVersions();
             boolean shouldWaitForNewFeedVersions = false;
 
             // Production ready feed versions.
             List<Deployment.SummarizedFeedVersion> pinnedFeedVersions = deployment.retrievePinnedFeedVersions();
+            Set<String> pinnedFeedSourceIds = new HashSet<>(
+                pinnedFeedVersions
+                    .stream()
+                    .map(pinnedFeedVersion -> pinnedFeedVersion.feedSource.id)
+                    .collect(Collectors.toList())
+            );
 
             // Iterate through each feed version for deployment.
             for (
-                Deployment.SummarizedFeedVersion currentDeploymentFeedVersion : deployment.retrieveFeedVersions()
+                Deployment.SummarizedFeedVersion currentDeploymentFeedVersion : previousFeedVersions
             ) {
                 // Retrieve the latest feed version associated with the feed source of the current
                 // feed version set for the deployment.
                 FeedVersion latestFeedVersion = currentDeploymentFeedVersion.feedSource.retrieveLatest();
                 // Make sure the latest feed version is not going to supersede a pinned feed version.
-                if (pinnedFeedVersions
-                    .stream()
-                    .anyMatch(feedVersion -> feedVersion.feedSource.id.equals(latestFeedVersion.feedSourceId))
-                ) {
+                if (pinnedFeedSourceIds.contains(latestFeedVersion.feedSourceId)) {
                     continue;
                 }
 
@@ -191,6 +196,20 @@ public class AutoDeployJob extends MonitorableJob {
             // of this update.
             for (Deployment.SummarizedFeedVersion pinnedFeedVersion : pinnedFeedVersions) {
                 updatedFeedVersionIds.add(pinnedFeedVersion.id);
+            }
+
+            // Check if the updated feed versions have any difference between the previous ones. If not, and if not
+            // doing a regularly scheduled update with street data, then don't bother starting a deploy job.
+            // TODO: add logic for street data update
+            Set<String> previousFeedVersionIds = new HashSet<>(
+                previousFeedVersions.stream().map(feedVersion -> feedVersion.id).collect(Collectors.toList())
+            );
+            if (
+                !updatedFeedVersionIds.stream()
+                    .anyMatch(feedVersionId -> !previousFeedVersionIds.contains(feedVersionId))
+            ) {
+                status.completeSuccessfully("No updated feed versions to deploy.");
+                return;
             }
 
             // Update the deployment's feed version IDs with the latest (and pinned) feed versions.

--- a/src/main/java/com/conveyal/datatools/manager/jobs/AutoDeployJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/AutoDeployJob.java
@@ -208,6 +208,7 @@ public class AutoDeployJob extends MonitorableJob {
                 !updatedFeedVersionIds.stream()
                     .anyMatch(feedVersionId -> !previousFeedVersionIds.contains(feedVersionId))
             ) {
+                LOG.info("No updated feed versions to deploy for project {}.", project.name);
                 status.completeSuccessfully("No updated feed versions to deploy.");
                 return;
             }

--- a/src/main/java/com/conveyal/datatools/manager/jobs/DeployJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/DeployJob.java
@@ -63,7 +63,9 @@ import com.conveyal.datatools.manager.models.CustomFile;
 import com.conveyal.datatools.manager.models.Deployment;
 import com.conveyal.datatools.manager.models.EC2Info;
 import com.conveyal.datatools.manager.models.EC2InstanceSummary;
+import com.conveyal.datatools.manager.models.FeedVersion;
 import com.conveyal.datatools.manager.models.OtpServer;
+import com.conveyal.datatools.manager.models.Project;
 import com.conveyal.datatools.manager.persistence.Persistence;
 import com.conveyal.datatools.manager.utils.StringUtils;
 import com.conveyal.datatools.manager.utils.TimeTracker;
@@ -574,10 +576,39 @@ public class DeployJob extends MonitorableJob {
         // Send notification to those subscribed to updates for the deployment.
         NotifyUsersForSubscriptionJob.createNotification("deployment-updated", deployment.id, message);
         if (!status.error) {
-            // A new FetchSingleFeedJob could be started after the AutoDeployJob has made sure no fetching jobs exist and
-            // the DeployJob has started. Therefore this new feed version wouldn't result in a new DeployJob getting kicked
-            // off since there was already one running. To catch this new feed version another auto deploy job is started.
-            DataManager.heavyExecutor.execute(new AutoDeployJob(deployment.parentProject(), owner));
+            // A new FetchSingleFeedJob could be started after the AutoDeployJob has made sure no fetching jobs exist
+            // and the DeployJob has started. Therefore this new feed version wouldn't result in a new DeployJob getting
+            // kicked off since there was already one running.
+
+            // Check if there is a need to start a new auto-deploy job.
+            Project project = deployment.parentProject();
+            Set<String> pinnedFeedVersionIds = new HashSet<>(deployment.pinnedfeedVersionIds);
+            if (
+                // make sure deployment is enabled for data tools. Not sure how we'd get this far if it weren't...
+                DataManager.isModuleEnabled("deployment") &&
+                    // make sure auto-deployment is enabled for the project
+                    project.autoDeployTypes.size() > 0 &&
+                    // check if there are any non-pinned feed versions newer than existing ones
+                    deployment.feedVersionIds.stream()
+                        .anyMatch(feedVersionId -> {
+                            // don't check pinned feed versions for a more recent feed version from the feed source
+                            if (pinnedFeedVersionIds.contains(feedVersionId)) {
+                                return false;
+                            }
+
+                            // get the latest feed version (it could be null)
+                            FeedVersion latest = Persistence.feedVersions.getById(feedVersionId)
+                                    .parentFeedSource()
+                                    .retrieveLatest();
+                            // return true if the latest feed version was created after the last time an auto-deploy job
+                            // completed for the project. This means there is at least one new feed version that hasn't
+                            // yet been auto deployed that must have been created while this deploy job ran.
+                            return latest != null && latest.dateCreated.after(project.lastAutoDeploy);
+                        })
+            ) {
+                // newer feed versions exist! Start a new auto-deploy job.
+                DataManager.heavyExecutor.execute(new AutoDeployJob(deployment.parentProject(), owner));
+            }
         }
     }
 

--- a/src/test/java/com/conveyal/datatools/manager/jobs/AutoDeployJobTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/jobs/AutoDeployJobTest.java
@@ -37,6 +37,7 @@ public class AutoDeployJobTest extends DatatoolsTest {
     private static Deployment deploymentA;
     private static Project projectA;
     private static FeedSource mockFeedSourceA;
+    private static FeedVersion mockFeedVersionA;
 
     private static Deployment deploymentB;
     private static Project projectB;
@@ -63,6 +64,10 @@ public class AutoDeployJobTest extends DatatoolsTest {
         projectA = createProject();
         deploymentA = createDeployment(deploySummary, projectA.id);
         mockFeedSourceA = createFeedSource("Mock feed source A", projectA.id);
+        mockFeedVersionA = TestUtils.createFeedVersion(mockFeedSourceA,
+            TestUtils.zipFolderFiles("fake-agency-expire-in-2099"));
+
+        // create a "newer" feed version so that there is a newer feed version to deploy
         TestUtils.createFeedVersion(mockFeedSourceA,
             TestUtils.zipFolderFiles("fake-agency-expire-in-2099"));
 
@@ -111,9 +116,7 @@ public class AutoDeployJobTest extends DatatoolsTest {
     public void canAutoDeployFeedVersionForProject() {
         projectA.pinnedDeploymentId = deploymentA.id;
         Persistence.projects.replace(projectA.id, projectA);
-        for (FeedVersion feedVersion : mockFeedSourceA.retrieveFeedVersions()) {
-            deploymentA.feedVersionIds.add(feedVersion.id);
-        }
+        deploymentA.feedVersionIds.add(mockFeedVersionA.id);
         Persistence.deployments.replace(deploymentA.id, deploymentA);
         AutoDeployJob autoDeployFeedJob = new AutoDeployJob(projectA, user);
         autoDeployFeedJob.run();


### PR DESCRIPTION
This adds some code that will prevent endless auto-deployment loops by adding 2 cases where auto-deployment will not proceed:

1. AutoDeployments won't get initiated from deploy jobs unless there is at least one feed version that completed after the last project auto-deploy time. Any feed versions yet to have their fetching/processing completed will still kick off another deploy job.
2. AutoDeployments won't start a deploy job if the updated feed version Ids for the deployment exactly match the deployment's previous feed version Ids.