### PR TITLE
fix(default otp version): Re-align OTP jar version dropdown with default

### DIFF
--- a/src/main/java/com/conveyal/datatools/manager/models/Deployment.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/Deployment.java
@@ -63,7 +63,8 @@ public class Deployment extends Model implements Serializable {
 
     public String name;
 
-    public static final String DEFAULT_OTP_VERSION = getConfigPropertyAsText("application.default_otp_version");
+    //OTP v1.4 is a historical version that was previously used as a fallback. Only use if application default not configured.
+    public static final String DEFAULT_OTP_VERSION = getConfigPropertyAsText("application.default_otp_version", "otp-v1.4.0");
 
     /** What server is this currently deployed to? */
     public String deployedTo;

--- a/src/main/java/com/conveyal/datatools/manager/models/Deployment.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/Deployment.java
@@ -4,6 +4,7 @@ import com.amazonaws.services.ec2.model.Filter;
 import com.conveyal.datatools.common.utils.aws.CheckedAWSException;
 import com.conveyal.datatools.common.utils.aws.EC2Utils;
 import com.conveyal.datatools.manager.DataManager;
+import static com.conveyal.datatools.manager.DataManager.getConfigPropertyAsText;
 import com.conveyal.datatools.manager.jobs.DeployJob;
 import com.conveyal.datatools.manager.persistence.Persistence;
 import com.conveyal.datatools.manager.utils.StringUtils;
@@ -62,7 +63,7 @@ public class Deployment extends Model implements Serializable {
 
     public String name;
 
-    public static final String DEFAULT_OTP_VERSION = "otp-v1.4.0";
+    public static final String DEFAULT_OTP_VERSION = getConfigPropertyAsText("application.default_otp_version");
 
     /** What server is this currently deployed to? */
     public String deployedTo;
@@ -181,7 +182,7 @@ public class Deployment extends Model implements Serializable {
      * {@link Deployment#DEFAULT_OTP_VERSION}. This is used to determine what jar file to download and does not have an
      * exact match to actual numbered/tagged releases.
      */
-    public String otpVersion;
+    public String otpVersion = DEFAULT_OTP_VERSION;
 
     public boolean buildGraphOnly;
 


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

It is useful for the OTP version dropdown to mirror what will be used in the case of no OTP version being selected. This was causing issues with the interpretation of certain feeds in OTP since an old version was unexpectedly being used. This PR relies on a new configuration value `application.default_otp_version`. 