### PR TITLE
Improve deployment debugging

### DIFF
--- a/src/main/java/com/conveyal/datatools/common/utils/SparkUtils.java
+++ b/src/main/java/com/conveyal/datatools/common/utils/SparkUtils.java
@@ -1,8 +1,7 @@
 package com.conveyal.datatools.common.utils;
 
-import com.bugsnag.Bugsnag;
-import com.bugsnag.Report;
 import com.conveyal.datatools.manager.auth.Auth0UserProfile;
+import com.conveyal.datatools.manager.utils.ErrorUtils;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -25,7 +24,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.Arrays;
 
-import static com.conveyal.datatools.manager.DataManager.getBugsnag;
 import static com.conveyal.datatools.manager.DataManager.getConfigPropertyAsText;
 import static spark.Spark.halt;
 
@@ -129,15 +127,7 @@ public class SparkUtils {
             LOG.error(message);
 
             // create report to notify bugsnag if configured
-            Bugsnag bugsnag = getBugsnag();
-            if (bugsnag != null && e != null) {
-                // create report to send to bugsnag
-                Report report = bugsnag.buildReport(e);
-                Auth0UserProfile userProfile = request != null ? request.attribute("user") : null;
-                String userEmail = userProfile != null ? userProfile.getEmail() : "no-auth";
-                report.setUserEmail(userEmail);
-                bugsnag.notify(report);
-            }
+            ErrorUtils.reportToBugsnag(e, request.attribute("user"));
         }
 
         JsonNode json = getObjectNode(message, statusCode, e);

--- a/src/main/java/com/conveyal/datatools/manager/DataManager.java
+++ b/src/main/java/com/conveyal/datatools/manager/DataManager.java
@@ -1,7 +1,5 @@
 package com.conveyal.datatools.manager;
 
-import com.bugsnag.Bugsnag;
-import com.conveyal.datatools.common.status.MonitorableJob;
 import com.conveyal.datatools.common.utils.CorsFilter;
 import com.conveyal.datatools.common.utils.RequestSummary;
 import com.conveyal.datatools.common.utils.Scheduler;
@@ -27,8 +25,8 @@ import com.conveyal.datatools.manager.extensions.mtc.MtcFeedResource;
 import com.conveyal.datatools.manager.extensions.transitfeeds.TransitFeedsFeedResource;
 import com.conveyal.datatools.manager.extensions.transitland.TransitLandFeedResource;
 import com.conveyal.datatools.manager.jobs.FeedUpdater;
-import com.conveyal.datatools.manager.persistence.FeedStore;
 import com.conveyal.datatools.manager.persistence.Persistence;
+import com.conveyal.datatools.manager.utils.ErrorUtils;
 import com.conveyal.datatools.manager.utils.json.JsonUtil;
 import com.conveyal.gtfs.GTFS;
 import com.conveyal.gtfs.GraphQLController;
@@ -37,7 +35,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import com.google.common.collect.Sets;
 import com.google.common.io.Resources;
 import org.apache.commons.io.Charsets;
 import org.slf4j.Logger;
@@ -53,10 +50,6 @@ import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
 
 import static com.conveyal.datatools.common.utils.SparkUtils.logMessageAndHalt;
 import static com.conveyal.datatools.common.utils.SparkUtils.logRequest;
@@ -123,7 +116,7 @@ public class DataManager {
         loadConfig(args);
         loadProperties();
 
-        getBugsnag();
+        ErrorUtils.initialize();
 
         // Optionally set port for server. Otherwise, Spark defaults to 4567.
         if (hasConfigProperty("application.port")) {
@@ -146,15 +139,6 @@ public class DataManager {
 
         // Initialize scheduled tasks
         Scheduler.initialize();
-    }
-
-    // intialize bugsnag
-    public static Bugsnag getBugsnag() {
-        String bugsnagKey = getConfigPropertyAsText("BUGSNAG_KEY");
-        if (bugsnagKey != null) {
-            return new Bugsnag(bugsnagKey);
-        }
-        return null;
     }
 
     /*

--- a/src/main/java/com/conveyal/datatools/manager/jobs/MonitorServerStatusJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/MonitorServerStatusJob.java
@@ -306,7 +306,7 @@ public class MonitorServerStatusJob extends MonitorableJob {
         try (CloseableHttpResponse response = httpClient.execute(httpGet)) {
             otpRunnerStatus = JsonUtil.objectMapper.readValue(response.getEntity().getContent(), OtpRunnerStatus.class);
         } catch (IOException e) {
-            LOG.error("Could not get otp-runner status from {}. It might not be available yet.", url);
+            LOG.warn("Could not get otp-runner status from {}. It might not be available yet.", url);
             return false;
         }
 

--- a/src/main/java/com/conveyal/datatools/manager/jobs/MonitorServerStatusJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/MonitorServerStatusJob.java
@@ -306,8 +306,7 @@ public class MonitorServerStatusJob extends MonitorableJob {
         try (CloseableHttpResponse response = httpClient.execute(httpGet)) {
             otpRunnerStatus = JsonUtil.objectMapper.readValue(response.getEntity().getContent(), OtpRunnerStatus.class);
         } catch (IOException e) {
-            LOG.error("Could not get otp-runner status from {}", url);
-            e.printStackTrace();
+            LOG.error("Could not get otp-runner status from {}. It might not be available yet.", url);
             return false;
         }
 

--- a/src/main/java/com/conveyal/datatools/manager/utils/ErrorUtils.java
+++ b/src/main/java/com/conveyal/datatools/manager/utils/ErrorUtils.java
@@ -9,6 +9,13 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Map;
 
+/**
+ * A util class for reporting errors to the project defined by the Bugsnag project notifier API key.
+ *
+ * A Bugsnag project identifier key is unique to a Bugsnag project and allows errors to be saved against it. This key
+ * can be obtained by logging into Bugsnag (https://app.bugsnag.com), clicking on Projects (left side menu) and
+ * selecting the required project. Once selected, the notifier API key is presented.
+ */
 public class ErrorUtils {
     private static final Logger LOG = LoggerFactory.getLogger(ErrorUtils.class);
 
@@ -61,7 +68,9 @@ public class ErrorUtils {
         bugsnag.notify(report);
     }
 
-    // intialize bugsnag
+    /**
+     * Initialize Bugsnag reporting if a Bugsnag key exists in the configuration.
+     */
     public static void initialize() {
         String bugsnagKey = DataManager.getConfigPropertyAsText("BUGSNAG_KEY");
         if (bugsnagKey != null) {

--- a/src/main/java/com/conveyal/datatools/manager/utils/ErrorUtils.java
+++ b/src/main/java/com/conveyal/datatools/manager/utils/ErrorUtils.java
@@ -1,0 +1,71 @@
+package com.conveyal.datatools.manager.utils;
+
+import com.bugsnag.Bugsnag;
+import com.bugsnag.Report;
+import com.conveyal.datatools.manager.DataManager;
+import com.conveyal.datatools.manager.auth.Auth0UserProfile;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+public class ErrorUtils {
+    private static final Logger LOG = LoggerFactory.getLogger(ErrorUtils.class);
+
+    private static Bugsnag bugsnag;
+
+    /**
+     * Create and send a report to bugsnag if configured.
+     *
+     * @param e The throwable object to send to Bugsnag. This MUST be provided or a report will not be generated.
+     * @param userProfile An optional user profile. If provided, the email address from this profile will be set in the
+     *                    Bugsnag report.
+     */
+    public static void reportToBugsnag(Throwable e, Auth0UserProfile userProfile) {
+        reportToBugsnag(e, null, userProfile);
+    }
+
+    /**
+     * Create and send a report to bugsnag if configured.
+     *
+     * @param e The throwable object to send to Bugsnag. This MUST be provided or a report will not be generated.
+     * @param debuggingMessages An optional Map of keys and values that will be added to the `debugging` tab within the
+     *                          Bugsnag report.
+     * @param userProfile An optional user profile. If provided, the email address from this profile will be set in the
+     *                    Bugsnag report.
+     */
+    public static void reportToBugsnag(
+        Throwable e, Map<String, String> debuggingMessages, Auth0UserProfile userProfile
+    ) {
+        if (bugsnag == null) {
+            LOG.warn("Bugsnag not configured to report errors!");
+            return;
+        }
+        if (e == null) {
+            LOG.warn("No Throwable object provided. A Bugsnag report will not be created!");
+            return;
+        }
+
+        // create report to send to bugsnag
+        Report report = bugsnag.buildReport(e);
+        String userEmail = userProfile != null ? userProfile.getEmail() : "no-auth";
+        report.setUserEmail(userEmail);
+        if (debuggingMessages != null) {
+            debuggingMessages.entrySet().stream()
+                .forEach((Map.Entry<String, String> entry) -> report.addToTab(
+                    "debugging",
+                    entry.getKey(),
+                    entry.getValue()
+                ));
+        }
+        bugsnag.notify(report);
+    }
+
+    // intialize bugsnag
+    public static void initialize() {
+        String bugsnagKey = DataManager.getConfigPropertyAsText("BUGSNAG_KEY");
+        if (bugsnagKey != null) {
+            bugsnag = new Bugsnag(bugsnagKey);
+        }
+    }
+}


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR does 3 things:

#### 1. Consolidation of Bugsnag logic into special ErrorUtils class

A new class called ErrorUtils was created that now contains all logic related to Bugsnag error reporting.

#### 2. Reporting of errors that otp-runner encountered to Bugsnag

If there is ever an error encountered by otp-runner, this error will now be reported to Bugsnag. It'd be a good idea to know about these because once a deployment configuration is setup, nearly any error encountered is almost certainly due to some kind of system error instead of anything bad the user did.

#### 3. Removes unneeded stacktrace printing

The printing of a stacktrace to the log output in a specific case was removed in order to declutter logs. In almost every deployment, it is expected at the beginning that there will be some kind of error for a little while when trying to fetch the otp-runner status file due to the instance booting up and then otp-runner loading and writing out the first status file.

The log output from a typical deployment looks like this:

> [34mc.c.d.m.jobs.MonitorServerStatusJob(MonitorServerStatusJob.java:309)[0;39m Could not get otp-runner status from http://#.#.#.#/status.json
com.fasterxml.jackson.core.JsonParseException: Unexpected character ('<' (code 60)): expected a valid value (JSON String, Number, Array, Object or token 'null', 'true' or 'false')
 at [Source: (org.apache.http.client.entity.LazyDecompressingInputStream); line: 1, column: 2]
	at com.fasterxml.jackson.core.JsonParser._constructError(JsonParser.java:2337)
	at com.fasterxml.jackson.core.base.ParserMinimalBase._reportError(ParserMinimalBase.java:710)
	at com.fasterxml.jackson.core.base.ParserMinimalBase._reportUnexpectedChar(ParserMinimalBase.java:635)
	at com.fasterxml.jackson.core.json.UTF8StreamJsonParser._handleUnexpectedValue(UTF8StreamJsonParser.java:2691)
	at com.fasterxml.jackson.core.json.UTF8StreamJsonParser._nextTokenNotInObject(UTF8StreamJsonParser.java:870)
	at com.fasterxml.jackson.core.json.UTF8StreamJsonParser.nextToken(UTF8StreamJsonParser.java:762)
	at com.fasterxml.jackson.databind.ObjectMapper._initForReading(ObjectMapper.java:4684)
	at com.fasterxml.jackson.databind.ObjectMapper._readMapAndClose(ObjectMapper.java:4586)
	at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3585)
	at com.conveyal.datatools.manager.jobs.MonitorServerStatusJob.checkForOtpRunnerCompletion(MonitorServerStatusJob.java:307)
	at com.conveyal.datatools.manager.jobs.MonitorServerStatusJob.jobLogic(MonitorServerStatusJob.java:106)
	at com.conveyal.datatools.common.status.MonitorableJob.run(MonitorableJob.java:160)
	at com.conveyal.datatools.manager.jobs.DeployJob.replaceEC2Servers(DeployJob.java:681)
	at com.conveyal.datatools.manager.jobs.DeployJob.jobLogic(DeployJob.java:326)
	at com.conveyal.datatools.common.status.MonitorableJob.run(MonitorableJob.java:160)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
[34mINFO [0;39m 2021-06-25T13:32:04.964 [33m[pool-3-thread-2][0;39m [34mc.c.d.m.jobs.MonitorServerStatusJob(MonitorServerStatusJob.java:238)[0;39m Waiting 4 seconds for otp-runner completion check: http://3.93.50.211/status.json
[1;31mERROR[0;39m 2021-06-25T13:32:09.024 [33m[pool-3-thread-2][0;39m [34mc.c.d.m.jobs.MonitorServerStatusJob(MonitorServerStatusJob.java:309)[0;39m Could not get otp-runner status from http://3.93.50.211/status.json
com.fasterxml.jackson.core.JsonParseException: Unexpected character ('<' (code 60)): expected a valid value (JSON String, Number, Array, Object or token 'null', 'true' or 'false')
 at [Source: (org.apache.http.client.entity.LazyDecompressingInputStream); line: 1, column: 2

That stacktrace was printed 8 times and then on the 9th check the status file was available and was parsed fine and the rest of the MonitorServerStatusJob ran just fine.