### PR TITLE
Always trigger Pelias update job

### DIFF
--- a/src/main/java/com/conveyal/datatools/manager/jobs/DeployJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/DeployJob.java
@@ -319,6 +319,16 @@ public class DeployJob extends MonitorableJob {
             }
         }
 
+        // Now that the build was successful, update Pelias
+        if (deployment.peliasUpdate) {
+            // Get log upload URI from deploy job
+            AmazonS3URI logUploadS3URI = getS3FolderURI();
+
+            // Execute the pelias update job and keep track of it
+            PeliasUpdateJob peliasUpdateJob = new PeliasUpdateJob(owner, "Updating Custom Geocoder Database", deployment, logUploadS3URI);
+            addNextJob(peliasUpdateJob);
+        }
+
         // Handle spinning up new EC2 servers for the load balancer's target group.
         if (otpServer.ec2Info != null) {
             if ("true".equals(DataManager.getConfigPropertyAsText("modules.deployment.ec2.enabled"))) {
@@ -341,15 +351,6 @@ public class DeployJob extends MonitorableJob {
             status.baseUrl = otpServer.publicUrl;
         }
 
-        // Now that the main instance is updated successfully, update Pelias
-        if (deployment.peliasUpdate) {
-            // Get log upload URI from deploy job
-            AmazonS3URI logUploadS3URI = getS3FolderURI();
-
-            // Execute the pelias update job and keep track of it
-            PeliasUpdateJob peliasUpdateJob = new PeliasUpdateJob(owner, "Updating Custom Geocoder Database", deployment, logUploadS3URI);
-            this.addNextJob(peliasUpdateJob);
-        }
 
         status.completed = true;
     }

--- a/src/main/java/com/conveyal/datatools/manager/jobs/DeployJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/DeployJob.java
@@ -315,18 +315,17 @@ public class DeployJob extends MonitorableJob {
                 } catch (Exception e) {
                     status.fail(String.format("Error uploading/copying deployment bundle to s3://%s", s3Bucket), e);
                 }
-
             }
-        }
+            
+            // Now that the build was successful, update Pelias
+            if (deployment.peliasUpdate) {
+                // Get log upload URI from deploy job
+                AmazonS3URI logUploadS3URI = getS3FolderURI();
 
-        // Now that the build was successful, update Pelias
-        if (deployment.peliasUpdate) {
-            // Get log upload URI from deploy job
-            AmazonS3URI logUploadS3URI = getS3FolderURI();
-
-            // Execute the pelias update job and keep track of it
-            PeliasUpdateJob peliasUpdateJob = new PeliasUpdateJob(owner, "Updating Custom Geocoder Database", deployment, logUploadS3URI);
-            addNextJob(peliasUpdateJob);
+                // Execute the pelias update job and keep track of it
+                PeliasUpdateJob peliasUpdateJob = new PeliasUpdateJob(owner, "Updating Custom Geocoder Database", deployment, logUploadS3URI);
+                addNextJob(peliasUpdateJob);
+            }
         }
 
         // Handle spinning up new EC2 servers for the load balancer's target group.


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

The Pelias update job wasn't firing correctly in certain cases where the server was already deployed. The Pelias update job trigger is in this PR is moved to immediately after the build, so that it only fires if the build is successful. 
