### PR TITLE
Improve feed versions load

### DIFF
--- a/src/main/java/com/conveyal/datatools/manager/controllers/api/FeedVersionController.java
+++ b/src/main/java/com/conveyal/datatools/manager/controllers/api/FeedVersionController.java
@@ -15,6 +15,7 @@ import com.conveyal.datatools.manager.models.FeedDownloadToken;
 import com.conveyal.datatools.manager.models.FeedRetrievalMethod;
 import com.conveyal.datatools.manager.models.FeedSource;
 import com.conveyal.datatools.manager.models.FeedVersion;
+import com.conveyal.datatools.manager.models.FeedVersionSummary;
 import com.conveyal.datatools.manager.models.JsonViews;
 import com.conveyal.datatools.manager.models.Snapshot;
 import com.conveyal.datatools.manager.persistence.Persistence;
@@ -66,12 +67,13 @@ public class FeedVersionController  {
     }
 
     /**
-     * Get all feed versions for a given feedSource (whose ID is specified in the request).
+     * Get all feed version summaries for a given feedSource (whose ID is specified in the request).
      */
-    private static Collection<FeedVersion> getAllFeedVersionsForFeedSource01(Request req, Response res) {
+    private static Collection<FeedVersionSummary> getAllFeedVersionSummariesForFeedSource(Request req, Response res) {
         // Check permissions and get the FeedSource whose FeedVersions we want.
         FeedSource feedSource = requestFeedSourceById(req, Actions.VIEW);
-        return feedSource.retrieveFeedVersionSummaries();
+        Collection<FeedVersionSummary> feedVersions = feedSource.retrieveFeedVersionSummaries();
+        return feedVersions;
     }
 
     /**
@@ -422,7 +424,7 @@ public class FeedVersionController  {
         get(apiPrefix + "secure/feedversion/:id/download", FeedVersionController::downloadFeedVersionDirectly);
         get(apiPrefix + "secure/feedversion/:id/downloadtoken", FeedVersionController::getDownloadCredentials, json::write);
         post(apiPrefix + "secure/feedversion/:id/validate", FeedVersionController::validate, json::write);
-        //get(apiPrefix + "secure/feedversionsummaries", FeedVersionController::getAllFeedVersionsForFeedSource, json::write);
+        get(apiPrefix + "secure/feedversionsummaries", FeedVersionController::getAllFeedVersionSummariesForFeedSource, json::write);
         get(apiPrefix + "secure/feedversion", FeedVersionController::getAllFeedVersionsForFeedSource, json::write);
         post(apiPrefix + "secure/feedversion", FeedVersionController::createFeedVersionViaUpload, json::write);
         post(apiPrefix + "secure/feedversion/shapes", FeedVersionController::exportGis, json::write);
@@ -433,6 +435,7 @@ public class FeedVersionController  {
         delete(apiPrefix + "secure/feedversion/:id", FeedVersionController::deleteFeedVersion, json::write);
 
         get(apiPrefix + "public/feedversion", FeedVersionController::getAllFeedVersionsForFeedSource, json::write);
+        //get(apiPrefix + "public/feedversionsummaries", FeedVersionController::getAllFeedVersionSummariesForFeedSource, json::write);
         get(apiPrefix + "public/feedversion/:id/downloadtoken", FeedVersionController::getDownloadCredentials, json::write);
 
         get(apiPrefix + "downloadfeed/:token", FeedVersionController::downloadFeedVersionWithToken);

--- a/src/main/java/com/conveyal/datatools/manager/controllers/api/FeedVersionController.java
+++ b/src/main/java/com/conveyal/datatools/manager/controllers/api/FeedVersionController.java
@@ -71,8 +71,7 @@ public class FeedVersionController  {
      */
     private static Collection<FeedVersionSummary> getAllFeedVersionSummariesForFeedSource(Request req, Response res) {
         FeedSource feedSource = requestFeedSourceById(req, Actions.VIEW);
-        Collection<FeedVersionSummary> feedVersions = feedSource.retrieveFeedVersionSummaries();
-        return feedVersions;
+        return feedSource.retrieveFeedVersionSummaries();
     }
 
     /**

--- a/src/main/java/com/conveyal/datatools/manager/controllers/api/FeedVersionController.java
+++ b/src/main/java/com/conveyal/datatools/manager/controllers/api/FeedVersionController.java
@@ -435,7 +435,7 @@ public class FeedVersionController  {
         delete(apiPrefix + "secure/feedversion/:id", FeedVersionController::deleteFeedVersion, json::write);
 
         get(apiPrefix + "public/feedversion", FeedVersionController::getAllFeedVersionsForFeedSource, json::write);
-        //get(apiPrefix + "public/feedversionsummaries", FeedVersionController::getAllFeedVersionSummariesForFeedSource, json::write);
+        get(apiPrefix + "public/feedversionsummaries", FeedVersionController::getAllFeedVersionSummariesForFeedSource, json::write);
         get(apiPrefix + "public/feedversion/:id/downloadtoken", FeedVersionController::getDownloadCredentials, json::write);
 
         get(apiPrefix + "downloadfeed/:token", FeedVersionController::downloadFeedVersionWithToken);

--- a/src/main/java/com/conveyal/datatools/manager/controllers/api/FeedVersionController.java
+++ b/src/main/java/com/conveyal/datatools/manager/controllers/api/FeedVersionController.java
@@ -68,6 +68,15 @@ public class FeedVersionController  {
     /**
      * Get all feed versions for a given feedSource (whose ID is specified in the request).
      */
+    private static Collection<FeedVersion> getAllFeedVersionsForFeedSource01(Request req, Response res) {
+        // Check permissions and get the FeedSource whose FeedVersions we want.
+        FeedSource feedSource = requestFeedSourceById(req, Actions.VIEW);
+        return feedSource.retrieveFeedVersionSummaries();
+    }
+
+    /**
+     * Get all feed versions for a given feedSource (whose ID is specified in the request).
+     */
     private static Collection<FeedVersion> getAllFeedVersionsForFeedSource(Request req, Response res) {
         // Check permissions and get the FeedSource whose FeedVersions we want.
         FeedSource feedSource = requestFeedSourceById(req, Actions.VIEW);
@@ -413,6 +422,7 @@ public class FeedVersionController  {
         get(apiPrefix + "secure/feedversion/:id/download", FeedVersionController::downloadFeedVersionDirectly);
         get(apiPrefix + "secure/feedversion/:id/downloadtoken", FeedVersionController::getDownloadCredentials, json::write);
         post(apiPrefix + "secure/feedversion/:id/validate", FeedVersionController::validate, json::write);
+        //get(apiPrefix + "secure/feedversionsummaries", FeedVersionController::getAllFeedVersionsForFeedSource, json::write);
         get(apiPrefix + "secure/feedversion", FeedVersionController::getAllFeedVersionsForFeedSource, json::write);
         post(apiPrefix + "secure/feedversion", FeedVersionController::createFeedVersionViaUpload, json::write);
         post(apiPrefix + "secure/feedversion/shapes", FeedVersionController::exportGis, json::write);

--- a/src/main/java/com/conveyal/datatools/manager/controllers/api/FeedVersionController.java
+++ b/src/main/java/com/conveyal/datatools/manager/controllers/api/FeedVersionController.java
@@ -70,7 +70,6 @@ public class FeedVersionController  {
      * Get all feed version summaries for a given feedSource (whose ID is specified in the request).
      */
     private static Collection<FeedVersionSummary> getAllFeedVersionSummariesForFeedSource(Request req, Response res) {
-        // Check permissions and get the FeedSource whose FeedVersions we want.
         FeedSource feedSource = requestFeedSourceById(req, Actions.VIEW);
         Collection<FeedVersionSummary> feedVersions = feedSource.retrieveFeedVersionSummaries();
         return feedVersions;

--- a/src/main/java/com/conveyal/datatools/manager/models/FeedSource.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/FeedSource.java
@@ -52,7 +52,6 @@ import static com.conveyal.datatools.manager.utils.StringUtils.getCleanName;
 import static com.mongodb.client.model.Filters.and;
 import static com.mongodb.client.model.Filters.eq;
 import static com.mongodb.client.model.Filters.in;
-import static com.mongodb.client.model.Projections.include;
 import static com.mongodb.client.model.Updates.pull;
 
 /**
@@ -551,18 +550,7 @@ public class FeedSource extends Model implements Cloneable {
     @JsonIgnore
     public Collection<FeedVersionSummary> retrieveFeedVersionSummaries() {
         return Persistence.feedVersionSummaries
-            .getFilteredWithProjection(
-                eq("feedSourceId", this.id),
-                include(
-                    "dateCreated",
-                    "lastUpdated",
-                    "retrievalMethod",
-                    "version",
-                    "name",
-                    "namespace",
-                    "fileSize"
-                )
-            );
+            .getFiltered(eq("feedSourceId", this.id));
     }
 
     /**

--- a/src/main/java/com/conveyal/datatools/manager/models/FeedSource.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/FeedSource.java
@@ -549,18 +549,22 @@ public class FeedSource extends Model implements Cloneable {
      * @return collection of feed versions
      */
     @JsonIgnore
-    public Collection<FeedVersion> retrieveFeedVersionSummaries() {
-        return Persistence.feedVersions.getFilteredWithProjection(
-            eq("feedSourceId", this.id),
-            include(
-                "dateCreated",
-                "lastUpdated",
-                "retrievalMethod",
-                "version",
-                "name",
-                "namespace"
+    public Collection<FeedVersionSummary> retrieveFeedVersionSummaries() {
+        return Persistence.feedVersions
+            .getFilteredWithProjection(
+                eq("feedSourceId", this.id),
+                include(
+                    "dateCreated",
+                    "lastUpdated",
+                    "retrievalMethod",
+                    "version",
+                    "name",
+                    "namespace"
+                )
             )
-        );
+            .stream()
+            .map(FeedVersionSummary::new)
+            .collect(Collectors.toList());
     }
 
     /**

--- a/src/main/java/com/conveyal/datatools/manager/models/FeedSource.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/FeedSource.java
@@ -559,7 +559,8 @@ public class FeedSource extends Model implements Cloneable {
                     "retrievalMethod",
                     "version",
                     "name",
-                    "namespace"
+                    "namespace",
+                    "fileSize"
                 )
             )
             .stream()

--- a/src/main/java/com/conveyal/datatools/manager/models/FeedSource.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/FeedSource.java
@@ -549,8 +549,7 @@ public class FeedSource extends Model implements Cloneable {
      */
     @JsonIgnore
     public Collection<FeedVersionSummary> retrieveFeedVersionSummaries() {
-        return Persistence.feedVersionSummaries
-            .getFiltered(eq("feedSourceId", this.id));
+        return Persistence.feedVersionSummaries.getFiltered(eq("feedSourceId", this.id));
     }
 
     /**

--- a/src/main/java/com/conveyal/datatools/manager/models/FeedSource.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/FeedSource.java
@@ -52,6 +52,7 @@ import static com.conveyal.datatools.manager.utils.StringUtils.getCleanName;
 import static com.mongodb.client.model.Filters.and;
 import static com.mongodb.client.model.Filters.eq;
 import static com.mongodb.client.model.Filters.in;
+import static com.mongodb.client.model.Projections.include;
 import static com.mongodb.client.model.Updates.pull;
 
 /**
@@ -541,6 +542,25 @@ public class FeedSource extends Model implements Cloneable {
     @JsonIgnore
     public Collection<FeedVersion> retrieveFeedVersions() {
         return Persistence.feedVersions.getFiltered(eq("feedSourceId", this.id));
+    }
+
+    /**
+     * Get all of the feed versions for this source
+     * @return collection of feed versions
+     */
+    @JsonIgnore
+    public Collection<FeedVersion> retrieveFeedVersionSummaries() {
+        return Persistence.feedVersions.getFilteredWithProjection(
+            eq("feedSourceId", this.id),
+            include(
+                "dateCreated",
+                "lastUpdated",
+                "retrievalMethod",
+                "version",
+                "name",
+                "namespace"
+            )
+        );
     }
 
     /**

--- a/src/main/java/com/conveyal/datatools/manager/models/FeedSource.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/FeedSource.java
@@ -545,12 +545,12 @@ public class FeedSource extends Model implements Cloneable {
     }
 
     /**
-     * Get all of the feed versions for this source
-     * @return collection of feed versions
+     * Get the summary information for all feed versions for this source.
+     * @return collection of feed version summaries.
      */
     @JsonIgnore
     public Collection<FeedVersionSummary> retrieveFeedVersionSummaries() {
-        return Persistence.feedVersions
+        return Persistence.feedVersionSummaries
             .getFilteredWithProjection(
                 eq("feedSourceId", this.id),
                 include(
@@ -562,10 +562,7 @@ public class FeedSource extends Model implements Cloneable {
                     "namespace",
                     "fileSize"
                 )
-            )
-            .stream()
-            .map(FeedVersionSummary::new)
-            .collect(Collectors.toList());
+            );
     }
 
     /**

--- a/src/main/java/com/conveyal/datatools/manager/models/FeedVersionSummary.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/FeedVersionSummary.java
@@ -6,12 +6,9 @@ import java.util.Date;
 /**
  * Includes summary data (a subset of fields) for a feed version.
  */
-public class FeedVersionSummary implements Serializable {
+public class FeedVersionSummary extends Model implements Serializable {
     private static final long serialVersionUID = 1L;
 
-    public String id;
-    public Date lastUpdated;
-    public Date dateCreated;
     public FeedRetrievalMethod retrievalMethod;
     public int version;
     public String name;
@@ -21,16 +18,5 @@ public class FeedVersionSummary implements Serializable {
     /** Empty constructor for serialization */
     public FeedVersionSummary() {
         // Do nothing
-    }
-
-    public FeedVersionSummary(FeedVersion feedVersion) {
-        id = feedVersion.id;
-        dateCreated = feedVersion.dateCreated;
-        lastUpdated = feedVersion.lastUpdated;
-        retrievalMethod = feedVersion.retrievalMethod;
-        version = feedVersion.version;
-        name = feedVersion.name;
-        namespace = feedVersion.namespace;
-        fileSize = feedVersion.fileSize;
     }
 }

--- a/src/main/java/com/conveyal/datatools/manager/models/FeedVersionSummary.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/FeedVersionSummary.java
@@ -14,6 +14,7 @@ public class FeedVersionSummary extends Model implements Serializable {
     public String name;
     public String namespace;
     public Long fileSize;
+    public Date updated;
 
     /** Empty constructor for serialization */
     public FeedVersionSummary() {

--- a/src/main/java/com/conveyal/datatools/manager/models/FeedVersionSummary.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/FeedVersionSummary.java
@@ -13,6 +13,7 @@ public class FeedVersionSummary extends Model implements Serializable {
     public int version;
     public String name;
     public String namespace;
+    public String originNamespace;
     public Long fileSize;
     public Date updated;
 

--- a/src/main/java/com/conveyal/datatools/manager/models/FeedVersionSummary.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/FeedVersionSummary.java
@@ -1,0 +1,36 @@
+package com.conveyal.datatools.manager.models;
+
+import java.io.Serializable;
+import java.util.Date;
+
+/**
+ * Includes summary data (a subset of fields) for a feed version.
+ */
+public class FeedVersionSummary implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    public String id;
+    public Date lastUpdated;
+    public Date dateCreated;
+    public FeedRetrievalMethod retrievalMethod;
+    public int version;
+    public String name;
+    public String namespace;
+    public Long fileSize;
+
+    /** Empty constructor for serialization */
+    public FeedVersionSummary() {
+        // Do nothing
+    }
+
+    public FeedVersionSummary(FeedVersion feedVersion) {
+        id = feedVersion.id;
+        dateCreated = feedVersion.dateCreated;
+        lastUpdated = feedVersion.lastUpdated;
+        retrievalMethod = feedVersion.retrievalMethod;
+        version = feedVersion.version;
+        name = feedVersion.name;
+        namespace = feedVersion.namespace;
+        fileSize = feedVersion.fileSize;
+    }
+}

--- a/src/main/java/com/conveyal/datatools/manager/persistence/Persistence.java
+++ b/src/main/java/com/conveyal/datatools/manager/persistence/Persistence.java
@@ -9,6 +9,7 @@ import com.conveyal.datatools.manager.models.ExternalFeedSourceProperty;
 import com.conveyal.datatools.manager.models.FeedDownloadToken;
 import com.conveyal.datatools.manager.models.FeedSource;
 import com.conveyal.datatools.manager.models.FeedVersion;
+import com.conveyal.datatools.manager.models.FeedVersionSummary;
 import com.conveyal.datatools.manager.models.Label;
 import com.conveyal.datatools.manager.models.Note;
 import com.conveyal.datatools.manager.models.Organization;
@@ -48,6 +49,7 @@ public class Persistence {
     public static TypedPersistence<Deployment> deployments;
     public static TypedPersistence<Project> projects;
     public static TypedPersistence<FeedVersion> feedVersions;
+    public static TypedPersistence<FeedVersionSummary> feedVersionSummaries;
     public static TypedPersistence<Note> notes;
     public static TypedPersistence<Organization> organizations;
     public static TypedPersistence<ExternalFeedSourceProperty> externalFeedSourceProperties;
@@ -110,6 +112,7 @@ public class Persistence {
         feedSources = new TypedPersistence(mongoDatabase, FeedSource.class);
         projects = new TypedPersistence(mongoDatabase, Project.class);
         feedVersions = new TypedPersistence(mongoDatabase, FeedVersion.class);
+        feedVersionSummaries = new TypedPersistence(mongoDatabase, FeedVersionSummary.class, "FeedVersion");
         deployments = new TypedPersistence(mongoDatabase, Deployment.class);
         notes = new TypedPersistence(mongoDatabase, Note.class);
         organizations = new TypedPersistence(mongoDatabase, Organization.class);

--- a/src/main/java/com/conveyal/datatools/manager/persistence/TypedPersistence.java
+++ b/src/main/java/com/conveyal/datatools/manager/persistence/TypedPersistence.java
@@ -18,7 +18,6 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
-import static com.mongodb.client.model.Filters.and;
 import static com.mongodb.client.model.Filters.eq;
 import static com.mongodb.client.model.Filters.in;
 import static com.mongodb.client.model.Updates.pull;
@@ -56,6 +55,9 @@ public class TypedPersistence<T extends Model> {
     private String collectionName;
     private final FindOneAndUpdateOptions findOneAndUpdateOptions = new FindOneAndUpdateOptions();
 
+    /**
+     * Maps a persistence class to a Mongo collection.
+     */
     public TypedPersistence(MongoDatabase mongoDatabase, Class<T> clazz, String collectionName) {
         mongoCollection = mongoDatabase.getCollection(collectionName, clazz);
         this.collectionName = collectionName;
@@ -72,7 +74,7 @@ public class TypedPersistence<T extends Model> {
     }
 
     /**
-     * Shorthand for above constructor
+     * Shorthand for above constructor using the class name as the collection name.
      */
     public TypedPersistence(MongoDatabase mongoDatabase, Class<T> clazz) {
         this(mongoDatabase, clazz, clazz.getSimpleName());
@@ -168,16 +170,6 @@ public class TypedPersistence<T extends Model> {
      */
     public List<T> getFiltered (Bson filter) {
         return mongoCollection.find(filter).into(new ArrayList<>());
-    }
-
-    /**
-     * Get all objects satisfying the supplied Mongo filter.
-     * This ties our persistence directly to Mongo for now but is expedient.
-     * We should really have a bit more abstraction here.
-     * @return
-     */
-    public List<T> getFilteredWithProjection (Bson filter, Bson projection) {
-        return mongoCollection.find(filter).projection(projection).into(new ArrayList<>());
     }
 
     /**

--- a/src/main/java/com/conveyal/datatools/manager/persistence/TypedPersistence.java
+++ b/src/main/java/com/conveyal/datatools/manager/persistence/TypedPersistence.java
@@ -56,9 +56,9 @@ public class TypedPersistence<T extends Model> {
     private String collectionName;
     private final FindOneAndUpdateOptions findOneAndUpdateOptions = new FindOneAndUpdateOptions();
 
-    public TypedPersistence(MongoDatabase mongoDatabase, Class<T> clazz) {
-        mongoCollection = mongoDatabase.getCollection(clazz.getSimpleName(), clazz);
-        collectionName = clazz.getSimpleName();
+    public TypedPersistence(MongoDatabase mongoDatabase, Class<T> clazz, String collectionName) {
+        mongoCollection = mongoDatabase.getCollection(collectionName, clazz);
+        this.collectionName = collectionName;
         try {
             noArgConstructor = clazz.getConstructor(new Class<?>[0]);
         } catch (NoSuchMethodException ex) {
@@ -69,6 +69,13 @@ public class TypedPersistence<T extends Model> {
 
         // TODO: can we merge update and create into createOrUpdate function using upsert option?
 //        findOneAndUpdateOptions.upsert(true);
+    }
+
+    /**
+     * Shorthand for above constructor
+     */
+    public TypedPersistence(MongoDatabase mongoDatabase, Class<T> clazz) {
+        this(mongoDatabase, clazz, clazz.getSimpleName());
     }
 
     /**

--- a/src/main/java/com/conveyal/datatools/manager/persistence/TypedPersistence.java
+++ b/src/main/java/com/conveyal/datatools/manager/persistence/TypedPersistence.java
@@ -164,6 +164,16 @@ public class TypedPersistence<T extends Model> {
     }
 
     /**
+     * Get all objects satisfying the supplied Mongo filter.
+     * This ties our persistence directly to Mongo for now but is expedient.
+     * We should really have a bit more abstraction here.
+     * @return
+     */
+    public List<T> getFilteredWithProjection (Bson filter, Bson projection) {
+        return mongoCollection.find(filter).projection(projection).into(new ArrayList<>());
+    }
+
+    /**
      * Expose the internal MongoCollection to the caller.
      * This ties our persistence directly to Mongo for now but is expedient.
      * We will write all the queries we need in the calling methods, then make an abstraction here on TypedPersistence


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR should fix #456 by adding a `feedversionsummaries` endpoint to used by the UI that returns only basic information about all feed versions. The complete feed version data is fetched later, on demand by the UI, and for specific feed versions only as opposed to all feed versions.

Sample comparison of loading times, running locally with a feed with 196 versions:
- Before (using `feedversions` endpoint): 65 kB, 3.15 s
- After (using `feedversionsummaries` endpoint): 15 kB 40 ms

