### PR TITLE
More auto-deploy changes.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -263,7 +263,7 @@
         <dependency>
             <groupId>com.github.conveyal</groupId>
             <artifactId>gtfs-lib</artifactId>
-            <version>6.2.2</version>
+            <version>6.2.4</version>
             <!-- Exclusions added in order to silence SLF4J warnings about multiple bindings:
                 http://www.slf4j.org/codes.html#multiple_bindings
             -->

--- a/src/main/java/com/conveyal/datatools/common/status/MonitorableJob.java
+++ b/src/main/java/com/conveyal/datatools/common/status/MonitorableJob.java
@@ -1,7 +1,7 @@
 package com.conveyal.datatools.common.status;
 
-import com.conveyal.datatools.manager.DataManager;
 import com.conveyal.datatools.manager.auth.Auth0UserProfile;
+import com.conveyal.datatools.manager.utils.JobUtils;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.commons.lang3.exception.ExceptionUtils;
@@ -18,8 +18,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
-import static com.conveyal.datatools.manager.controllers.api.StatusController.getJobsForUser;
-
 /**
  * Created by landon on 6/13/16.
  */
@@ -31,6 +29,13 @@ public abstract class MonitorableJob implements Runnable, Serializable {
     // Public fields will be serialized over HTTP API and visible to the web client
     public final JobType type;
     public File file;
+
+    /**
+     * Whether the job is currently running. This is needed since some jobs can be recurring jobs that won't run until
+     * their scheduled time and when they finish they could run again.
+     */
+    public boolean active = false;
+
     protected String parentJobId;
     protected JobType parentJobType;
     // Status is not final to allow some jobs to have extra status fields.
@@ -101,9 +106,9 @@ public abstract class MonitorableJob implements Runnable, Serializable {
     private void registerJob() {
         // Get all active jobs and add the latest active job. Note: Removal of job from user's set of jobs is handled
         // in the StatusController when a user requests their active jobs and the job has finished/errored.
-        Set<MonitorableJob> userJobs = getJobsForUser(this.owner);
+        Set<MonitorableJob> userJobs = JobUtils.getJobsForUser(this.owner);
         userJobs.add(this);
-        DataManager.userJobsMap.put(retrieveUserId(), userJobs);
+        JobUtils.userJobsMap.put(retrieveUserId(), userJobs);
     }
 
     @JsonProperty("owner")
@@ -144,6 +149,7 @@ public abstract class MonitorableJob implements Runnable, Serializable {
      * override jobLogic and jobFinished method(s).
      */
     public void run () {
+        active = true;
         boolean parentJobErrored = false;
         boolean subTaskErrored = false;
         String cancelMessage = "";
@@ -199,8 +205,10 @@ public abstract class MonitorableJob implements Runnable, Serializable {
             // could be displayed by the client.
         } catch (Exception e) {
             status.fail("Job failed due to unhandled exception!", e);
+        } finally {
+            LOG.info("{} (jobId={}) {} in {} ms", type, jobId, status.error ? "errored" : "completed", status.duration);
+            active = false;
         }
-        LOG.info("{} (jobId={}) {} in {} ms", type, jobId, status.error ? "errored" : "completed", status.duration);
     }
 
     /**

--- a/src/main/java/com/conveyal/datatools/editor/controllers/api/SnapshotController.java
+++ b/src/main/java/com/conveyal/datatools/editor/controllers/api/SnapshotController.java
@@ -16,6 +16,7 @@ import com.conveyal.datatools.manager.models.FeedVersion;
 import com.conveyal.datatools.manager.models.JsonViews;
 import com.conveyal.datatools.manager.models.Snapshot;
 import com.conveyal.datatools.manager.persistence.Persistence;
+import com.conveyal.datatools.manager.utils.JobUtils;
 import com.conveyal.datatools.manager.utils.json.JsonManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -101,7 +102,7 @@ public class SnapshotController {
             createSnapshotJob.addNextJob(new CreateFeedVersionFromSnapshotJob(feedSource, snapshot, userProfile));
         }
         // Begin asynchronous execution.
-        DataManager.heavyExecutor.execute(createSnapshotJob);
+        JobUtils.heavyExecutor.execute(createSnapshotJob);
         return SparkUtils.formatJobMessage(createSnapshotJob.jobId, "Creating snapshot.");
     }
 
@@ -122,7 +123,7 @@ public class SnapshotController {
         boolean preserveBuffer = "true".equals(req.queryParams("preserveBuffer")) && feedSource.editorNamespace != null;
         CreateSnapshotJob createSnapshotJob =
                 new CreateSnapshotJob(userProfile, snapshot, true, false, preserveBuffer);
-        DataManager.heavyExecutor.execute(createSnapshotJob);
+        JobUtils.heavyExecutor.execute(createSnapshotJob);
         return formatJobMessage(createSnapshotJob.jobId, "Importing version as snapshot.");
     }
 
@@ -161,7 +162,7 @@ public class SnapshotController {
         String name = "Restore snapshot " + snapshotToRestore.name;
         Snapshot snapshot = new Snapshot(name, feedSource.id, snapshotToRestore.namespace);
         CreateSnapshotJob createSnapshotJob = new CreateSnapshotJob(userProfile, snapshot, true, false, preserveBuffer);
-        DataManager.heavyExecutor.execute(createSnapshotJob);
+        JobUtils.heavyExecutor.execute(createSnapshotJob);
         return formatJobMessage(createSnapshotJob.jobId, "Restoring snapshot...");
     }
 
@@ -175,7 +176,7 @@ public class SnapshotController {
         // Create and kick off export job.
         // FIXME: what if a snapshot is already written to S3?
         ExportSnapshotToGTFSJob exportSnapshotToGTFSJob = new ExportSnapshotToGTFSJob(userProfile,  snapshot);
-        DataManager.heavyExecutor.execute(exportSnapshotToGTFSJob);
+        JobUtils.heavyExecutor.execute(exportSnapshotToGTFSJob);
         return formatJobMessage(exportSnapshotToGTFSJob.jobId, "Exporting snapshot to GTFS.");
     }
 

--- a/src/main/java/com/conveyal/datatools/manager/ConvertMain.java
+++ b/src/main/java/com/conveyal/datatools/manager/ConvertMain.java
@@ -6,9 +6,9 @@ import com.conveyal.datatools.editor.datastore.VersionedDataStore;
 import com.conveyal.datatools.editor.jobs.ConvertEditorMapDBToSQL;
 import com.conveyal.datatools.editor.models.Snapshot;
 import com.conveyal.datatools.manager.controllers.DumpController;
-import com.conveyal.datatools.manager.controllers.api.StatusController;
 import com.conveyal.datatools.manager.models.FeedSource;
 import com.conveyal.datatools.manager.persistence.Persistence;
+import com.conveyal.datatools.manager.utils.JobUtils;
 import org.apache.commons.io.FileUtils;
 import org.mapdb.Fun;
 import org.slf4j.Logger;
@@ -97,15 +97,15 @@ public class ConvertMain {
         // STEP 3A: For each snapshot/editor DB, create a snapshot Mongo object for the feed source with the FeedLoadResult.
         migrateEditorFeeds();
         LOG.info("Done queueing!!!!!!!!");
-        int totalJobs = StatusController.getAllJobs().size();
-        while (!StatusController.filterActiveJobs(StatusController.getAllJobs()).isEmpty()) {
+        int totalJobs = JobUtils.getAllJobs().size();
+        while (!JobUtils.filterActiveJobs(JobUtils.getAllJobs()).isEmpty()) {
             // While there are still active jobs, continue waiting.
-            Set<MonitorableJob> activeJobs = StatusController.filterActiveJobs(StatusController.getAllJobs());
+            Set<MonitorableJob> activeJobs = JobUtils.filterActiveJobs(JobUtils.getAllJobs());
             LOG.info(String.format("%d/%d jobs still active. Checking for completion again in 5 seconds...", activeJobs.size(), totalJobs));
 //            LOG.info(String.join(", ", activeJobs.stream().map(job -> job.name).collect(Collectors.toList())));
-            int jobsInExecutor = ((ThreadPoolExecutor) DataManager.heavyExecutor).getActiveCount();
+            int jobsInExecutor = ((ThreadPoolExecutor) JobUtils.heavyExecutor).getActiveCount();
             LOG.info(String.format("Jobs in thread pool executor: %d", jobsInExecutor));
-            LOG.info(String.format("Jobs completed by executor: %d", ((ThreadPoolExecutor) DataManager.heavyExecutor).getCompletedTaskCount()));
+            LOG.info(String.format("Jobs completed by executor: %d", ((ThreadPoolExecutor) JobUtils.heavyExecutor).getCompletedTaskCount()));
             Thread.sleep(5000);
         }
         long durationInMillis = System.currentTimeMillis() - startTime;
@@ -141,11 +141,11 @@ public class ConvertMain {
                     if (!feedSourcesEncountered.contains(feedSource.id)) {
                         // If this is the first feed encountered, load the editor buffer.
                         ConvertEditorMapDBToSQL convertEditorBufferToSQL = new ConvertEditorMapDBToSQL(snapshot.id.a, null);
-                        DataManager.heavyExecutor.execute(convertEditorBufferToSQL);
+                        JobUtils.heavyExecutor.execute(convertEditorBufferToSQL);
                         count++;
                     }
                     ConvertEditorMapDBToSQL convertEditorMapDBToSQL = new ConvertEditorMapDBToSQL(snapshot.id.a, snapshot.id.b);
-                    DataManager.heavyExecutor.execute(convertEditorMapDBToSQL);
+                    JobUtils.heavyExecutor.execute(convertEditorMapDBToSQL);
                     LOG.info(count + "/" + snapshotCount + " snapshot conversion queued");
                     feedSourcesEncountered.add(feedSource.id);
                     count++;

--- a/src/main/java/com/conveyal/datatools/manager/DataManager.java
+++ b/src/main/java/com/conveyal/datatools/manager/DataManager.java
@@ -87,20 +87,8 @@ public class DataManager {
     // TODO: define type for ExternalFeedResource Strings
     public static final Map<String, ExternalFeedResource> feedResources = new HashMap<>();
 
-    /**
-     * Stores jobs underway by user ID. NOTE: any set created and stored here must be created with
-     * {@link Sets#newConcurrentHashSet()} or similar thread-safe Set.
-     */
-    public static Map<String, Set<MonitorableJob>> userJobsMap = new ConcurrentHashMap<>();
-
     // ObjectMapper that loads in YAML config files
     private static final ObjectMapper yamlMapper = new ObjectMapper(new YAMLFactory());
-
-
-    // Heavy executor should contain long-lived CPU-intensive tasks (e.g., feed loading/validation)
-    public static Executor heavyExecutor = Executors.newFixedThreadPool(4);
-    // light executor is for tasks for things that should finish quickly (e.g., email notifications)
-    public static Executor lightExecutor = Executors.newSingleThreadExecutor();
 
     public static String repoUrl;
     public static String commit = "";

--- a/src/main/java/com/conveyal/datatools/manager/controllers/DumpController.java
+++ b/src/main/java/com/conveyal/datatools/manager/controllers/DumpController.java
@@ -1,7 +1,6 @@
 package com.conveyal.datatools.manager.controllers;
 
 import com.conveyal.datatools.common.status.MonitorableJob;
-import com.conveyal.datatools.manager.DataManager;
 import com.conveyal.datatools.manager.auth.Auth0UserProfile;
 import com.conveyal.datatools.manager.jobs.ProcessSingleFeedJob;
 import com.conveyal.datatools.manager.jobs.ValidateFeedJob;
@@ -15,6 +14,7 @@ import com.conveyal.datatools.manager.models.Note;
 import com.conveyal.datatools.manager.models.Project;
 import com.conveyal.datatools.manager.models.Snapshot;
 import com.conveyal.datatools.manager.persistence.Persistence;
+import com.conveyal.datatools.manager.utils.JobUtils;
 import com.conveyal.datatools.manager.utils.json.JsonManager;
 import com.conveyal.gtfs.validator.ValidationResult;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -365,7 +365,7 @@ public class DumpController {
             } else {
                 job = new ValidateFeedJob(version, systemUser, false);
             }
-            DataManager.heavyExecutor.execute(job);
+            JobUtils.heavyExecutor.execute(job);
         }
         // ValidateAllFeedsJob validateAllFeedsJob = new ValidateAllFeedsJob("system", force, load);
         return true;

--- a/src/main/java/com/conveyal/datatools/manager/controllers/api/DeploymentController.java
+++ b/src/main/java/com/conveyal/datatools/manager/controllers/api/DeploymentController.java
@@ -6,7 +6,6 @@ import com.conveyal.datatools.common.utils.aws.CheckedAWSException;
 import com.conveyal.datatools.common.utils.SparkUtils;
 import com.conveyal.datatools.common.utils.aws.EC2Utils;
 import com.conveyal.datatools.common.utils.aws.S3Utils;
-import com.conveyal.datatools.manager.DataManager;
 import com.conveyal.datatools.manager.auth.Auth0UserProfile;
 import com.conveyal.datatools.manager.jobs.DeployJob;
 import com.conveyal.datatools.manager.models.Deployment;
@@ -17,6 +16,7 @@ import com.conveyal.datatools.manager.models.JsonViews;
 import com.conveyal.datatools.manager.models.OtpServer;
 import com.conveyal.datatools.manager.models.Project;
 import com.conveyal.datatools.manager.persistence.Persistence;
+import com.conveyal.datatools.manager.utils.JobUtils;
 import com.conveyal.datatools.manager.utils.json.JsonManager;
 import com.mongodb.client.FindIterable;
 import org.bson.Document;
@@ -108,7 +108,7 @@ public class DeploymentController {
         }
         if (summaryToDownload == null) {
             // See if there is an ongoing job for the provided jobId.
-            MonitorableJob job = StatusController.getJobByJobId(jobId);
+            MonitorableJob job = JobUtils.getJobByJobId(jobId);
             if (job instanceof DeployJob) {
                 uriString = ((DeployJob) job).getS3FolderURI().toString();
             } else {
@@ -378,21 +378,23 @@ public class DeploymentController {
     }
 
     /**
-     * Queue a new {@link DeployJob} if there are no conflicting jobs assigned to the specified server.
-     * @param deployJob new deploy job to queue
-     * @return whether the deploy job was successfully queued or not
+     * Creates and queues a new {@link DeployJob} if there are no conflicting jobs assigned to the specified server.
+     *
+     * @param deployment The deployment to associate the new DeployJob with
+     * @param owner The owner to associate the new DeployJob with
+     * @param server The server to associate the new DeployJob with
+     * @return returns the DeployJob if the job was successfully queued, otherwise this returns null
      */
-    public static boolean queueDeployJob(DeployJob deployJob) {
-        String serverId = deployJob.getServerId();
+    public static DeployJob queueDeployJob(Deployment deployment, Auth0UserProfile owner, OtpServer server) {
         // Check that we can deploy to the specified target. (Any deploy job for the target that is presently active will
         // cause a halt.)
-        if (deploymentJobsByServer.containsKey(serverId)) {
+        if (deploymentJobsByServer.containsKey(server.id)) {
             // There is a deploy job for the server. Check if it is active.
-            DeployJob conflictingDeployJob = deploymentJobsByServer.get(serverId);
+            DeployJob conflictingDeployJob = deploymentJobsByServer.get(server.id);
             if (conflictingDeployJob != null && !conflictingDeployJob.status.completed) {
                 // Another deploy job is actively being deployed to the server target.
                 LOG.error("New deploy job will not be queued due to active deploy job in progress.");
-                return false;
+                return null;
             }
         }
 
@@ -400,17 +402,18 @@ public class DeploymentController {
         // this new one will overwrite it. NOTE: deployedTo for the current deployment will only be updated after the
         // successful completion of the deploy job.
         FindIterable<Deployment> deploymentsWithSameTarget = Deployment.retrieveDeploymentForServerAndRouterId(
-            serverId,
-            deployJob.getDeployment().routerId
+            server.id,
+            deployment.routerId
         );
         for (Deployment oldDeployment : deploymentsWithSameTarget) {
             LOG.info("Setting deployment target to null for id={}", oldDeployment.id);
             Persistence.deployments.updateField(oldDeployment.id, "deployedTo", null);
         }
         // Finally, add deploy job to the heavy executor.
-        DataManager.heavyExecutor.execute(deployJob);
-        deploymentJobsByServer.put(serverId, deployJob);
-        return true;
+        DeployJob deployJob = new DeployJob(deployment, owner, server);
+        JobUtils.heavyExecutor.execute(deployJob);
+        deploymentJobsByServer.put(server.id, deployJob);
+        return deployJob;
     }
 
     /**
@@ -460,8 +463,8 @@ public class DeploymentController {
         }
 
         // Execute the deployment job and keep track of it in the jobs for server map.
-        DeployJob job = new DeployJob(deployment, userProfile, otpServer);
-        if (!queueDeployJob(job)) {
+        DeployJob job = queueDeployJob(deployment, userProfile, otpServer);
+        if (job == null) {
             // Job for the target is still active! Send a 202 to the requester to indicate that it is not possible
             // to deploy to this target right now because someone else is deploying.
             String message = String.format(

--- a/src/main/java/com/conveyal/datatools/manager/controllers/api/FeedSourceController.java
+++ b/src/main/java/com/conveyal/datatools/manager/controllers/api/FeedSourceController.java
@@ -13,6 +13,7 @@ import com.conveyal.datatools.manager.models.FeedSource;
 import com.conveyal.datatools.manager.models.JsonViews;
 import com.conveyal.datatools.manager.models.Project;
 import com.conveyal.datatools.manager.persistence.Persistence;
+import com.conveyal.datatools.manager.utils.JobUtils;
 import com.conveyal.datatools.manager.utils.json.JsonManager;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -273,7 +274,7 @@ public class FeedSourceController {
         // Run in light executor, but if a new feed is found, do not continue thread (a new one will be started in
         // heavyExecutor in the body of the fetch job.
         FetchSingleFeedJob fetchSingleFeedJob = new FetchSingleFeedJob(s, userProfile, false);
-        DataManager.lightExecutor.execute(fetchSingleFeedJob);
+        JobUtils.lightExecutor.execute(fetchSingleFeedJob);
 
         // Return the jobId so that the requester can track the job's progress.
         return formatJobMessage(fetchSingleFeedJob.jobId, "Fetching latest feed source.");

--- a/src/main/java/com/conveyal/datatools/manager/controllers/api/FeedVersionController.java
+++ b/src/main/java/com/conveyal/datatools/manager/controllers/api/FeedVersionController.java
@@ -17,6 +17,7 @@ import com.conveyal.datatools.manager.models.FeedVersion;
 import com.conveyal.datatools.manager.models.JsonViews;
 import com.conveyal.datatools.manager.models.Snapshot;
 import com.conveyal.datatools.manager.persistence.Persistence;
+import com.conveyal.datatools.manager.utils.JobUtils;
 import com.conveyal.datatools.manager.utils.json.JsonManager;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -127,7 +128,7 @@ public class FeedVersionController  {
 
         // Must be handled by executor because it takes a long time.
         ProcessSingleFeedJob processSingleFeedJob = new ProcessSingleFeedJob(newFeedVersion, userProfile, true);
-        DataManager.heavyExecutor.execute(processSingleFeedJob);
+        JobUtils.heavyExecutor.execute(processSingleFeedJob);
 
         return formatJobMessage(processSingleFeedJob.jobId, "Feed version is processing.");
     }
@@ -153,7 +154,7 @@ public class FeedVersionController  {
         }
         CreateFeedVersionFromSnapshotJob createFromSnapshotJob =
             new CreateFeedVersionFromSnapshotJob(feedSource, snapshot, userProfile);
-        DataManager.heavyExecutor.execute(createFromSnapshotJob);
+        JobUtils.heavyExecutor.execute(createFromSnapshotJob);
 
         return true;
     }
@@ -277,7 +278,7 @@ public class FeedVersionController  {
         // Create and run shapefile export.
         GisExportJob.ExportType exportType = GisExportJob.ExportType.valueOf(type);
         GisExportJob gisExportJob = new GisExportJob(exportType, temp, feedIds, userProfile);
-        DataManager.heavyExecutor.execute(gisExportJob);
+        JobUtils.heavyExecutor.execute(gisExportJob);
         // Do not use S3 to store the file, which should only be stored ephemerally (until requesting
         // user has downloaded file).
         FeedDownloadToken token = new FeedDownloadToken(gisExportJob);
@@ -351,7 +352,7 @@ public class FeedVersionController  {
         // Kick off merge feeds job.
         Auth0UserProfile userProfile = req.attribute("user");
         MergeFeedsJob mergeFeedsJob = new MergeFeedsJob(userProfile, versions, "merged", mergeType);
-        DataManager.heavyExecutor.execute(mergeFeedsJob);
+        JobUtils.heavyExecutor.execute(mergeFeedsJob);
         return SparkUtils.formatJobMessage(mergeFeedsJob.jobId, "Merging feed versions...");
     }
 

--- a/src/main/java/com/conveyal/datatools/manager/controllers/api/GtfsPlusController.java
+++ b/src/main/java/com/conveyal/datatools/manager/controllers/api/GtfsPlusController.java
@@ -8,6 +8,7 @@ import com.conveyal.datatools.manager.jobs.ProcessSingleFeedJob;
 import com.conveyal.datatools.manager.models.FeedVersion;
 import com.conveyal.datatools.manager.persistence.FeedStore;
 import com.conveyal.datatools.manager.persistence.Persistence;
+import com.conveyal.datatools.manager.utils.JobUtils;
 import com.conveyal.datatools.manager.utils.json.JsonUtil;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.eclipse.jetty.http.HttpStatus;
@@ -239,7 +240,7 @@ public class GtfsPlusController {
 
         // Must be handled by executor because it takes a long time.
         ProcessSingleFeedJob processSingleFeedJob = new ProcessSingleFeedJob(newFeedVersion, profile, true);
-        DataManager.heavyExecutor.execute(processSingleFeedJob);
+        JobUtils.heavyExecutor.execute(processSingleFeedJob);
 
         return formatJobMessage(processSingleFeedJob.jobId, "Feed version is processing.");
     }

--- a/src/main/java/com/conveyal/datatools/manager/controllers/api/ProjectController.java
+++ b/src/main/java/com/conveyal/datatools/manager/controllers/api/ProjectController.java
@@ -16,6 +16,7 @@ import com.conveyal.datatools.manager.models.JsonViews;
 import com.conveyal.datatools.manager.models.OtpServer;
 import com.conveyal.datatools.manager.models.Project;
 import com.conveyal.datatools.manager.persistence.Persistence;
+import com.conveyal.datatools.manager.utils.JobUtils;
 import com.conveyal.datatools.manager.utils.json.JsonManager;
 import org.bson.Document;
 import org.eclipse.jetty.http.HttpStatus;
@@ -256,7 +257,7 @@ public class ProjectController {
             }
         }
         MergeFeedsJob mergeFeedsJob = new MergeFeedsJob(userProfile, feedVersions, project.id, REGIONAL);
-        DataManager.heavyExecutor.execute(mergeFeedsJob);
+        JobUtils.heavyExecutor.execute(mergeFeedsJob);
         // Return job ID to requester for monitoring job status.
         return formatJobMessage(mergeFeedsJob.jobId, "Merge operation is processing.");
     }
@@ -298,7 +299,7 @@ public class ProjectController {
         }
         // Run as lightweight job.
         PublishProjectFeedsJob publishProjectFeedsJob = new PublishProjectFeedsJob(p, userProfile);
-        DataManager.lightExecutor.execute(publishProjectFeedsJob);
+        JobUtils.lightExecutor.execute(publishProjectFeedsJob);
         return formatJobMessage(publishProjectFeedsJob.jobId, "Publishing public feeds");
     }
 

--- a/src/main/java/com/conveyal/datatools/manager/controllers/api/StatusController.java
+++ b/src/main/java/com/conveyal/datatools/manager/controllers/api/StatusController.java
@@ -5,14 +5,13 @@ import com.conveyal.datatools.common.utils.RequestSummary;
 import com.conveyal.datatools.manager.DataManager;
 import com.conveyal.datatools.manager.auth.Auth0UserProfile;
 import com.conveyal.datatools.manager.models.JsonViews;
+import com.conveyal.datatools.manager.utils.JobUtils;
 import com.conveyal.datatools.manager.utils.json.JsonManager;
-import com.google.common.collect.Sets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import spark.Request;
 import spark.Response;
 
-import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
@@ -25,8 +24,6 @@ import static spark.Spark.get;
  * Created by landon on 6/13/16.
  */
 public class StatusController {
-    private static final Logger LOG = LoggerFactory.getLogger(ProjectController.class);
-
     private static JsonManager<MonitorableJob.Status> json =
         new JsonManager<>(MonitorableJob.Status.class, JsonViews.UserInterface.class);
 
@@ -38,7 +35,7 @@ public class StatusController {
         if (!userProfile.canAdministerApplication()) {
             logMessageAndHalt(req, 401, "User not authorized to view all jobs");
         }
-        return getAllJobs();
+        return JobUtils.getAllJobs();
     }
 
     /**
@@ -54,12 +51,6 @@ public class StatusController {
             .collect(Collectors.toList());
     }
 
-    public static Set<MonitorableJob> getAllJobs() {
-        return DataManager.userJobsMap.values().stream()
-                .flatMap(Collection::stream)
-                .collect(Collectors.toSet());
-    }
-
     /**
      * API route that returns single job by ID from among the jobs for the currently authenticated user.
      */
@@ -68,7 +59,7 @@ public class StatusController {
         Auth0UserProfile userProfile = req.attribute("user");
         // FIXME: refactor underscore in user_id methods
         String userId = userProfile.getUser_id();
-        return getJobById(userId, jobId, true);
+        return JobUtils.getJobById(userId, jobId, true);
     }
 
     /**
@@ -85,35 +76,6 @@ public class StatusController {
 //        return job;
 //    }
 
-    /** Shorthand method for getting a single job by job ID. */
-    public static MonitorableJob getJobByJobId(String jobId) {
-        for (MonitorableJob job : getAllJobs()) if (job.jobId.equals(jobId)) return job;
-        return null;
-    }
-
-    /**
-     * Gets a job by user ID and job ID.
-     * @param clearCompleted if true, remove requested job if it has completed or errored
-     */
-    public static MonitorableJob getJobById(String userId, String jobId, boolean clearCompleted) {
-        // Get jobs set directly from userJobsMap because we may remove an element from it below.
-        Set<MonitorableJob> userJobs = DataManager.userJobsMap.get(userId);
-        if (userJobs == null) {
-            return null;
-        }
-        for (MonitorableJob job : userJobs) {
-            if (job.jobId.equals(jobId)) {
-                if (clearCompleted && (job.status.completed || job.status.error)) {
-                    // remove job if completed or errored
-                    userJobs.remove(job);
-                }
-                return job;
-            }
-        }
-        // if job is not found (because it doesn't exist or was completed).
-        return null;
-    }
-
     /**
      * API route that returns a set of active jobs for the currently authenticated user.
      */
@@ -122,50 +84,7 @@ public class StatusController {
         // FIXME: refactor underscore in user_id methods
         String userId = userProfile.getUser_id();
         // Get a copy of all existing jobs before we purge the completed ones.
-        return getJobsByUserId(userId, true);
-    }
-
-    /**
-     * Convenience wrapper method to retrieve all jobs for {@link Auth0UserProfile}.
-     */
-    public static Set<MonitorableJob> getJobsForUser(Auth0UserProfile user) {
-        if (user == null) {
-            LOG.warn("Null user passed to getJobsForUser!");
-            return Sets.newConcurrentHashSet();
-        }
-        return getJobsByUserId(user.getUser_id(), false);
-    }
-
-    /**
-     * Get set of active jobs by user ID. If there are no active jobs, return a new set.
-     *
-     * NOTE: this should be a concurrent hash set so that it is threadsafe.
-     *
-     * @param clearCompleted if true, remove all completed and errored jobs for this user.
-     */
-    private static Set<MonitorableJob> getJobsByUserId(String userId, boolean clearCompleted) {
-        Set<MonitorableJob> allJobsForUser = DataManager.userJobsMap.get(userId);
-        if (allJobsForUser == null) {
-            return Sets.newConcurrentHashSet();
-        }
-        if (clearCompleted) {
-            // Any active jobs will still have their status updated, so they need to be retrieved again with any status
-            // updates. All completed or errored jobs are in their final state and will not be updated any longer, so we
-            // remove them once the client has seen them.
-            Set<MonitorableJob> jobsStillActive = filterActiveJobs(allJobsForUser);
-
-            DataManager.userJobsMap.put(userId, jobsStillActive);
-        }
-        return allJobsForUser;
-    }
-
-    public static Set<MonitorableJob> filterActiveJobs(Set<MonitorableJob> jobs) {
-        // Note: this must be a thread-safe set in case it is placed into the DataManager#userJobsMap.
-        Set<MonitorableJob> jobsStillActive = Sets.newConcurrentHashSet();
-        jobs.stream()
-                .filter(job -> !job.status.completed && !job.status.error)
-                .forEach(jobsStillActive::add);
-        return jobsStillActive;
+        return JobUtils.getJobsByUserId(userId, true);
     }
 
     public static void register (String apiPrefix) {

--- a/src/main/java/com/conveyal/datatools/manager/jobs/AutoDeployJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/AutoDeployJob.java
@@ -2,12 +2,12 @@ package com.conveyal.datatools.manager.jobs;
 
 import com.conveyal.datatools.common.status.MonitorableJob;
 import com.conveyal.datatools.manager.auth.Auth0UserProfile;
-import com.conveyal.datatools.manager.controllers.api.DeploymentController;
 import com.conveyal.datatools.manager.models.Deployment;
 import com.conveyal.datatools.manager.models.FeedVersion;
 import com.conveyal.datatools.manager.models.OtpServer;
 import com.conveyal.datatools.manager.models.Project;
 import com.conveyal.datatools.manager.persistence.Persistence;
+import com.conveyal.datatools.manager.utils.JobUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -181,7 +181,7 @@ public class AutoDeployJob extends MonitorableJob {
             // Skip auto-deployment for this project if any of the feed versions contained critical errors.
             if (latestVersionsWithCriticalErrors.size() > 0) {
                 StringBuilder errorMessageBuilder = new StringBuilder(
-                    String.format("Auto deployment for project %s! %s feed(s) contain critical errors:",
+                    String.format("Auto deployment for project %s has %s feed(s) with critical errors:",
                         project.name,
                         latestVersionsWithCriticalErrors.size())
                 );
@@ -229,7 +229,7 @@ public class AutoDeployJob extends MonitorableJob {
             }
 
             // Queue up the deploy job.
-            if (DeploymentController.queueDeployJob(deployment, owner, server) != null) {
+            if (JobUtils.queueDeployJob(deployment, owner, server) != null) {
                 LOG.info("Last auto deploy date updated for project {}.", project.name);
                 // Update the deployment's feed version IDs with the latest (and pinned) feed versions.
                 deployment.feedVersionIds = updatedFeedVersionIds;

--- a/src/main/java/com/conveyal/datatools/manager/jobs/FetchProjectFeedsJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/FetchProjectFeedsJob.java
@@ -1,13 +1,12 @@
 package com.conveyal.datatools.manager.jobs;
 
 import com.conveyal.datatools.common.status.MonitorableJob;
-import com.conveyal.datatools.common.utils.Scheduler;
-import com.conveyal.datatools.manager.DataManager;
 import com.conveyal.datatools.manager.auth.Auth0UserProfile;
 import com.conveyal.datatools.manager.models.FeedRetrievalMethod;
 import com.conveyal.datatools.manager.models.FeedSource;
 import com.conveyal.datatools.manager.models.Project;
 import com.conveyal.datatools.manager.persistence.Persistence;
+import com.conveyal.datatools.manager.utils.JobUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -57,7 +56,7 @@ public class FetchProjectFeedsJob extends MonitorableJob {
             // Run this in a heavy executor with continueThread = true, so that fetch/process jobs for each
             // feed source execute in order (i.e., fetch feed source A, then process; next, fetch feed source b, then
             // process).
-            DataManager.heavyExecutor.execute(fetchSingleFeedJob);
+            JobUtils.heavyExecutor.execute(fetchSingleFeedJob);
         }
     }
 

--- a/src/main/java/com/conveyal/datatools/manager/jobs/FetchSingleFeedJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/FetchSingleFeedJob.java
@@ -2,11 +2,11 @@ package com.conveyal.datatools.manager.jobs;
 
 import com.conveyal.datatools.common.status.FeedVersionJob;
 import com.conveyal.datatools.common.utils.Scheduler;
-import com.conveyal.datatools.manager.DataManager;
 import com.conveyal.datatools.manager.auth.Auth0UserProfile;
 import com.conveyal.datatools.manager.models.FeedSource;
 import com.conveyal.datatools.manager.models.FeedVersion;
 import com.conveyal.datatools.manager.persistence.Persistence;
+import com.conveyal.datatools.manager.utils.JobUtils;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -75,7 +75,7 @@ public class FetchSingleFeedJob extends FeedVersionJob {
             if (continueThread) {
                 addNextJob(processSingleFeedJob);
             } else {
-                DataManager.heavyExecutor.execute(processSingleFeedJob);
+                JobUtils.heavyExecutor.execute(processSingleFeedJob);
             }
         }
     }

--- a/src/main/java/com/conveyal/datatools/manager/jobs/NotifyUsersForSubscriptionJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/NotifyUsersForSubscriptionJob.java
@@ -5,6 +5,7 @@ import com.conveyal.datatools.manager.models.Deployment;
 import com.conveyal.datatools.manager.models.FeedSource;
 import com.conveyal.datatools.manager.models.Project;
 import com.conveyal.datatools.manager.persistence.Persistence;
+import com.conveyal.datatools.manager.utils.JobUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,7 +41,7 @@ public class NotifyUsersForSubscriptionJob implements Runnable {
             return;
         }
         NotifyUsersForSubscriptionJob notifyJob = new NotifyUsersForSubscriptionJob(subscriptionType, target, message);
-        DataManager.lightExecutor.execute(notifyJob);
+        JobUtils.lightExecutor.execute(notifyJob);
         LOG.info("Notification job scheduled in light executor");
     }
 

--- a/src/main/java/com/conveyal/datatools/manager/models/FeedSource.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/FeedSource.java
@@ -10,7 +10,6 @@ import com.conveyal.datatools.common.utils.Scheduler;
 import com.conveyal.datatools.common.utils.aws.CheckedAWSException;
 import com.conveyal.datatools.common.utils.aws.S3Utils;
 import com.conveyal.datatools.manager.DataManager;
-import com.conveyal.datatools.manager.controllers.api.StatusController;
 import com.conveyal.datatools.manager.jobs.CreateFeedVersionFromSnapshotJob;
 import com.conveyal.datatools.manager.jobs.FetchSingleFeedJob;
 import com.conveyal.datatools.manager.jobs.MergeFeedsJob;
@@ -18,6 +17,7 @@ import com.conveyal.datatools.manager.jobs.ProcessSingleFeedJob;
 import com.conveyal.datatools.manager.models.transform.FeedTransformRules;
 import com.conveyal.datatools.manager.models.transform.FeedTransformation;
 import com.conveyal.datatools.manager.persistence.Persistence;
+import com.conveyal.datatools.manager.utils.JobUtils;
 import com.conveyal.gtfs.GTFS;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -606,7 +606,7 @@ public class FeedSource extends Model implements Cloneable {
      * occurring at the same time).
      */
     public boolean hasJobsInProgress() {
-        return StatusController.filterActiveJobs(StatusController.getAllJobs()).stream().anyMatch(job -> {
+        return JobUtils.filterActiveJobs(JobUtils.getAllJobs()).stream().anyMatch(job -> {
             String jobFeedSourceId = null;
             if (
                 job instanceof FetchSingleFeedJob ||

--- a/src/main/java/com/conveyal/datatools/manager/models/Project.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/Project.java
@@ -72,6 +72,11 @@ public class Project extends Model {
      */
     public Set<AutoDeployType> autoDeployTypes = new HashSet<>();
 
+    /**
+     * Whether to auto-deploy feeds that have critical errors.
+     */
+    public boolean autoDeployWithCriticalErrors = false;
+
     // Identifies a specific "pinned" deployment for the project. This is used in datatools-ui in 2 places:
     // 1. In the list of project deployments, a "pinned" deployment is shown first and highlighted.
     // 2. In the project feed source table, if a "pinned" deployment exists, the status of the versions that were in

--- a/src/main/java/com/conveyal/datatools/manager/utils/JobUtils.java
+++ b/src/main/java/com/conveyal/datatools/manager/utils/JobUtils.java
@@ -1,0 +1,107 @@
+package com.conveyal.datatools.manager.utils;
+
+import com.conveyal.datatools.common.status.MonitorableJob;
+import com.conveyal.datatools.manager.auth.Auth0UserProfile;
+import com.google.common.collect.Sets;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
+
+public class JobUtils {
+    private static final Logger LOG = LoggerFactory.getLogger(JobUtils.class);
+
+    /**
+     * Stores jobs underway by user ID. NOTE: any set created and stored here must be created with
+     * {@link Sets#newConcurrentHashSet()} or similar thread-safe Set.
+     */
+    public static Map<String, Set<MonitorableJob>> userJobsMap = new ConcurrentHashMap<>();
+
+    // Heavy executor should contain long-lived CPU-intensive tasks (e.g., feed loading/validation)
+    public static Executor heavyExecutor = Executors.newFixedThreadPool(4);
+
+    // light executor is for tasks for things that should finish quickly (e.g., email notifications)
+    public static Executor lightExecutor = Executors.newSingleThreadExecutor();
+
+    public static Set<MonitorableJob> getAllJobs() {
+        return userJobsMap.values().stream()
+                .flatMap(Collection::stream)
+                .collect(Collectors.toSet());
+    }
+
+    /** Shorthand method for getting a single job by job ID. */
+    public static MonitorableJob getJobByJobId(String jobId) {
+        for (MonitorableJob job : getAllJobs()) if (job.jobId.equals(jobId)) return job;
+        return null;
+    }
+
+    /**
+     * Gets a job by user ID and job ID.
+     * @param clearCompleted if true, remove requested job if it has completed or errored
+     */
+    public static MonitorableJob getJobById(String userId, String jobId, boolean clearCompleted) {
+        // Get jobs set directly from userJobsMap because we may remove an element from it below.
+        Set<MonitorableJob> userJobs = userJobsMap.get(userId);
+        if (userJobs == null) {
+            return null;
+        }
+        for (MonitorableJob job : userJobs) {
+            if (job.jobId.equals(jobId)) {
+                if (clearCompleted && (job.status.completed || job.status.error)) {
+                    // remove job if completed or errored
+                    userJobs.remove(job);
+                }
+                return job;
+            }
+        }
+        // if job is not found (because it doesn't exist or was completed).
+        return null;
+    }
+
+    /**
+     * Convenience wrapper method to retrieve all jobs for {@link Auth0UserProfile}.
+     */
+    public static Set<MonitorableJob> getJobsForUser(Auth0UserProfile user) {
+        if (user == null) {
+            LOG.warn("Null user passed to getJobsForUser!");
+            return Sets.newConcurrentHashSet();
+        }
+        return getJobsByUserId(user.getUser_id(), false);
+    }
+
+    /**
+     * Get set of active jobs by user ID. If there are no active jobs, return a new set.
+     *
+     * NOTE: this should be a concurrent hash set so that it is threadsafe.
+     *
+     * @param clearCompleted if true, remove all completed and errored jobs for this user.
+     */
+    public static Set<MonitorableJob> getJobsByUserId(String userId, boolean clearCompleted) {
+        Set<MonitorableJob> allJobsForUser = userJobsMap.get(userId);
+        if (allJobsForUser == null) {
+            return Sets.newConcurrentHashSet();
+        }
+        if (clearCompleted) {
+            // Any active jobs will still have their status updated, so they need to be retrieved again with any status
+            // updates. All completed or errored jobs are in their final state and will not be updated any longer, so we
+            // remove them once the client has seen them.
+            Set<MonitorableJob> jobsStillActive = filterActiveJobs(allJobsForUser);
+
+            userJobsMap.put(userId, jobsStillActive);
+        }
+        return allJobsForUser;
+    }
+
+    public static Set<MonitorableJob> filterActiveJobs(Set<MonitorableJob> jobs) {
+        // Note: this must be a thread-safe set in case it is placed into the DataManager#userJobsMap.
+        Set<MonitorableJob> jobsStillActive = Sets.newConcurrentHashSet();
+        jobs.stream().filter(job -> job.active).forEach(jobsStillActive::add);
+        return jobsStillActive;
+    }
+}

--- a/src/test/java/com/conveyal/datatools/manager/jobs/AutoDeployJobTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/jobs/AutoDeployJobTest.java
@@ -3,7 +3,6 @@ package com.conveyal.datatools.manager.jobs;
 import com.conveyal.datatools.DatatoolsTest;
 import com.conveyal.datatools.TestUtils;
 import com.conveyal.datatools.common.status.MonitorableJob;
-import com.conveyal.datatools.manager.DataManager;
 import com.conveyal.datatools.manager.auth.Auth0Connection;
 import com.conveyal.datatools.manager.auth.Auth0UserProfile;
 import com.conveyal.datatools.manager.models.Deployment;
@@ -13,6 +12,7 @@ import com.conveyal.datatools.manager.models.FeedVersion;
 import com.conveyal.datatools.manager.models.OtpServer;
 import com.conveyal.datatools.manager.models.Project;
 import com.conveyal.datatools.manager.persistence.Persistence;
+import com.conveyal.datatools.manager.utils.JobUtils;
 import com.google.common.collect.Sets;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -146,7 +146,7 @@ public class AutoDeployJobTest extends DatatoolsTest {
         // indefinitely).
         Set<MonitorableJob> userJobs = Sets.newConcurrentHashSet();
         userJobs.add(new ProcessSingleFeedJob(feedVersionC, user, true));
-        DataManager.userJobsMap.put(user.getUser_id(), userJobs);
+        JobUtils.userJobsMap.put(user.getUser_id(), userJobs);
 
         // Add mock feed 1 to the deployment so that it is detected in the Deployment#hasFeedFetchesInProgress check
         // (called during auto deploy).


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

A few more changes so that auto-deployment works somewhat smoothly in practice. And a refactor to consolidate a bunch of job-related logic into its own util file.

- Move all job-related fields and methods into new JobUtils class.
- Introduce a new `active` field into MonitorableJob to correctly identify active jobs even when jobs are recurring or not yet started.
- Change the way active jobs are found to use that new `active` field.
- When queueing a new DeployJob, wait to create a new one so it doesn't show up in list of jobs for a split second.
- Add new field `autoDeployWithCriticalErrors` to Project and update AutoDeployJob to use this field accordingly
- Add a bunch of new completion messages to the AutoDeployJob
- Only update feed versions in a deployment when the AutoDeployJob starts a DeployJob
- Avoid overwriting deployment data in DeployJob by fetching needed data at point of update