### PR TITLE
Normalize fields fix

### DIFF
--- a/src/main/java/com/conveyal/datatools/manager/utils/json/JsonUtil.java
+++ b/src/main/java/com/conveyal/datatools/manager/utils/json/JsonUtil.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.type.CollectionType;
 import spark.Request;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 
 import static com.conveyal.datatools.common.utils.SparkUtils.getObjectNode;
@@ -55,6 +56,7 @@ public class JsonUtil {
 
     /**
      * Utility method to parse generic objects from {@link JsonNode} and return as list
+     * (or at least an empty list).
      */
     public static <T> List<T> getPOJOFromJSONAsList(JsonNode json, Class<T> clazz) {
         if (json != null) {
@@ -66,7 +68,7 @@ public class JsonUtil {
                 e.printStackTrace();
             }
         }
-        return null;
+        return new ArrayList<>();
     }
 
     /**

--- a/src/test/java/com/conveyal/datatools/manager/utils/JsonUtilTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/utils/JsonUtilTest.java
@@ -22,7 +22,7 @@ public class JsonUtilTest {
     */
     @ParameterizedTest
     @MethodSource("createPOJOFromJSONCases")
-    public void testGetPOJOFromJSONAsListIsNotEmpty(JsonNode jsonNode) {
+    public void testGetPOJOFromJSONAsListIsNotNull(JsonNode jsonNode) {
         assertNotNull(JsonUtil.getPOJOFromJSONAsList(
             jsonNode,
             Substitution.class

--- a/src/test/java/com/conveyal/datatools/manager/utils/JsonUtilTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/utils/JsonUtilTest.java
@@ -1,0 +1,40 @@
+package com.conveyal.datatools.manager.utils;
+
+import com.conveyal.datatools.manager.models.transform.Substitution;
+import com.conveyal.datatools.manager.utils.json.JsonUtil;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class JsonUtilTest {
+    final static String JSON_LIST = "[{ \"pattern\": \"abc\" }, {\"pattern\": \"def\"}]";
+
+    /**
+     * Ensure {@link JsonUtil#getPOJOFromJSONAsList} returns at least an empty list
+     * for the given jsonNode input.
+    */
+    @ParameterizedTest
+    @MethodSource("createPOJOFromJSONCases")
+    public void testGetPOJOFromJSONAsListIsNotEmpty(JsonNode jsonNode) {
+        assertNotNull(JsonUtil.getPOJOFromJSONAsList(
+            jsonNode,
+            Substitution.class
+        ));
+    }
+
+    private static Stream<Arguments> createPOJOFromJSONCases() throws JsonProcessingException {
+        return Stream.of(
+            // Handle cases where JSON config data is missing.
+            Arguments.of((Object) null),
+            // Normal cases where JSON config data is populated.
+            Arguments.of(new ObjectMapper().readTree(JSON_LIST))
+        );
+    }
+}

--- a/src/test/java/com/conveyal/datatools/manager/utils/JsonUtilTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/utils/JsonUtilTest.java
@@ -3,38 +3,48 @@ package com.conveyal.datatools.manager.utils;
 import com.conveyal.datatools.manager.models.transform.Substitution;
 import com.conveyal.datatools.manager.utils.json.JsonUtil;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.api.Test;
 
-import java.util.stream.Stream;
+import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+/**
+ * Test class for JsonUtil.
+ * We use, as an illustration, {@link Substitution} as the target class for JSON parsing.
+ */
 public class JsonUtilTest {
     final static String JSON_LIST = "[{ \"pattern\": \"abc\" }, {\"pattern\": \"def\"}]";
 
     /**
-     * Ensure {@link JsonUtil#getPOJOFromJSONAsList} returns at least an empty list
-     * for the given jsonNode input.
+     * Ensure {@link JsonUtil#getPOJOFromJSONAsList} returns an empty list
+     * if the given jsonNode input is null.
     */
-    @ParameterizedTest
-    @MethodSource("createPOJOFromJSONCases")
-    public void testGetPOJOFromJSONAsListIsNotNull(JsonNode jsonNode) {
-        assertNotNull(JsonUtil.getPOJOFromJSONAsList(
-            jsonNode,
+    @Test
+    public void testGetPOJOFromNullJSONIsNotNull() {
+
+        List<Substitution> list = JsonUtil.getPOJOFromJSONAsList(
+            null,
             Substitution.class
-        ));
+        );
+        assertNotNull(list);
+        assertEquals(0, list.size());
     }
 
-    private static Stream<Arguments> createPOJOFromJSONCases() throws JsonProcessingException {
-        return Stream.of(
-            // Handle cases where JSON config data is missing.
-            Arguments.of((Object) null),
-            // Normal cases where JSON config data is populated.
-            Arguments.of(new ObjectMapper().readTree(JSON_LIST))
+    /**
+     * Ensure {@link JsonUtil#getPOJOFromJSONAsList} populates a list from JSON.
+     */
+    @Test
+    public void testGetPOJOFromJSONAsListIsPopulated() throws JsonProcessingException {
+        List<Substitution> list = JsonUtil.getPOJOFromJSONAsList(
+            new ObjectMapper().readTree(JSON_LIST),
+            Substitution.class
         );
+        assertNotNull(list);
+        assertEquals(2, list.size());
+        assertEquals("abc", list.get(0).pattern);
+        assertEquals("def", list.get(1).pattern);
     }
 }


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [na] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR supplements #371 by making `NormalizeFieldTransformation.substitutions` and `NormalizeFieldTransformation.capitalizationExceptions` not null if no default substitutions are specified in the configurations (at least an empty list is returned).
