### PR TITLE
Skip autopublish if disabled in MTC config

### DIFF
--- a/src/main/java/com/conveyal/datatools/manager/jobs/ProcessSingleFeedJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/ProcessSingleFeedJob.java
@@ -151,10 +151,11 @@ public class ProcessSingleFeedJob extends FeedVersionJob {
             addNextJob(new AutoDeployJob(feedSource.retrieveProject(), owner));
         }
 
-        // If auto-publish job is enabled (MTC extension required),
-        // create an auto-publish job for feeds that are fetched automatically.
+        // If auto-publish is enabled for a feed source and not disabled (it should be disabled on developer machines),
+        // create an auto-publish job for feeds that are fetched automatically (MTC extension required).
         if (
             DataManager.isExtensionEnabled("mtc") &&
+                !"true".equals(DataManager.getExtensionPropertyAsText("mtc", "disableAutoPublish")) &&
                 feedSource.autoPublish &&
                 feedVersion.retrievalMethod == FeedRetrievalMethod.FETCHED_AUTOMATICALLY
         ) {


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [na] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [na] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR introduces a new MTC config flag `disableAutoPublish`.
If set to `true`, which would be the case almost all of the time on development machines, no auto-publishing of feeds to the external publisher would occur.
