### PR TITLE
Delete feed lock via navigator.sendBeacon

### DIFF
--- a/src/main/java/com/conveyal/datatools/editor/controllers/EditorLockController.java
+++ b/src/main/java/com/conveyal/datatools/editor/controllers/EditorLockController.java
@@ -35,8 +35,6 @@ public class EditorLockController {
 
 
     private static String lockFeed (Request req, Response res) {
-        // FIXME: why is content type not being set in before()/after()?
-        res.type("application/json");
         Auth0UserProfile userProfile = req.attribute("user");
         String feedId = req.queryParams("feedId");
         EditorSession currentSession = sessionsForFeedIds.get(feedId);
@@ -95,13 +93,10 @@ public class EditorLockController {
     private static String invalidateAndCreateNewSession(Request req) {
         req.session().invalidate();
         Session session = req.session(true);
-        String newSessionId = session.id();
-        return newSessionId;
+        return session.id();
     }
 
     private static String maintainLock(Request req, Response res) {
-        // FIXME: why is content type not being set in before()/after()?
-        res.type("application/json");
         String sessionId = req.params("id");
         String feedId = req.queryParams("feedId");
         Auth0UserProfile userProfile = req.attribute("user");
@@ -121,7 +116,7 @@ public class EditorLockController {
             if (currentSession.userEmail.equals(userProfile.getEmail())) {
                 // If the new current session is held by this user, give them the option to evict the current session /
                 // unlock the feed.
-                LOG.warn("User {} already has an active editor session () for feed {}.", userProfile.getEmail(), currentSession.sessionId, currentSession.feedId);
+                LOG.warn("User {} already has an active editor session {} for feed {}.", userProfile.getEmail(), currentSession.sessionId, currentSession.feedId);
                 logMessageAndHalt(req, 400, "Warning! You have an active editing session for this feed underway in a different browser tab.");
             } else {
                 LOG.warn("User {} attempted editor session for feed {} while active session underway for user {}.", userProfile.getEmail(), currentSession.feedId, currentSession.userEmail);
@@ -132,7 +127,6 @@ public class EditorLockController {
             // Otherwise, the current session matches the session the user is attempting to maintain. Update the
             // lastEdited time.
             currentSession.lastCheckIn = System.currentTimeMillis();
-//            LOG.info("Updating session {} check-in time to {} for user {}", currentSession.sessionId, currentSession.lastCheckIn, currentSession.userEmail);
             return formatJSON("Updating time for user " + currentSession.userEmail, 200, feedId, null);
         }
     }
@@ -141,7 +135,7 @@ public class EditorLockController {
      * Normal path for deleting a feed lock.
      */
     private static String deleteFeedLock(Request req, Response res) {
-        return deleteFeedLock(req, res, req.attribute("user"));
+        return deleteFeedLockCore(req, req.attribute("user"));
     }
 
     /**
@@ -149,12 +143,10 @@ public class EditorLockController {
      */
     private static String deleteFeedLockBeacon(Request req, Response res) {
         // The sendBeacon call does not contain any Authorization headers, so we just pass a null userProfile.
-        return deleteFeedLock(req, res, null);
+        return deleteFeedLockCore(req, null);
     }
 
-    private static String deleteFeedLock(Request req, Response res, Auth0UserProfile userProfile) {
-        // FIXME: why is content type not being set in before()/after()?
-        res.type("application/json");
+    private static String deleteFeedLockCore(Request req, Auth0UserProfile userProfile) {
         String feedId = req.queryParams("feedId");
         String sessionId = req.params("id");
         EditorSession currentSession = sessionsForFeedIds.get(feedId);
@@ -167,7 +159,7 @@ public class EditorLockController {
             // Note: There used to be a check here that the requesting user was the same as the user with an open
             // session; however, this has been removed because in practice it became a nuisance. Respectful users with
             // shared access to a feed can generally be trusted not to boot one another out in a combative manner.
-            boolean overwrite = Boolean.valueOf(req.queryParams("overwrite"));
+            boolean overwrite = Boolean.parseBoolean(req.queryParams("overwrite"));
             if (userProfile != null && overwrite) {
                 sessionId = invalidateAndCreateNewSession(req);
                 EditorSession newEditorSession = new EditorSession(feedId, sessionId, userProfile);


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Partial solution for https://github.com/ibi-group/datatools-ui/issues/175, https://github.com/ibi-group/datatools-ui/issues/179

This PR introduces an additional endpoint to support deleting an editor feed lock via the browser's [`navigator.sendBeacon` method](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/sendBeacon), which makes a "last-gasp", unauthenticated POST request before the corresponding editor tab/window is closed/reloaded/navigated away. (Regular fetch/XMLHttpRequest calls are dropped by Chrome in such situations.)

Also included in this PR are removal of FIXMEs regarding setting the application type and minor refactors.
