### PR TITLE
Add /updatetrips endpoint for updating multiple trips in one request.

### DIFF
--- a/src/main/java/com/conveyal/datatools/editor/controllers/api/EditorController.java
+++ b/src/main/java/com/conveyal/datatools/editor/controllers/api/EditorController.java
@@ -119,8 +119,9 @@ public abstract class EditorController<T extends Entity> {
         // Delete entity request
         delete(ROOT_ROUTE + ID_PARAM, this::deleteOne, json::write);
 
-        // Handle special multiple delete method for trip endpoint
+        // Handle special multiple delete method and multiple update method for trip endpoint
         if ("trip".equals(classToLowercase)) {
+            post(ROOT_ROUTE + "/updatetrips", this::updateMultipleTrips, json::write);
             delete(ROOT_ROUTE, this::deleteMultipleTrips, json::write);
         }
 
@@ -130,6 +131,49 @@ public abstract class EditorController<T extends Entity> {
             put(ROOT_ROUTE + ID_PARAM + "/stop_times", this::updateStopTimesFromPatternStops, json::write);
             delete(ROOT_ROUTE + ID_PARAM + "/trips", this::deleteTripsForPattern, json::write);
         }
+    }
+
+    /**
+     * Endpoint to update multiple trips in a single transaction.
+     * Creation of this endpoint was prompted by the need to allow trip ID "flipping",
+     * where trip IDs may swap values in one request. Previously this case would cause an error
+     * since trips were saved one by one, without knowledge that a target trip ID had been "flipped".
+     */
+    private String updateMultipleTrips(Request req, Response res) {
+        /* TODO: Deleting all trips involved in the update is obviously
+            overkill and will have performance impacts. */
+        // FIXME: how does autoCommit in this method affect performance?
+        String namespace = getNamespaceAndValidateSession(req);
+        try {
+            JsonNode jsonNode = mapper.readTree(req.body());
+            JdbcTableWriter tableWriter = new JdbcTableWriter(table, datasource, namespace);
+            JsonNode trips = jsonNode.get("trips");
+            ArrayList<String> returnedJsonStrings = new ArrayList<>();
+
+            if (jsonNode == null) {
+                logMessageAndHalt(req, 400, "JSON body must be provided with trip update request.");
+            }
+            for (final JsonNode trip: trips) {
+                int id = trip.get("id").intValue();
+                // Id == -2 is the front end indication that the trip is being created.
+                if (id != -2){
+                    tableWriter.delete(id, false);
+                }
+            }
+            for (final JsonNode thisTrip: trips) {
+                String jsonBody = thisTrip.toString();
+                JsonNode lastTrip = trips.get(trips.size()-1);
+                Boolean isLastTrip = lastTrip.equals(thisTrip);
+                // Autocommit: true for last trip
+                returnedJsonStrings.add(tableWriter.create(jsonBody, isLastTrip));
+            }
+            return "[" + String.join(",", returnedJsonStrings) + "]";
+        }
+        catch (Exception e) {
+            e.printStackTrace();
+            logMessageAndHalt(req, 500, "Could not save trips", e);
+        }
+        return null;
     }
 
     /**


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR adds an endpoint to save multiple trips with one request, effectively moving the loop over edited timetable trips from the frontend to the backend. The new endpoint also changes saving behaviour by first deleting all of the referenced trips, and then re-saving new ones. This is done to allow trip ID swapping in one request which was previously causing errors, and which should be allowable user behaviour. The bug can be seen here: https://drive.google.com/file/d/1ho01C1DaF0apxMWDbJuRD195OeEYMgTu/view?usp=sharing

Looking for feedback on ways to improve performance, especially regarding the use of autocommits in the database connection. If you'd like, I have a front end branch which uses the new endpoint setup for testing purposes here: https://github.com/ibi-group/datatools-ui/tree/test-new-multitrip-endpoint
