### PR TITLE
fix(SparkUtils): Remove conflicting content encoding header data.

### DIFF
--- a/src/main/java/com/conveyal/datatools/common/utils/SparkUtils.java
+++ b/src/main/java/com/conveyal/datatools/common/utils/SparkUtils.java
@@ -53,9 +53,9 @@ public class SparkUtils {
         if (file == null) logMessageAndHalt(req, 404, "File is null");
         HttpServletResponse raw = res.raw();
         raw.setContentType("application/octet-stream");
-        raw.setHeader("Content-Disposition", "attachment; filename=" + filename);
         // Override the gzip content encoding applied to standard API responses.
-        res.header("Content-Encoding", "identity");
+        raw.setHeader("Content-Encoding", "identity");
+        raw.setHeader("Content-Disposition", "attachment; filename=" + filename);
         try (
             FileInputStream fileInputStream = new FileInputStream(file);
             ServletOutputStream outputStream = raw.getOutputStream()


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [na] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Fix https://github.com/ibi-group/datatools-ui/issues/762, fix https://github.com/ibi-group/datatools-ui/issues/710.
