### PR TITLE
Fix otp runner e2e

### DIFF
--- a/src/main/java/com/conveyal/datatools/manager/jobs/DeployJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/DeployJob.java
@@ -402,12 +402,12 @@ public class DeployJob extends MonitorableJob {
                     status.fail("Failed to create directories for otp-runner E2E manifest.");
                     return;
                 }
+                otpManifestFile.createNewFile();
                 try (
                     FileWriter fw =  new FileWriter(otpManifestFile)
                 ) {
                     ObjectMapper mapper = new ObjectMapper();
                     mapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
-                    otpManifestFile.createNewFile();
                     fw.write(mapper.writeValueAsString(manifest));
                 } catch (JsonProcessingException e) {
                     status.fail("Failed to create E2E manifest for otp-runner!", e);

--- a/src/main/java/com/conveyal/datatools/manager/jobs/DeployJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/DeployJob.java
@@ -397,10 +397,14 @@ public class DeployJob extends MonitorableJob {
                 // Write manifest to temp file (create dirs also if needed).
                 String otpRunnerManifestFile = String.format("/tmp/%s/otp-runner-manifest.json", getTripPlannerString());
                 File otpManifestFile = new File(otpRunnerManifestFile);
-                boolean mkdirSucceeded = otpManifestFile.mkdirs();
-                if (!mkdirSucceeded) {
-                    status.fail("Failed to create directories for otp-runner E2E manifest.");
-                    return;
+                if (otpManifestFile.exists()) {
+                    otpManifestFile.delete();
+                } else {
+                    boolean mkdirSucceeded = otpManifestFile.getParentFile().mkdirs();
+                    if (!mkdirSucceeded) {
+                        status.fail("Failed to create directories for otp-runner E2E manifest.");
+                        return;
+                    }
                 }
                 otpManifestFile.createNewFile();
                 try (

--- a/src/main/java/com/conveyal/datatools/manager/jobs/DeployJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/DeployJob.java
@@ -394,8 +394,8 @@ public class DeployJob extends MonitorableJob {
                 // (In E2E environments, there is already an OTP instance running in the background)
                 manifest.runServer = false;
 
-                // Write manifest to file (create dirs also if needed).
-                String otpRunnerManifestFile = String.format("/var/%s/otp-runner-manifest.json", getTripPlannerString());
+                // Write manifest to temp file (create dirs also if needed).
+                String otpRunnerManifestFile = String.format("/tmp/%s/otp-runner-manifest.json", getTripPlannerString());
                 File otpManifestFile = new File(otpRunnerManifestFile);
                 boolean mkdirSucceeded = otpManifestFile.mkdirs();
                 if (!mkdirSucceeded) {

--- a/src/main/java/com/conveyal/datatools/manager/jobs/DeployJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/DeployJob.java
@@ -394,9 +394,14 @@ public class DeployJob extends MonitorableJob {
                 // (In E2E environments, there is already an OTP instance running in the background)
                 manifest.runServer = false;
 
-                // Write manifest to file
+                // Write manifest to file (create dirs also if needed).
                 String otpRunnerManifestFile = String.format("/var/%s/otp-runner-manifest.json", getTripPlannerString());
                 File otpManifestFile = new File(otpRunnerManifestFile);
+                boolean mkdirSucceeded = otpManifestFile.mkdirs();
+                if (!mkdirSucceeded) {
+                    status.fail("Failed to create directories for otp-runner E2E manifest.");
+                    return;
+                }
                 try (
                     FileWriter fw =  new FileWriter(otpManifestFile)
                 ) {
@@ -416,10 +421,7 @@ public class DeployJob extends MonitorableJob {
                 // Run otp-runner with the manifest produced earlier.
                 Process p = Runtime.getRuntime().exec(String.format("otp-runner %s", otpRunnerManifestFile));
                 p.waitFor();
-                System.out.println("otp-runner exit code: " + p.exitValue());
-
-                // Remove the otp-runner install.
-                //Runtime.getRuntime().exec("yarn global remove https://github.com/ibi-group/otp-runner.git");
+                System.out.println(String.format("otp-runner exit code: %d", p.exitValue()));
             } catch (IOException e) {
                 e.printStackTrace();
             } catch (InterruptedException e) {


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [na] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [ ] All tests and CI builds passing

### Description

This PR helps address errors in datatools E2E tests that are run from the datatools-ui repo.
Changes include constructing an otp-runner manifest file, so that a new graph is built and loaded by the test OTP instance for the e2e test deployment.
