### PR TITLE
Check if validationResult exists for old feeds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -197,15 +197,6 @@
                 <updatePolicy>always</updatePolicy>
             </snapshots>
         </repository>
-        <repository>
-            <id>boundless</id>
-            <name>Boundless Maven Repository</name>
-            <url>https://repo.boundlessgeo.com/main</url>
-            <snapshots>
-                <enabled>true</enabled>
-                <updatePolicy>always</updatePolicy>
-            </snapshots>
-        </repository>
         <!--  used for importing java projects from github -->
         <repository>
             <id>jitpack.io</id>
@@ -270,8 +261,8 @@
         <dependency>
             <groupId>com.github.conveyal</groupId>
             <artifactId>gtfs-lib</artifactId>
-            <!-- gtfs-lib 7.1.0 + fix for trip pattern loading + others before -->
-            <version>3826eeda92f488f9d9ab4022d08be3b1281980de</version>
+            <!-- Latest dev build on jitpack.io -->
+            <version>ca419a8149</version>
             <!-- Exclusions added in order to silence SLF4J warnings about multiple bindings:
                 http://www.slf4j.org/codes.html#multiple_bindings
             -->

--- a/src/main/java/com/conveyal/datatools/manager/models/FeedVersionSummary.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/FeedVersionSummary.java
@@ -56,8 +56,11 @@ public class FeedVersionSummary extends Model implements Serializable {
         public LocalDate endDate;
 
         PartialValidationSummary() {
-            this.startDate = validationResult.firstCalendarDate;
-            this.endDate = validationResult.lastCalendarDate;
+            // Older feeds created in datatools may not have validationResult
+            if (validationResult != null) {
+                this.startDate = validationResult.firstCalendarDate;
+                this.endDate = validationResult.lastCalendarDate;
+            }
         }
     }
 }


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [ ] All tests and CI builds passing

### Description

Old datatools feeds may not contain a validationResult in the database and will not be able to display various information regarding validation. This case will create a NPE on the backend. This PR adds a check to avoid any NPEs for empty validationResults. 
