### PR TITLE
ci(maven.yml): Upload jar to S3 only on master, dev, or with [save-jar]

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -124,6 +124,8 @@ jobs:
           FIRST_JAR="${ALL_JARS[0]}"
           cp "$FIRST_JAR" "deploy/dt-latest-$BRANCH_CLEAN.jar"
       - name: Deploy to S3
-        if: github.event_name == 'push'
+        # To make the datastools-builds bucket more manageable,
+        # upload to S3 only on pushes to dev, master, or for other branches, if "[save-jar]" is in the commit message.
+        if: "github.event_name == 'push' && (github.ref_name == 'dev' || github.ref_name == 'master' || contains(github.event.head_commit.message, '[save-jar]'))"
         run: |
           aws s3 cp ./deploy s3://datatools-builds --recursive --acl public-read


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [na] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [na] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [ ] All tests and CI builds passing

### Description

This PR restricts S3 uploads of the jar built during CI to the `master` and `dev` branches, and on-demand with `[save-jar]` for other branches.
