### PR TITLE
fix(FeedSource): resolve incorrectly thrown 404 when updating feed source

### DIFF
--- a/src/main/java/com/conveyal/datatools/manager/models/FeedSource.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/FeedSource.java
@@ -42,6 +42,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import static com.conveyal.datatools.manager.utils.StringUtils.getCleanName;
@@ -339,18 +340,18 @@ public class FeedSource extends Model implements Cloneable {
         // Compare every property other than labels
         return this.name.equals(o.name) &&
                 this.preserveStopTimesSequence == o.preserveStopTimesSequence &&
-                this.transformRules.equals(o.transformRules) &&
+                Objects.equals(this.transformRules, o.transformRules) &&
                 this.isPublic == o.isPublic &&
                 this.deployable == o.deployable &&
-                this.retrievalMethod.equals(o.retrievalMethod) &&
-                this.fetchFrequency.equals(o.fetchFrequency) &&
+                Objects.equals(this.retrievalMethod, o.retrievalMethod) &&
+                Objects.equals(this.fetchFrequency, o.fetchFrequency) &&
                 this.fetchInterval == o.fetchInterval &&
-                this.lastFetched.equals(o.lastFetched) &&
-                this.url.equals(o.url) &&
-                this.s3Url.equals(o.s3Url) &&
-                this.snapshotVersion.equals(o.snapshotVersion) &&
-                this.publishedVersionId.equals(o.publishedVersionId) &&
-                this.editorNamespace.equals(o.editorNamespace);
+                Objects.equals(this.lastFetched, o.lastFetched) &&
+                Objects.equals(this.url, o.url) &&
+                Objects.equals(this.s3Url, o.s3Url) &&
+                Objects.equals(this.snapshotVersion, o.snapshotVersion) &&
+                Objects.equals(this.publishedVersionId, o.publishedVersionId) &&
+                Objects.equals(this.editorNamespace, o.editorNamespace);
     }
 
     public String toString () {


### PR DESCRIPTION
Closes #422. The issue was a Null pointer exception being thrown on deciding whether or not to send an email to the user about the feed source update. The issue was solved by correcting the method used to compare feed sources.

### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing
