### PR TITLE
Update `gtfs-lib`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -270,7 +270,7 @@
         <dependency>
             <groupId>com.github.conveyal</groupId>
             <artifactId>gtfs-lib</artifactId>
-            <version>7.0.3</version>
+            <version>7.0.4</version>
             <!-- Exclusions added in order to silence SLF4J warnings about multiple bindings:
                 http://www.slf4j.org/codes.html#multiple_bindings
             -->

--- a/src/main/java/com/conveyal/datatools/manager/jobs/feedmerge/MergeLineContext.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/feedmerge/MergeLineContext.java
@@ -601,7 +601,7 @@ public class MergeLineContext {
                         skipRecord = true;
                         continue;
                     }
-                } else if (job.mergeType.equals(REGIONAL)){
+                } else if (job.mergeType.equals(REGIONAL)) {
                     // If merging feed versions from different agencies, the reference id is updated to avoid conflicts.
                     // e.g. stop_id becomes Fake_Agency2:123 instead of 123. This method allows referencing fields to be
                     // updated to the newer id.

--- a/src/main/java/com/conveyal/datatools/manager/jobs/feedmerge/MergeLineContext.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/feedmerge/MergeLineContext.java
@@ -601,9 +601,13 @@ public class MergeLineContext {
                         skipRecord = true;
                         continue;
                     }
+                } else {
+                    // TODO: this method renames a lot of fields which don't seem to be updated
+                    // when using SERVICE_PERIOD. However, it may do other things which are needed even when
+                    // using SERVICE_PERIOD
+                    checkFieldsForReferences(fieldContext);
                 }
 
-                checkFieldsForReferences(fieldContext);
 
                 // If the current field is a foreign reference, check if the reference has been removed in the
                 // merged result. If this is the case (or other conditions are met), we will need to skip this

--- a/src/main/java/com/conveyal/datatools/manager/jobs/feedmerge/MergeLineContext.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/feedmerge/MergeLineContext.java
@@ -601,13 +601,12 @@ public class MergeLineContext {
                         skipRecord = true;
                         continue;
                     }
-                } else {
-                    // TODO: this method renames a lot of fields which don't seem to be updated
-                    // when using SERVICE_PERIOD. However, it may do other things which are needed even when
-                    // using SERVICE_PERIOD
+                } else if (job.mergeType.equals(REGIONAL)){
+                    // If merging feed versions from different agencies, the reference id is updated to avoid conflicts.
+                    // e.g. stop_id becomes Fake_Agency2:123 instead of 123. This method allows referencing fields to be
+                    // updated to the newer id.
                     checkFieldsForReferences(fieldContext);
                 }
-
 
                 // If the current field is a foreign reference, check if the reference has been removed in the
                 // merged result. If this is the case (or other conditions are met), we will need to skip this

--- a/src/main/java/com/conveyal/datatools/manager/jobs/feedmerge/StopsMergeLineContext.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/feedmerge/StopsMergeLineContext.java
@@ -47,8 +47,8 @@ public class StopsMergeLineContext extends MergeLineContext {
             String parentStation = fieldContext.getValue();
             if (!"".equals(parentStation)) {
                 LOG.debug("Updating parent station to: {}", getIdWithScope(parentStation));
-                updateAndRemapOutput(fieldContext);
                 fieldContext.resetValue(getIdWithScope(parentStation));
+                updateAndRemapOutput(fieldContext);
             }
         }
     }

--- a/src/main/java/com/conveyal/datatools/manager/jobs/feedmerge/StopsMergeLineContext.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/feedmerge/StopsMergeLineContext.java
@@ -46,9 +46,9 @@ public class StopsMergeLineContext extends MergeLineContext {
         if (fieldContext.nameEquals("parent_station")) {
             String parentStation = fieldContext.getValue();
             if (!"".equals(parentStation)) {
-                updateAndRemapOutput(fieldContext);
                 LOG.debug("Updating parent station to: {}", getIdWithScope(parentStation));
-                fieldContext.resetValue(parentStation);
+                updateAndRemapOutput(fieldContext);
+                fieldContext.resetValue(getIdWithScope(parentStation));
             }
         }
     }

--- a/src/main/java/com/conveyal/datatools/manager/jobs/feedmerge/StopsMergeLineContext.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/feedmerge/StopsMergeLineContext.java
@@ -46,9 +46,9 @@ public class StopsMergeLineContext extends MergeLineContext {
         if (fieldContext.nameEquals("parent_station")) {
             String parentStation = fieldContext.getValue();
             if (!"".equals(parentStation)) {
+                updateAndRemapOutput(fieldContext);
                 LOG.debug("Updating parent station to: {}", getIdWithScope(parentStation));
                 fieldContext.resetValue(parentStation);
-                updateAndRemapOutput(fieldContext);
             }
         }
     }

--- a/src/main/java/com/conveyal/datatools/manager/jobs/feedmerge/StopsMergeLineContext.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/feedmerge/StopsMergeLineContext.java
@@ -48,7 +48,6 @@ public class StopsMergeLineContext extends MergeLineContext {
             if (!"".equals(parentStation)) {
                 LOG.debug("Updating parent station to: {}", getIdWithScope(parentStation));
                 updateAndRemapOutput(fieldContext);
-                fieldContext.resetValue(getIdWithScope(parentStation));
             }
         }
     }

--- a/src/main/java/com/conveyal/datatools/manager/jobs/feedmerge/StopsMergeLineContext.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/feedmerge/StopsMergeLineContext.java
@@ -47,8 +47,8 @@ public class StopsMergeLineContext extends MergeLineContext {
             String parentStation = fieldContext.getValue();
             if (!"".equals(parentStation)) {
                 LOG.debug("Updating parent station to: {}", getIdWithScope(parentStation));
-                fieldContext.resetValue(getIdWithScope(parentStation));
                 updateAndRemapOutput(fieldContext);
+                fieldContext.resetValue(getIdWithScope(parentStation));
             }
         }
     }


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR updates `gtfs-lib`. Part of that release includes https://github.com/conveyal/gtfs-lib/pull/275 which validates parent stations. As part of this, the new validator found a bug in the merge code where the stop_id is only sometimes changed, although it's always updated. We've solved this by changing the logic a little bit, but are unsure if this has unforeseen implications (although all the tests pass). @br648 as author of the code could you possibly double check that everything is still as expected?
