### PR TITLE
Quickfix for parent job scope

### DIFF
--- a/src/main/java/com/conveyal/datatools/common/status/MonitorableJob.java
+++ b/src/main/java/com/conveyal/datatools/common/status/MonitorableJob.java
@@ -36,6 +36,7 @@ public abstract class MonitorableJob implements Runnable, Serializable {
      */
     public boolean active = false;
 
+    // The two fields below are public because they are used by the UI through the /jobs endpoint.
     public String parentJobId;
     public JobType parentJobType;
     // Status is not final to allow some jobs to have extra status fields.

--- a/src/main/java/com/conveyal/datatools/common/status/MonitorableJob.java
+++ b/src/main/java/com/conveyal/datatools/common/status/MonitorableJob.java
@@ -36,8 +36,8 @@ public abstract class MonitorableJob implements Runnable, Serializable {
      */
     public boolean active = false;
 
-    protected String parentJobId;
-    protected JobType parentJobType;
+    public String parentJobId;
+    public JobType parentJobType;
     // Status is not final to allow some jobs to have extra status fields.
     public Status status = new Status();
     // Name is not final in case it needs to be amended during job processing.

--- a/src/test/java/com/conveyal/datatools/TestUtils.java
+++ b/src/test/java/com/conveyal/datatools/TestUtils.java
@@ -2,6 +2,7 @@ package com.conveyal.datatools;
 
 import com.conveyal.datatools.manager.auth.Auth0UserProfile;
 import com.conveyal.datatools.manager.jobs.ProcessSingleFeedJob;
+import com.conveyal.datatools.manager.models.FeedRetrievalMethod;
 import com.conveyal.datatools.manager.models.FeedSource;
 import com.conveyal.datatools.manager.models.FeedVersion;
 import com.conveyal.datatools.manager.utils.HttpUtils;
@@ -141,6 +142,17 @@ public class TestUtils {
             e.printStackTrace();
         }
         return version;
+    }
+
+    /**
+     * Utility function to construct a mock feed version from a feedSourceId
+     * @return
+     */
+    public static FeedVersion createMockFeedVersion(String feedSourceId) {
+        FeedVersion f = new FeedVersion();
+        f.feedSourceId = feedSourceId;
+        f.retrievalMethod = FeedRetrievalMethod.FETCHED_AUTOMATICALLY;
+        return f;
     }
 
     /**

--- a/src/test/java/com/conveyal/datatools/TestUtils.java
+++ b/src/test/java/com/conveyal/datatools/TestUtils.java
@@ -146,7 +146,6 @@ public class TestUtils {
 
     /**
      * Utility function to construct a mock feed version from a feedSourceId
-     * @return
      */
     public static FeedVersion createMockFeedVersion(String feedSourceId) {
         FeedVersion f = new FeedVersion();

--- a/src/test/java/com/conveyal/datatools/manager/jobs/JobChainTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/jobs/JobChainTest.java
@@ -1,0 +1,63 @@
+package com.conveyal.datatools.manager.jobs;
+
+import com.conveyal.datatools.DatatoolsTest;
+import com.conveyal.datatools.TestUtils;
+import com.conveyal.datatools.manager.auth.Auth0UserProfile;
+import com.conveyal.datatools.manager.models.FeedRetrievalMethod;
+import com.conveyal.datatools.manager.models.FeedSource;
+import com.conveyal.datatools.manager.models.FeedVersion;
+import com.conveyal.datatools.manager.models.Project;
+import com.conveyal.datatools.manager.persistence.Persistence;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Date;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Test class for checking job chaining functionality.
+ */
+class JobChainTest extends DatatoolsTest {
+    private static final Logger LOG = LoggerFactory.getLogger(JobChainTest.class);
+    private static final Auth0UserProfile user = Auth0UserProfile.createTestAdminUser();
+    private static FeedSource mockFeedSource;
+    private static Project project;
+
+    @BeforeAll
+    public static void setUp() throws IOException {
+        DatatoolsTest.setUp();
+        LOG.info("{} setup", JobChainTest.class.getSimpleName());
+
+        // Create a project, feed sources to pass to jobs.
+        project = new Project();
+        project.name = String.format("Test %s", new Date());
+        Persistence.projects.create(project);
+        mockFeedSource = new FeedSource("Mock Feed Source", project.id, FeedRetrievalMethod.MANUALLY_UPLOADED);
+        Persistence.feedSources.create(mockFeedSource);
+    }
+
+    @AfterAll
+    public static void tearDown() {
+        mockFeedSource.delete();
+        project.delete();
+    }
+
+    @Test
+    void shouldPopulateParentJobIdAndTypeInSubjobs() {
+        FeedVersion f = TestUtils.createMockFeedVersion(mockFeedSource.id);
+
+        // Define a simple job chain.
+        // (The data for these jobs is arbitrary, the jobs are not actually executed.)
+        ProcessSingleFeedJob parentJob = new ProcessSingleFeedJob(f, user, true);
+        FetchSingleFeedJob subJob = new FetchSingleFeedJob(mockFeedSource, user, true);
+        parentJob.addNextJob(subJob);
+
+        assertEquals(parentJob.jobId, subJob.parentJobId);
+        assertEquals(parentJob.type, subJob.parentJobType);
+    }
+}

--- a/src/test/java/com/conveyal/datatools/manager/jobs/ProcessSingleFeedJobNotificationTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/jobs/ProcessSingleFeedJobNotificationTest.java
@@ -1,6 +1,7 @@
 package com.conveyal.datatools.manager.jobs;
 
 import com.conveyal.datatools.DatatoolsTest;
+import com.conveyal.datatools.TestUtils;
 import com.conveyal.datatools.manager.auth.Auth0UserProfile;
 import com.conveyal.datatools.manager.models.FeedRetrievalMethod;
 import com.conveyal.datatools.manager.models.FeedSource;
@@ -95,9 +96,6 @@ public class ProcessSingleFeedJobNotificationTest extends DatatoolsTest {
     }
 
     private FeedVersion createMockFeedVersion() {
-        FeedVersion f = new FeedVersion();
-        f.feedSourceId = mockFeedSource.id;
-        f.retrievalMethod = FeedRetrievalMethod.FETCHED_AUTOMATICALLY;
-        return f;
+        return TestUtils.createMockFeedVersion(mockFeedSource.id);
     }
 }


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR fixes #405 by making `parentJobId` and `parentJobType` in `MonitorableJob` public.
A test class is included to provide coverage for these fields.
A test using the actual `/jobs` endpoint was tried in #406 and led to errors hard to troubleshoot. 

To test, use a configuration (e.g. MTC) where GTFS file storage is on the server (and not S3).
