### PR TITLE
Remove mongo restart from CI

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -65,8 +65,6 @@ jobs:
         run: mkdir /tmp/gtfsplus
       - name: Build with Maven (run unit tests)
         run: mvn --no-transfer-progress package
-      - name: Restart MongoDB with fresh database (for e2e tests)
-        run: ./scripts/restart-mongo-with-fresh-db.sh
       - name: Run e2e tests
         if: env.SHOULD_RUN_E2E == 'true'
         run: mvn test


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

CI tests were failing. Mongo is now in Docker for the e2e tests and so we do not need to restart it. In fact, restarting it breaks the CI.
