### PR TITLE
Add `FeedSourceCount` Property To Project

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -32,10 +32,10 @@ jobs:
         with:
           java-version: 1.8
       # Install node 14 for running e2e tests (and for maven-semantic-release).
-      - name: Use Node.js 14.x
+      - name: Use Node.js 18.x
         uses: actions/setup-node@v1
         with:
-          node-version: 14.x
+          node-version: 18.x
       - name: Start MongoDB
         uses: supercharge/mongodb-github-action@1.3.0
         with:

--- a/src/main/java/com/conveyal/datatools/manager/models/Project.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/Project.java
@@ -127,11 +127,11 @@ public class Project extends Model {
     public Collection<Label> labels;
 
     @JsonProperty
-    public int feedSourceCount() {
+    public long feedSourceCount() {
         if (retrieveProjectFeedSources() == null) {
             return -1;
         }
-        return retrieveProjectFeedSources().size();
+        return Persistence.feedSources.count(eq("projectId", this.id));
     }
 
 

--- a/src/main/java/com/conveyal/datatools/manager/models/Project.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/Project.java
@@ -126,6 +126,14 @@ public class Project extends Model {
     @BsonIgnore
     public Collection<Label> labels;
 
+    @JsonProperty
+    public int feedSourceCount() {
+        if (retrieveProjectFeedSources() == null) {
+            return -1;
+        }
+        return retrieveProjectFeedSources().size();
+    }
+
 
     // Note: Previously a numberOfFeeds() dynamic Jackson JsonProperty was in place here. But when the number of projects
     // in the database grows large, the efficient calculation of this field does not scale.


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR adds a new `feedSourceCount` property to the Project json response. This is useful to allow the client to determine if it has fully downloaded the project. 

Looking for feedback on perhaps how to better generate the number!