### PR TITLE
Support locking individual items in a feed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -261,8 +261,8 @@
         <dependency>
             <groupId>com.github.conveyal</groupId>
             <artifactId>gtfs-lib</artifactId>
-            <!-- gtfs-lib 7.1.0 + fix for trip pattern loading + others before -->
-            <version>3826eeda92f488f9d9ab4022d08be3b1281980de</version>
+            <!-- Latest dev build on jitpack.io -->
+            <version>ca419a8149</version>
             <!-- Exclusions added in order to silence SLF4J warnings about multiple bindings:
                 http://www.slf4j.org/codes.html#multiple_bindings
             -->

--- a/pom.xml
+++ b/pom.xml
@@ -197,15 +197,6 @@
                 <updatePolicy>always</updatePolicy>
             </snapshots>
         </repository>
-        <repository>
-            <id>boundless</id>
-            <name>Boundless Maven Repository</name>
-            <url>https://repo.boundlessgeo.com/main</url>
-            <snapshots>
-                <enabled>true</enabled>
-                <updatePolicy>always</updatePolicy>
-            </snapshots>
-        </repository>
         <!--  used for importing java projects from github -->
         <repository>
             <id>jitpack.io</id>

--- a/src/main/java/com/conveyal/datatools/editor/controllers/EditorLockController.java
+++ b/src/main/java/com/conveyal/datatools/editor/controllers/EditorLockController.java
@@ -30,8 +30,8 @@ public class EditorLockController {
 
     private static final JsonManager<EditorLockController> json = new JsonManager<>(EditorLockController.class, JsonViews.UserInterface.class);
     private static final Logger LOG = LoggerFactory.getLogger(EditorLockController.class);
-    public static final Map<String, EditorSession> sessionsForFeedIds = new HashMap<>();
-    private static final long SESSION_LENGTH_IN_SECONDS = 10 * 60; // Ten minutes
+    private static final Map<String, EditorSession> sessionsForFeedIds = new HashMap<>();
+    private static final long SESSION_LENGTH_IN_SECONDS = 10 * 60L; // Ten minutes
 
     /**
      * Holds useful data from an editor lock request.
@@ -43,17 +43,12 @@ public class EditorLockController {
         public final String itemToLock;
         public final String sessionId;
 
-        public ParsedRequest(Request req, String sessionId, String itemToLock) {
+        public ParsedRequest(Request req) {
             this.request = req;
             this.userProfile = req.attribute("user");
             this.feedId = req.queryParams("feedId");
-            this.itemToLock = itemToLock;
-            this.sessionId = sessionId;
-            System.out.println("sessionId: " + sessionId);
-        }
-
-        public ParsedRequest(Request req) {
-            this(req, req.params("id"), req.queryParamOrDefault("item", ""));
+            this.itemToLock = req.queryParamOrDefault("item", "");
+            this.sessionId = req.params("id");
         }
 
         /**
@@ -66,8 +61,21 @@ public class EditorLockController {
         }
     }
 
+    /**
+     * Returns the current session based on the info provided.
+     */
     public static EditorSession getCurrentSession(ParsedRequest req) {
         return sessionsForFeedIds.get(req.getSessionKey());
+    }
+
+    /**
+     * Returns the session based on its id.
+     */
+    public static EditorSession getSession(String sessionId) {
+        return sessionsForFeedIds.values().stream()
+            .filter(s -> s.sessionId.equals(sessionId))
+            .findFirst()
+            .orElse(null);
     }
 
     private static String lockFeed (Request req, Response res) {

--- a/src/main/java/com/conveyal/datatools/editor/controllers/EditorLockController.java
+++ b/src/main/java/com/conveyal/datatools/editor/controllers/EditorLockController.java
@@ -107,7 +107,7 @@ public class EditorLockController {
         EditorSession newEditorSession = new EditorSession(req.feedId, newSessionId, req.userProfile, req.itemToLock);
         sessionsForFeedIds.put(req.getSessionKey(), newEditorSession);
         LOG.info("{} (Session ID: {})", logMessage, newSessionId);
-        return formatJSON(message, req.feedId, newSessionId);
+        return formatSuccessJSON(message, req.feedId, newSessionId);
     }
 
     private static String getLockedFeedMessage(EditorSession session) {
@@ -155,7 +155,7 @@ public class EditorLockController {
             // If the current session matches the session the user is attempting to maintain. Update the
             // lastEdited time.
             currentSession.lastCheckIn = System.currentTimeMillis();
-            return formatJSON("Updating time for user " + currentSession.userEmail, parsedReq.feedId, null);
+            return formatSuccessJSON("Updating time for user " + currentSession.userEmail, parsedReq.feedId, null);
         } else {
             return null;
         }
@@ -211,7 +211,7 @@ public class EditorLockController {
             // the user's editing session has been closed (by either exiting the editor or closing the browser tab).
             LOG.info("Closed session {} for feed {} successfully.", currentSession.sessionId, currentSession.feedId);
             sessionsForFeedIds.remove(parsedReq.getSessionKey());
-            return formatJSON("Session has been closed successfully.", parsedReq.feedId, parsedReq.sessionId);
+            return formatSuccessJSON("Session has been closed successfully.", parsedReq.feedId, parsedReq.sessionId);
         }
     }
 
@@ -224,7 +224,7 @@ public class EditorLockController {
         post(apiPrefix + "deletelock/:id", EditorLockController::deleteFeedLockBeacon, json::write);
     }
 
-    private static String formatJSON(String message, String feedId, String sessionId) {
+    private static String formatSuccessJSON(String message, String feedId, String sessionId) {
         JsonObject object = new JsonObject();
         object.addProperty("result", "OK");
         object.addProperty("message", message);

--- a/src/main/java/com/conveyal/datatools/editor/controllers/api/EditorController.java
+++ b/src/main/java/com/conveyal/datatools/editor/controllers/api/EditorController.java
@@ -40,7 +40,6 @@ import java.util.stream.Stream;
 import static com.conveyal.datatools.common.utils.SparkUtils.formatJSON;
 import static com.conveyal.datatools.common.utils.SparkUtils.getObjectNode;
 import static com.conveyal.datatools.common.utils.SparkUtils.logMessageAndHalt;
-import static com.conveyal.datatools.editor.controllers.EditorLockController.sessionsForFeedIds;
 import static com.conveyal.datatools.manager.controllers.api.UserController.inTestingEnvironment;
 import static spark.Spark.delete;
 import static spark.Spark.options;
@@ -426,8 +425,7 @@ public abstract class EditorController<T extends Entity> {
         // TODO: Add way to mock session.
         if (!inTestingEnvironment()) {
             // TODO: Refactor, looks like duplicate code
-            EditorLockController.ParsedRequest parsedReq = new EditorLockController.ParsedRequest(req, sessionId, "gtfs-editor");
-            EditorLockController.EditorSession currentSession = EditorLockController.getCurrentSession(parsedReq);
+            EditorLockController.EditorSession currentSession = EditorLockController.getSession(sessionId);
             if (currentSession == null) {
                 logMessageAndHalt(req, 400, "There is no active editing session for user.");
             }

--- a/src/main/java/com/conveyal/datatools/editor/controllers/api/EditorController.java
+++ b/src/main/java/com/conveyal/datatools/editor/controllers/api/EditorController.java
@@ -425,7 +425,9 @@ public abstract class EditorController<T extends Entity> {
         // Only check for editing session if not in testing environment.
         // TODO: Add way to mock session.
         if (!inTestingEnvironment()) {
-            EditorLockController.EditorSession currentSession = sessionsForFeedIds.get(feedId);
+            // TODO: Refactor, looks like duplicate code
+            EditorLockController.ParsedRequest parsedReq = new EditorLockController.ParsedRequest(req, sessionId, "gtfs-editor");
+            EditorLockController.EditorSession currentSession = EditorLockController.getCurrentSession(parsedReq);
             if (currentSession == null) {
                 logMessageAndHalt(req, 400, "There is no active editing session for user.");
             }

--- a/src/main/java/com/conveyal/datatools/editor/controllers/api/EditorController.java
+++ b/src/main/java/com/conveyal/datatools/editor/controllers/api/EditorController.java
@@ -424,22 +424,9 @@ public abstract class EditorController<T extends Entity> {
         // Only check for editing session if not in testing environment.
         // TODO: Add way to mock session.
         if (!inTestingEnvironment()) {
-            // TODO: Refactor, looks like duplicate code
-            EditorLockController.EditorSession currentSession = EditorLockController.getSession(sessionId);
-            if (currentSession == null) {
-                logMessageAndHalt(req, 400, "There is no active editing session for user.");
-            }
-            if (!currentSession.sessionId.equals(sessionId)) {
-                // This session does not match the current active session for the feed.
-                Auth0UserProfile userProfile = req.attribute("user");
-                if (currentSession.userEmail.equals(userProfile.getEmail())) {
-                    LOG.warn("User {} already has editor session {} for feed {}. Same user cannot make edits on session {}.", currentSession.userEmail, currentSession.sessionId, feedId, req.session().id());
-                    logMessageAndHalt(req, 400, "You have another editing session open for " + feedSource.name);
-                } else {
-                    LOG.warn("User {} already has editor session {} for feed {}. User {} cannot make edits on session {}.", currentSession.userEmail, currentSession.sessionId, feedId, userProfile.getEmail(), req.session().id());
-                    logMessageAndHalt(req, 400, "Somebody else is editing the " + feedSource.name + " feed.");
-                }
-            } else {
+            Auth0UserProfile userProfile = req.attribute("user");
+            EditorLockController.EditorSession currentSession = EditorLockController.getSession(feedId);
+            if (EditorLockController.checkUserHasActiveSession(req, sessionId, userProfile.getEmail(), currentSession)) {
                 currentSession.lastEdit = System.currentTimeMillis();
                 LOG.info("Updating session {} last edit time to {}", sessionId, currentSession.lastEdit);
             }


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [na] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR refactors the `EditorController` so it supports a new, optional, query parameter `item` through which a client can specify which item to lock.

The PR also contains a repo update (boundlessgeo seems to have been retired recently).