### PR TITLE
Flag invalid regex patterns in Substitutions

### DIFF
--- a/src/main/java/com/conveyal/datatools/manager/models/transform/NormalizeFieldTransformation.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/transform/NormalizeFieldTransformation.java
@@ -141,8 +141,21 @@ public class NormalizeFieldTransformation extends ZipTransformation {
 
     @Override
     public void validateParameters(MonitorableJob.Status status) {
+        // fieldName must not be null
         if (fieldName == null) {
             status.fail("Field name must not be null");
+            return;
+        }
+
+        // Substitutions must have valid patterns (gather invalid patterns).
+        List<String> invalidSubstitutionPatterns = new ArrayList<>();
+        for (Substitution substitution : substitutions) {
+            if (substitution.isInvalid()) {
+                invalidSubstitutionPatterns.add(substitution.pattern);
+            }
+        }
+        if (invalidSubstitutionPatterns.size() != 0) {
+            status.fail("Some substitution patterns are invalid: " + String.join(", ", invalidSubstitutionPatterns));
         }
     }
 

--- a/src/main/java/com/conveyal/datatools/manager/models/transform/NormalizeFieldTransformation.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/transform/NormalizeFieldTransformation.java
@@ -148,15 +148,33 @@ public class NormalizeFieldTransformation extends ZipTransformation {
         }
 
         // Substitutions must have valid patterns (gather invalid patterns).
-        List<String> invalidSubstitutionPatterns = new ArrayList<>();
+        List<String> invalidPatterns = getInvalidSubstitutionPatterns(substitutions);
+        if (!invalidPatterns.isEmpty()) {
+            status.fail(getInvalidSubstitutionMessage(invalidPatterns));
+        }
+    }
+
+    /**
+     * @return A formatted error message regarding invalid substitution search patterns.
+     */
+    public static String getInvalidSubstitutionMessage(List<String> invalidPatterns) {
+        return String.format(
+            "Some substitution patterns are invalid: %s",
+            String.join(", ", invalidPatterns)
+        );
+    }
+
+    /**
+     * @return a list of invalid substitution search patterns.
+     */
+    public static List<String> getInvalidSubstitutionPatterns(List<Substitution> substitutions) {
+        List<String> invalidPatterns = new ArrayList<>();
         for (Substitution substitution : substitutions) {
             if (!substitution.isValid()) {
-                invalidSubstitutionPatterns.add(substitution.pattern);
+                invalidPatterns.add(substitution.pattern);
             }
         }
-        if (invalidSubstitutionPatterns.size() != 0) {
-            status.fail("Some substitution patterns are invalid: " + String.join(", ", invalidSubstitutionPatterns));
-        }
+        return invalidPatterns;
     }
 
     @Override

--- a/src/main/java/com/conveyal/datatools/manager/models/transform/Substitution.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/transform/Substitution.java
@@ -23,7 +23,7 @@ public class Substitution implements Serializable {
 
     /**
      * Whether this substitution object is invalid.
-     * This property is read-only from the UI (empty setter below) and is not persisted to Mongo.
+     * The `valid` property is read-only from the UI (see the empty setter below) and is not persisted to Mongo.
      * @return rue if the pattern for this substitution is invalid.
      */
     @BsonIgnore
@@ -36,10 +36,13 @@ public class Substitution implements Serializable {
         }
     }
 
+    /**
+     * This empty setter is needed to send the `valid` field to the UI
+     * and to accept, without doing anything, substitution data from the UI that contain the `valid` field.
+     * The `valid` property is read-only from the UI and is not persisted to Mongo.
+     */
     @BsonIgnore
-    public void setValid(boolean value) {
-        // Does nothing (read-only field).
-    }
+    public void setValid(boolean value) { }
 
     private Pattern patternObject;
     /**

--- a/src/main/java/com/conveyal/datatools/manager/models/transform/Substitution.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/transform/Substitution.java
@@ -1,7 +1,10 @@
 package com.conveyal.datatools.manager.models.transform;
 
+import org.bson.codecs.pojo.annotations.BsonIgnore;
+
 import java.io.Serializable;
 import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 
 /**
  * This class holds the regex/replacement pair, and the cached compiled regex pattern.
@@ -17,6 +20,26 @@ public class Substitution implements Serializable {
     public String replacement;
     /** true if whitespace surrounding regex should be create or normalized to one space. */
     public boolean normalizeSpace;
+
+    /**
+     * Whether this substitution object is invalid.
+     * This property is read-only from the UI (empty setter below) and is not persisted to Mongo.
+     * @return rue if the pattern for this substitution is invalid.
+     */
+    @BsonIgnore
+    public boolean isInvalid() {
+        try {
+            initialize();
+            return false;
+        } catch (PatternSyntaxException pse) {
+            return true;
+        }
+    }
+
+    @BsonIgnore
+    public void setInvalid(boolean value) {
+        // Does nothing (read-only field).
+    }
 
     private Pattern patternObject;
     /**

--- a/src/test/java/com/conveyal/datatools/manager/models/transform/SubstitutionTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/models/transform/SubstitutionTest.java
@@ -1,0 +1,20 @@
+package com.conveyal.datatools.manager.models.transform;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class SubstitutionTest {
+    @Test
+    public void shouldNotFlagValidPattern() {
+        Substitution substitution = new Substitution("\\bCir\\b", "Circle");
+        assertFalse(substitution.isInvalid());
+    }
+
+    @Test
+    public void shouldFlagInvalidPattern() {
+        Substitution substitution = new Substitution("\\Cir\\b", "Circle");
+        assertTrue(substitution.isInvalid());
+    }
+}


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR fixes #391 by changing `NormalizeFieldTranformation` as follows:
- Invalid substitution search patterns are reported in the ZIP transform job status (see screenshot),
- Substitutions with invalid search patterns are rejected on persistence,
- For UI feedback in PR https://github.com/ibi-group/datatools-ui/pull/687, a `valid` field is added to the returned JSON for each substitution of the transformation. 

To test, use a configuration that enables field normalization transformations.

![image](https://user-images.githubusercontent.com/56846598/122051632-d072f680-cdb2-11eb-97b5-a80fb8a1a7be.png)

