### PR TITLE
ci: don’t push to s3 when running on pull requests

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -103,6 +103,7 @@ jobs:
           semantic-release --prepare @conveyal/maven-semantic-release --publish @semantic-release/github,@conveyal/maven-semantic-release --verify-conditions @semantic-release/github,@conveyal/maven-semantic-release --verify-release @conveyal/maven-semantic-release --use-conveyal-workflow --dev-branch=dev --skip-maven-deploy
       # The git commands get the commit hash of the HEAD commit and the commit just before HEAD.
       - name: Prepare deploy artifacts
+        if: github.event_name != 'pull_request'
         run: |
           # get branch name of current branch for use in jar name
           export BRANCH=$GITHUB_HEAD_REF_SLUG
@@ -122,5 +123,6 @@ jobs:
           FIRST_JAR="${ALL_JARS[0]}"
           cp "$FIRST_JAR" "deploy/dt-latest-$BRANCH_CLEAN.jar"
       - name: Deploy to S3
+        if: github.event_name != 'pull_request'
         run: |
           aws s3 cp ./deploy s3://datatools-builds --recursive --acl public-read

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -107,7 +107,7 @@ jobs:
         if: github.event_name == 'push'
         run: |
           # get branch name of current branch for use in jar name
-          export BRANCH=$GITHUB_HEAD_REF_SLUG
+          export BRANCH=$GITHUB_REF_SLUG
           # Replace forward slashes with underscores in branch name.
           export BRANCH_CLEAN=${BRANCH//\//_}
           # Create directory that will contain artifacts to deploy to s3.

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -103,7 +103,8 @@ jobs:
           semantic-release --prepare @conveyal/maven-semantic-release --publish @semantic-release/github,@conveyal/maven-semantic-release --verify-conditions @semantic-release/github,@conveyal/maven-semantic-release --verify-release @conveyal/maven-semantic-release --use-conveyal-workflow --dev-branch=dev --skip-maven-deploy
       # The git commands get the commit hash of the HEAD commit and the commit just before HEAD.
       - name: Prepare deploy artifacts
-        if: github.event_name != 'pull_request'
+        # Only deploy on push (pull_request will deploy a temp. merge commit. See #400.)
+        if: github.event_name == 'push'
         run: |
           # get branch name of current branch for use in jar name
           export BRANCH=$GITHUB_HEAD_REF_SLUG
@@ -123,6 +124,6 @@ jobs:
           FIRST_JAR="${ALL_JARS[0]}"
           cp "$FIRST_JAR" "deploy/dt-latest-$BRANCH_CLEAN.jar"
       - name: Deploy to S3
-        if: github.event_name != 'pull_request'
+        if: github.event_name == 'push'
         run: |
           aws s3 cp ./deploy s3://datatools-builds --recursive --acl public-read


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Adjusts the Github actions to not prepare for S3 deployment or or deploy to S3 when running on pull requests. Resolves #400.