### PR TITLE
Support Dropping Pelias DB

### DIFF
--- a/src/main/java/com/conveyal/datatools/manager/jobs/DeployJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/DeployJob.java
@@ -344,7 +344,7 @@ public class DeployJob extends MonitorableJob {
             AmazonS3URI logUploadS3URI = getS3FolderURI();
 
             // Execute the pelias update job and keep track of it
-            PeliasUpdateJob peliasUpdateJob = new PeliasUpdateJob(owner, "Updating Custom Geocoder Database", deployment, logUploadS3URI);
+            PeliasUpdateJob peliasUpdateJob = new PeliasUpdateJob(owner, "Updating Local Places Index", deployment, logUploadS3URI);
             addNextJob(peliasUpdateJob);
         }
 

--- a/src/main/java/com/conveyal/datatools/manager/jobs/PeliasUpdateJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/PeliasUpdateJob.java
@@ -131,7 +131,7 @@ public class PeliasUpdateJob extends MonitorableJob {
         peliasWebhookRequestBody.csvFiles = deployment.peliasCsvFiles;
         peliasWebhookRequestBody.logUploadUrl = logUploadS3URI.toString();
         peliasWebhookRequestBody.deploymentId = deployment.id;
-        peliasWebhookRequestBody.resetDb = deployment.peliasReset;
+        peliasWebhookRequestBody.resetDb = deployment.peliasResetDb;
 
         String query = JsonUtil.toJson(peliasWebhookRequestBody);
 

--- a/src/main/java/com/conveyal/datatools/manager/jobs/PeliasUpdateJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/PeliasUpdateJob.java
@@ -131,6 +131,7 @@ public class PeliasUpdateJob extends MonitorableJob {
         peliasWebhookRequestBody.csvFiles = deployment.peliasCsvFiles;
         peliasWebhookRequestBody.logUploadUrl = logUploadS3URI.toString();
         peliasWebhookRequestBody.deploymentId = deployment.id;
+        peliasWebhookRequestBody.resetDb = deployment.peliasReset;
 
         String query = JsonUtil.toJson(peliasWebhookRequestBody);
 
@@ -203,6 +204,7 @@ public class PeliasUpdateJob extends MonitorableJob {
         public List<String> csvFiles;
         public String logUploadUrl;
         public String deploymentId;
+        public boolean resetDb;
     }
 
     /**

--- a/src/main/java/com/conveyal/datatools/manager/models/Deployment.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/Deployment.java
@@ -76,6 +76,7 @@ public class Deployment extends Model implements Serializable {
     /* Pelias fields, used to determine where/if to send data to the Pelias webhook */
     public String peliasWebhookUrl;
     public boolean peliasUpdate;
+    public boolean peliasReset;
     public List<String> peliasCsvFiles = new ArrayList<>();
 
     /**

--- a/src/main/java/com/conveyal/datatools/manager/models/Deployment.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/Deployment.java
@@ -76,7 +76,7 @@ public class Deployment extends Model implements Serializable {
     /* Pelias fields, used to determine where/if to send data to the Pelias webhook */
     public String peliasWebhookUrl;
     public boolean peliasUpdate;
-    public boolean peliasReset;
+    public boolean peliasResetDb;
     public List<String> peliasCsvFiles = new ArrayList<>();
 
     /**


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Adds a new field to the Pelias webhook config that adds support for using the DB-dropping functionality added in https://github.com/ibi-group/transit-pois-pelias/pull/5