### PR TITLE
Reduce feedsource mongo queries

### DIFF
--- a/src/main/java/com/conveyal/datatools/manager/jobs/DeployJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/DeployJob.java
@@ -30,7 +30,14 @@ import com.conveyal.datatools.common.utils.aws.S3Utils;
 import com.conveyal.datatools.manager.DataManager;
 import com.conveyal.datatools.manager.auth.Auth0UserProfile;
 import com.conveyal.datatools.manager.jobs.OtpRunnerManifest.OtpRunnerBaseFolderDownload;
-import com.conveyal.datatools.manager.models.*;
+import com.conveyal.datatools.manager.models.CustomFile;
+import com.conveyal.datatools.manager.models.Deployment;
+import com.conveyal.datatools.manager.models.EC2Info;
+import com.conveyal.datatools.manager.models.EC2InstanceSummary;
+import com.conveyal.datatools.manager.models.FeedSource;
+import com.conveyal.datatools.manager.models.FeedVersion;
+import com.conveyal.datatools.manager.models.OtpServer;
+import com.conveyal.datatools.manager.models.Project;
 import com.conveyal.datatools.manager.persistence.Persistence;
 import com.conveyal.datatools.manager.utils.JobUtils;
 import com.conveyal.datatools.manager.utils.StringUtils;
@@ -650,7 +657,13 @@ public class DeployJob extends MonitorableJob {
         FeedVersion deployedFeedVersion = Persistence.feedVersions.getById(deployment.feedVersionIds.stream().findFirst().get());
         FeedSource deployedFeedSource = Persistence.feedSources.getById(deployedFeedVersion.feedSourceId);
 
-        deployedFeedSource.setDeploymentInfo(deployedFeedVersion.id, deployedFeedVersion.validationSummary().startDate, deployedFeedVersion.validationSummary().endDate);
+        // Define and save deployed feed version.
+        deployedFeedSource.setDeploymentInfo(
+            deployedFeedVersion.id,
+            deployedFeedVersion.validationSummary().startDate,
+            deployedFeedVersion.validationSummary().endDate
+        );
+        Persistence.feedSources.replace(deployedFeedSource.id, deployedFeedSource);
 
         // Send notification to those subscribed to updates for the deployment.
         NotifyUsersForSubscriptionJob.createNotification("deployment-updated", deployment.id, message);

--- a/src/main/java/com/conveyal/datatools/manager/jobs/DeployJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/DeployJob.java
@@ -654,16 +654,18 @@ public class DeployJob extends MonitorableJob {
         Persistence.deployments.replace(deployment.id, latestDeployment);
 
         // FIXME: we're assuming deployment.feedVersionIds is sorted properly. If things stop working... this is probably the issue ✨
-        FeedVersion deployedFeedVersion = Persistence.feedVersions.getById(deployment.feedVersionIds.stream().findFirst().get());
-        FeedSource deployedFeedSource = Persistence.feedSources.getById(deployedFeedVersion.feedSourceId);
+        if (deployment.feedVersionIds.stream().findFirst().isPresent()) {
+            FeedVersion deployedFeedVersion = Persistence.feedVersions.getById(deployment.feedVersionIds.stream().findFirst().get());
+            FeedSource deployedFeedSource = Persistence.feedSources.getById(deployedFeedVersion.feedSourceId);
 
-        // Define and save deployed feed version.
-        deployedFeedSource.setDeploymentInfo(
-            deployedFeedVersion.id,
-            deployedFeedVersion.validationSummary().startDate,
-            deployedFeedVersion.validationSummary().endDate
-        );
-        Persistence.feedSources.replace(deployedFeedSource.id, deployedFeedSource);
+            // Define and save deployed feed version.
+            deployedFeedSource.setDeploymentInfo(
+                    deployedFeedVersion.id,
+                    deployedFeedVersion.validationSummary().startDate,
+                    deployedFeedVersion.validationSummary().endDate
+            );
+            Persistence.feedSources.replace(deployedFeedSource.id, deployedFeedSource);
+        }
 
         // Send notification to those subscribed to updates for the deployment.
         NotifyUsersForSubscriptionJob.createNotification("deployment-updated", deployment.id, message);

--- a/src/main/java/com/conveyal/datatools/manager/models/FeedSource.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/FeedSource.java
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.annotation.JsonView;
 import com.mongodb.client.FindIterable;
 import com.mongodb.client.model.Sorts;
 import org.bson.codecs.pojo.annotations.BsonIgnore;
+import org.bson.codecs.pojo.annotations.BsonProperty;
 import org.bson.conversions.Bson;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -62,6 +63,8 @@ import static com.mongodb.client.model.Updates.pull;
 public class FeedSource extends Model implements Cloneable {
 
     private static final long serialVersionUID = 1L;
+
+
 
     public static final Logger LOG = LoggerFactory.getLogger(FeedSource.class);
 
@@ -145,6 +148,12 @@ public class FeedSource extends Model implements Cloneable {
      * From whence is this feed fetched?
      */
     public URL url;
+
+    public String deployedFeedVersionId = "Dummy";
+    @BsonProperty
+    public LocalDate deployedFeedVersionStartDate;
+    @BsonProperty
+    public LocalDate deployedFeedVersionEndDate;
 
     /**
      * Where the feed exists on s3
@@ -471,28 +480,31 @@ public class FeedSource extends Model implements Cloneable {
     @BsonIgnore
     private FeedVersion deployedFeedVersion = null;
 
+    public void setDeploymentInfo(String versionId, LocalDate startDate, LocalDate endDate) {
+        this.deployedFeedVersionId = versionId;
+        this.deployedFeedVersionStartDate = startDate;
+        this.deployedFeedVersionEndDate = endDate;
+    }
+
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonView(JsonViews.UserInterface.class)
     @JsonProperty("deployedFeedVersionId")
     public String getDeployedFeedVersionId() {
-        FeedVersion feedVersion = getDeployedFeedVersion();
-        return feedVersion != null ? feedVersion.id : null;
+        return this.deployedFeedVersionId;
     }
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonView(JsonViews.UserInterface.class)
     @JsonProperty("deployedFeedVersionStartDate")
     public LocalDate getDeployedFeedVersionStartDate() {
-        FeedVersion feedVersion = getDeployedFeedVersion();
-        return feedVersion != null ? feedVersion.validationSummary().startDate : null;
+        return this.deployedFeedVersionStartDate;
     }
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonView(JsonViews.UserInterface.class)
     @JsonProperty("deployedFeedVersionEndDate")
     public LocalDate getDeployedFeedVersionEndDate() {
-        FeedVersion feedVersion = getDeployedFeedVersion();
-        return feedVersion != null ? feedVersion.validationSummary().endDate : null;
+        return this.deployedFeedVersionEndDate;
     }
 
     /**

--- a/src/main/java/com/conveyal/datatools/manager/models/FeedSource.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/FeedSource.java
@@ -160,8 +160,6 @@ public class FeedSource extends Model implements Cloneable {
 
     @BsonIgnore
     private FeedVersion deployedFeedVersion;
-    @BsonIgnore
-    private FeedVersion latestFeedVersion;
 
     /**
      * Where the feed exists on s3
@@ -435,19 +433,18 @@ public class FeedSource extends Model implements Cloneable {
     /**
      * Get the latest version of this feed
      * @return the latest version of this feed
+     *
+     * TODO: somehow cache the response to improve response time
      */
     @JsonIgnore
     public FeedVersion retrieveLatest() {
-        if (latestFeedVersion == null) {
-            latestFeedVersion = Persistence.feedVersions
+        FeedVersion newestVersion = Persistence.feedVersions
                     .getOneFiltered(eq("feedSourceId", this.id), Sorts.descending("version"));
-        }
-        
-        if (latestFeedVersion == null) {
+        if (newestVersion == null) {
             // Is this what happens if there are none?
             return null;
         }
-        return latestFeedVersion;
+        return newestVersion;
     }
 
     /**

--- a/src/main/java/com/conveyal/datatools/manager/models/FeedSource.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/FeedSource.java
@@ -9,6 +9,7 @@ import com.conveyal.datatools.common.status.MonitorableJob;
 import com.conveyal.datatools.common.utils.Scheduler;
 import com.conveyal.datatools.common.utils.aws.CheckedAWSException;
 import com.conveyal.datatools.common.utils.aws.S3Utils;
+import com.conveyal.datatools.editor.utils.JacksonSerializers;
 import com.conveyal.datatools.manager.DataManager;
 import com.conveyal.datatools.manager.jobs.CreateFeedVersionFromSnapshotJob;
 import com.conveyal.datatools.manager.jobs.FetchSingleFeedJob;
@@ -26,6 +27,8 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonView;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.mongodb.client.FindIterable;
 import com.mongodb.client.model.Sorts;
 import org.bson.codecs.pojo.annotations.BsonIgnore;
@@ -151,8 +154,12 @@ public class FeedSource extends Model implements Cloneable {
 
     public String deployedFeedVersionId = "🤌";
     @BsonProperty
+    @JsonSerialize(using = JacksonSerializers.LocalDateIsoSerializer.class)
+    @JsonDeserialize(using = JacksonSerializers.LocalDateIsoDeserializer.class)
     public LocalDate deployedFeedVersionStartDate;
     @BsonProperty
+    @JsonSerialize(using = JacksonSerializers.LocalDateIsoSerializer.class)
+    @JsonDeserialize(using = JacksonSerializers.LocalDateIsoDeserializer.class)
     public LocalDate deployedFeedVersionEndDate;
 
     @BsonIgnore
@@ -476,15 +483,6 @@ public class FeedSource extends Model implements Cloneable {
         FeedVersion latest = retrieveLatest();
         return latest != null ? latest.id : null;
     }
-
-    /**
-     * The feed version used in the latest deployment.
-     * This cannot be returned because of a circular reference between feed source and feed version. Instead, individual
-     * parameters (version id and end date) are returned.
-     */
-    @JsonIgnore
-    @BsonIgnore
-    private FeedVersion deployedFeedVersion = null;
 
     public void setDeploymentInfo(String versionId, LocalDate startDate, LocalDate endDate) {
         this.deployedFeedVersionId = versionId;

--- a/src/main/java/com/conveyal/datatools/manager/utils/json/JsonUtil.java
+++ b/src/main/java/com/conveyal/datatools/manager/utils/json/JsonUtil.java
@@ -7,8 +7,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.type.CollectionType;
-import org.apache.http.HttpResponse;
-import org.apache.http.util.EntityUtils;
 import spark.Request;
 
 import java.io.IOException;

--- a/src/test/java/com/conveyal/datatools/manager/controllers/api/FeedSourceControllerTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/controllers/api/FeedSourceControllerTest.java
@@ -4,12 +4,15 @@ import com.conveyal.datatools.DatatoolsTest;
 import com.conveyal.datatools.TestUtils;
 import com.conveyal.datatools.common.utils.Scheduler;
 import com.conveyal.datatools.manager.auth.Auth0Connection;
+import com.conveyal.datatools.manager.auth.Auth0UserProfile;
+import com.conveyal.datatools.manager.jobs.DeployJob;
 import com.conveyal.datatools.manager.models.Deployment;
 import com.conveyal.datatools.manager.models.FeedRetrievalMethod;
 import com.conveyal.datatools.manager.models.FeedSource;
 import com.conveyal.datatools.manager.models.FeedVersion;
 import com.conveyal.datatools.manager.models.FetchFrequency;
 import com.conveyal.datatools.manager.models.Label;
+import com.conveyal.datatools.manager.models.OtpServer;
 import com.conveyal.datatools.manager.models.Project;
 import com.conveyal.datatools.manager.persistence.Persistence;
 import com.conveyal.datatools.manager.utils.HttpUtils;
@@ -254,6 +257,14 @@ public class FeedSourceControllerTest extends DatatoolsTest {
      */
     @Test
     void canRetrieveFeedSourceWithDeployedFeedVersion() throws IOException {
+        DeployJob deployJob = new DeployJob(
+            deploymentDeployed,
+            Auth0UserProfile.createTestAdminUser(),
+            new OtpServer(),
+            "test-deploy",
+            DeployJob.DeployType.USE_PRELOADED_BUNDLE
+        );
+        deployJob.run();
         SimpleHttpResponse response = TestUtils.makeRequest(
             String.format("/api/manager/secure/feedsource?projectId=%s", project.id),
             null,

--- a/src/test/java/com/conveyal/datatools/manager/controllers/api/FeedSourceControllerTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/controllers/api/FeedSourceControllerTest.java
@@ -54,6 +54,8 @@ public class FeedSourceControllerTest extends DatatoolsTest {
     private static Deployment deploymentSuperseded = null;
     private static Deployment deploymentDeployed = null;
 
+    private static final Auth0UserProfile user = Auth0UserProfile.createTestAdminUser();
+
     @BeforeAll
     public static void setUp() throws IOException {
         DatatoolsTest.setUp();
@@ -260,7 +262,7 @@ public class FeedSourceControllerTest extends DatatoolsTest {
         DeployJob deployJob = new DeployJob(
             "Deploying " + deploymentDeployed.name,
             deploymentDeployed,
-            Auth0UserProfile.createTestAdminUser(),
+            user,
             new OtpServer(),
             "test-deploy",
             DeployJob.DeployType.USE_PRELOADED_BUNDLE,

--- a/src/test/java/com/conveyal/datatools/manager/controllers/api/FeedSourceControllerTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/controllers/api/FeedSourceControllerTest.java
@@ -258,11 +258,13 @@ public class FeedSourceControllerTest extends DatatoolsTest {
     @Test
     void canRetrieveFeedSourceWithDeployedFeedVersion() throws IOException {
         DeployJob deployJob = new DeployJob(
+            "Deploying " + deploymentDeployed.name,
             deploymentDeployed,
             Auth0UserProfile.createTestAdminUser(),
             new OtpServer(),
             "test-deploy",
-            DeployJob.DeployType.USE_PRELOADED_BUNDLE
+            DeployJob.DeployType.USE_PRELOADED_BUNDLE,
+            true
         );
         deployJob.run();
         SimpleHttpResponse response = TestUtils.makeRequest(


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing
- [x] The description lists all relevant PRs included in this release _(remove this if not merging to master)_
- [x] e2e tests are all passing _(remove this if not merging to master)_

### Description

Reduces `FeedSource` endpoint loading time by removing expensive mongo queries and instead saving data into static fields. Does use old method if those static fields are missing.
