### PR TITLE
fix(FeedSourceController): delete feed zip when feed becomes private

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -32,10 +32,10 @@ jobs:
         with:
           java-version: 1.8
       # Install node 14 for running e2e tests (and for maven-semantic-release).
-      - name: Use Node.js 14.x
+      - name: Use Node.js 18.x
         uses: actions/setup-node@v1
         with:
-          node-version: 14.x
+          node-version: 18.x
       - name: Start MongoDB
         uses: supercharge/mongodb-github-action@1.3.0
         with:

--- a/src/main/java/com/conveyal/datatools/manager/controllers/api/FeedSourceController.java
+++ b/src/main/java/com/conveyal/datatools/manager/controllers/api/FeedSourceController.java
@@ -1,6 +1,8 @@
 package com.conveyal.datatools.manager.controllers.api;
 
 import com.conveyal.datatools.common.utils.Scheduler;
+import com.conveyal.datatools.common.utils.aws.CheckedAWSException;
+import com.conveyal.datatools.common.utils.aws.S3Utils;
 import com.conveyal.datatools.manager.DataManager;
 import com.conveyal.datatools.manager.auth.Actions;
 import com.conveyal.datatools.manager.auth.Auth0UserProfile;
@@ -189,7 +191,7 @@ public class FeedSourceController {
      * fields the updated feed source should contain. This change allows us to parse the JSON into a POJO, which
      * essentially does type checking for us and prevents issues with deserialization from MongoDB into POJOs.
      */
-    private static FeedSource updateFeedSource(Request req, Response res) throws IOException {
+    private static FeedSource updateFeedSource(Request req, Response res) throws IOException, CheckedAWSException {
         String feedSourceId = req.params("id");
         FeedSource formerFeedSource = requestFeedSourceById(req, Actions.MANAGE);
         FeedSource updatedFeedSource = getPOJOFromRequestBody(req, FeedSource.class);
@@ -200,6 +202,12 @@ public class FeedSourceController {
             updatedFeedSource.lastFetched = null;
         }
         Persistence.feedSources.replace(feedSourceId, updatedFeedSource);
+
+        // If feed just changed from public to private, delete feed from public repo if it's present there
+        if(formerFeedSource.isPublic && !updatedFeedSource.isPublic) {
+            LOG.info("Deleting {} as feed is being adjusted from public to private.", updatedFeedSource.toPublicKey());
+            S3Utils.getDefaultS3Client().deleteObject(S3Utils.DEFAULT_BUCKET, updatedFeedSource.toPublicKey());
+        }
 
         if (shouldNotifyUsersOnFeedUpdated(formerFeedSource, updatedFeedSource)) {
             return updatedFeedSource;

--- a/src/main/java/com/conveyal/datatools/manager/controllers/api/FeedSourceController.java
+++ b/src/main/java/com/conveyal/datatools/manager/controllers/api/FeedSourceController.java
@@ -203,8 +203,8 @@ public class FeedSourceController {
         }
         Persistence.feedSources.replace(feedSourceId, updatedFeedSource);
 
-        // If feed just changed from public to private, delete feed from public repo if it's present there
-        if(formerFeedSource.isPublic && !updatedFeedSource.isPublic) {
+        // If feed just changed from public to private, delete feed from public repo if it's present there.
+        if (formerFeedSource.isPublic && !updatedFeedSource.isPublic) {
             LOG.info("Deleting {} as feed is being adjusted from public to private.", updatedFeedSource.toPublicKey());
             S3Utils.getDefaultS3Client().deleteObject(S3Utils.DEFAULT_BUCKET, updatedFeedSource.toPublicKey());
         }


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Currently when setting a feed source to private the feed source is removed from the generated `index.html`, but the file is still present so anyone who has that link will still get access to that previous feed. This PR repairs this, deleting the zip file from S3 when it is set to private.