### PR TITLE
Mtc optimize feedupdater

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -66,6 +66,7 @@ jobs:
       - name: Build with Maven (run unit tests)
         run: mvn --no-transfer-progress package
       - name: Restart MongoDB with fresh database (for e2e tests)
+        if: env.SHOULD_RUN_E2E == 'true'
         run: ./scripts/restart-mongo-with-fresh-db.sh
       - name: Run e2e tests
         if: env.SHOULD_RUN_E2E == 'true'

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -29,10 +29,10 @@ jobs:
         with:
           java-version: 1.8
       # Install node 14 for running e2e tests (and for maven-semantic-release).
-      - name: Use Node.js 14.x
+      - name: Use Node.js 18.x
         uses: actions/setup-node@v1
         with:
-          node-version: 14.x
+          node-version: 18.x
       - name: Start MongoDB
         uses: supercharge/mongodb-github-action@1.3.0
         with:

--- a/pom.xml
+++ b/pom.xml
@@ -197,15 +197,6 @@
                 <updatePolicy>always</updatePolicy>
             </snapshots>
         </repository>
-        <repository>
-            <id>boundless</id>
-            <name>Boundless Maven Repository</name>
-            <url>https://repo.boundlessgeo.com/main</url>
-            <snapshots>
-                <enabled>true</enabled>
-                <updatePolicy>always</updatePolicy>
-            </snapshots>
-        </repository>
         <!--  used for importing java projects from github -->
         <repository>
             <id>jitpack.io</id>
@@ -270,8 +261,8 @@
         <dependency>
             <groupId>com.github.conveyal</groupId>
             <artifactId>gtfs-lib</artifactId>
-            <!-- gtfs-lib 7.1.0 + fix for trip pattern loading + others before -->
-            <version>3826eeda92f488f9d9ab4022d08be3b1281980de</version>
+            <!-- Latest dev build on jitpack.io -->
+            <version>ca419a8149</version>
             <!-- Exclusions added in order to silence SLF4J warnings about multiple bindings:
                 http://www.slf4j.org/codes.html#multiple_bindings
             -->

--- a/src/main/java/com/conveyal/datatools/manager/gtfsplus/GtfsPlusValidation.java
+++ b/src/main/java/com/conveyal/datatools/manager/gtfsplus/GtfsPlusValidation.java
@@ -308,7 +308,7 @@ public class GtfsPlusValidation implements Serializable {
     }
 
     /**
-     * Gets the text that is displayed for an option.
+     * Gets the displayed text for an option.
      */
     static String getOptionText(String value, JsonNode specField) {
         JsonNode optionNode = findOptionNode(value, specField);

--- a/src/main/java/com/conveyal/datatools/manager/gtfsplus/GtfsPlusValidation.java
+++ b/src/main/java/com/conveyal/datatools/manager/gtfsplus/GtfsPlusValidation.java
@@ -308,7 +308,7 @@ public class GtfsPlusValidation implements Serializable {
     }
 
     /**
-     * Gets the displayed text for an option.
+     * Gets the text that is displayed for an option.
      */
     static String getOptionText(String value, JsonNode specField) {
         JsonNode optionNode = findOptionNode(value, specField);

--- a/src/main/java/com/conveyal/datatools/manager/jobs/FeedUpdater.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/FeedUpdater.java
@@ -151,7 +151,7 @@ public class FeedUpdater {
             .collect(Collectors.toMap(src -> src.id, Function.identity()));
 
         return feedIdsToFeedSourceIds.entrySet().stream()
-            .collect(Collectors.toMap(e -> e.getKey(), e -> feedSourceIdToFeedSource.get(e.getValue())));
+            .collect(Collectors.toMap(Map.Entry::getKey, e -> feedSourceIdToFeedSource.get(e.getValue())));
     }
 
     private class UpdateFeedsTask implements Runnable {

--- a/src/main/java/com/conveyal/datatools/manager/jobs/FeedUpdater.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/FeedUpdater.java
@@ -156,11 +156,8 @@ public class FeedUpdater {
 
     private class UpdateFeedsTask implements Runnable {
         public void run() {
-            LOG.info("Starting UpdateFeedsTask");
-            long startMillis = System.currentTimeMillis();
             try {
                 LOG.debug("Checking MTC feeds for newly processed versions");
-                versionsToMarkAsProcessed = getFeedVersionsToMarkAsProcessed();
                 Map<String, String> updatedTags = checkForUpdatedFeeds();
                 eTagForFeed.putAll(updatedTags);
                 if (!updatedTags.isEmpty()) LOG.info("New eTag list: {}", eTagForFeed);
@@ -168,8 +165,6 @@ public class FeedUpdater {
             } catch (Exception e) {
                 LOG.error("Error updating feeds {}", e);
             }
-
-            LOG.info("Completed UpdateFeedsTask in {} ms", System.currentTimeMillis() - startMillis);
         }
     }
 
@@ -184,6 +179,8 @@ public class FeedUpdater {
             LOG.info("Running initial check for feeds on S3.");
             eTagForFeed = new HashMap<>();
         }
+
+        versionsToMarkAsProcessed = getFeedVersionsToMarkAsProcessed();
 
         LOG.debug("Checking for feeds on S3.");
         Map<String, String> newTags = new HashMap<>();

--- a/src/main/java/com/conveyal/datatools/manager/jobs/FeedUpdater.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/FeedUpdater.java
@@ -118,10 +118,11 @@ public class FeedUpdater {
 
     public static Map<String, String> mapFeedIdsToFeedSourceIds(List<ExternalFeedSourceProperty> properties) {
         Map<String, String> feedToFeedSourceId = new HashMap<>();
+        Map<String, Boolean> multipleSourceWarning = new HashMap<>();
         for (ExternalFeedSourceProperty prop : properties) {
             String feedId = prop.value;
-            if (feedToFeedSourceId.get(feedId) != null) {
-                // TODO: this log is a regression from original code.
+            if (feedToFeedSourceId.get(feedId) != null && !multipleSourceWarning.getOrDefault(feedId, false)) {
+                multipleSourceWarning.put(feedId, true);
                 LOG.warn("Found multiple feed sources for {}: {}. The published status on some feed versions will be incorrect.",
                     feedId,
                     properties

--- a/src/main/java/com/conveyal/datatools/manager/jobs/FeedUpdater.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/FeedUpdater.java
@@ -188,7 +188,7 @@ public class FeedUpdater {
                 lt(PROCESSED_BY_EXTERNAL_PUBLISHER_FIELD, SENT_TO_EXTERNAL_PUBLISHER_FIELD)
             )
         );
-        versionsToMarkAsProcessed = Persistence.feedVersions.getFiltered(query)
+        versionsToMarkAsProcessed = Persistence.feedVersionSummaries.getFiltered(query)
             .stream()
             .map(v -> v.id)
             .collect(Collectors.toList());

--- a/src/main/java/com/conveyal/datatools/manager/models/ExternalFeedSourceProperty.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/ExternalFeedSourceProperty.java
@@ -13,12 +13,16 @@ public class ExternalFeedSourceProperty extends Model {
     // constructor for data dump load
     public ExternalFeedSourceProperty() {}
 
-    public ExternalFeedSourceProperty(FeedSource feedSource, String resourceType, String name, String value) {
-        this.id = constructId(feedSource, resourceType, name);
-        this.feedSourceId = feedSource.id;
+    public ExternalFeedSourceProperty(String feedSourceId, String resourceType, String name, String value) {
+        this.feedSourceId = feedSourceId;
         this.resourceType = resourceType;
         this.name = name;
         this.value = value;
+    }
+
+    public ExternalFeedSourceProperty(FeedSource feedSource, String resourceType, String name, String value) {
+        this(feedSource.id, resourceType, name, value);
+        this.id = constructId(feedSource, resourceType, name);
     }
 
     public static String constructId(FeedSource feedSource, String resourceType, String name) {

--- a/src/test/java/com/conveyal/datatools/manager/jobs/FeedUpdaterTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/jobs/FeedUpdaterTest.java
@@ -74,7 +74,7 @@ class FeedUpdaterTest {
             .stream()
             .map(k -> {
                 S3ObjectSummary s3Obj = new S3ObjectSummary();
-                s3Obj.setKey("s3bucket/firstFeed.zip");
+                s3Obj.setKey(k);
                 return s3Obj;
             })
             .collect(Collectors.toList());

--- a/src/test/java/com/conveyal/datatools/manager/jobs/FeedUpdaterTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/jobs/FeedUpdaterTest.java
@@ -14,9 +14,9 @@ class FeedUpdaterTest {
     @Test
     void shouldGetFeedIdsFromS3ObjectSummaries() {
         S3ObjectSummary s3Obj1 = new S3ObjectSummary();
-        s3Obj1.setKey("s3bucket/firstFeed");
+        s3Obj1.setKey("s3bucket/firstFeed.zip");
         S3ObjectSummary s3Obj2 = new S3ObjectSummary();
-        s3Obj2.setKey("s3bucket/otherFeed");
+        s3Obj2.setKey("s3bucket/otherFeed.zip");
         S3ObjectSummary s3Obj3 = new S3ObjectSummary();
         s3Obj3.setKey("s3bucket/"); // format for S3 bucket top-level folders.
         List<S3ObjectSummary> s3objects = Lists.newArrayList(

--- a/src/test/java/com/conveyal/datatools/manager/jobs/FeedUpdaterTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/jobs/FeedUpdaterTest.java
@@ -1,18 +1,55 @@
 package com.conveyal.datatools.manager.jobs;
 
 import com.amazonaws.services.s3.model.S3ObjectSummary;
+import com.conveyal.datatools.DatatoolsTest;
 import com.conveyal.datatools.manager.models.ExternalFeedSourceProperty;
 import com.conveyal.datatools.manager.models.FeedSource;
+import com.conveyal.datatools.manager.models.FeedVersion;
+import com.conveyal.datatools.manager.models.Project;
+import com.conveyal.datatools.manager.persistence.Persistence;
 import com.google.common.collect.Lists;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
 import static com.conveyal.datatools.manager.extensions.mtc.MtcFeedResource.AGENCY_ID_FIELDNAME;
+import static com.mongodb.client.model.Filters.in;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 class FeedUpdaterTest {
+    public static final String FEED_SOURCE_1_ID = "feed-source1-id";
+    public static final String FEED_SOURCE_2_ID = "feed-source2-id";
+    private static Project project;
+
+    private static final String PROJECT_NAME = String.format("Test %s", new Date());
+
+    @BeforeAll
+    public static void setUp() throws IOException {
+        // start server if it isn't already running
+        DatatoolsTest.setUp();
+
+        // Create a project.
+        project = new Project();
+        project.id = PROJECT_NAME;
+        project.name = PROJECT_NAME;
+        Persistence.projects.create(project);
+    }
+
+    @AfterAll
+    public static void tearDown() {
+        Persistence.feedVersions.removeFiltered(in("feedSourceId", FEED_SOURCE_1_ID, FEED_SOURCE_2_ID));
+        if (project != null) {
+            project.delete();
+        }
+    }
+
     @Test
     void shouldGetFeedIdsFromS3ObjectSummaries() {
         S3ObjectSummary s3Obj1 = new S3ObjectSummary();
@@ -34,7 +71,7 @@ class FeedUpdaterTest {
     }
 
     @Test
-    void shouldGetFeedSourceIdForFeedId() {
+    void shouldMapFeedIdsToFeedSourceIds() {
         ExternalFeedSourceProperty prop1 = new ExternalFeedSourceProperty();
         prop1.name = AGENCY_ID_FIELDNAME;
         prop1.value = "firstFeed";
@@ -60,11 +97,11 @@ class FeedUpdaterTest {
 
         assertEquals("id-for-first-feed", feedIdsToFeedSourceIds.get("firstFeed"));
         assertEquals("id2-for-other-feed", feedIdsToFeedSourceIds.get("otherFeed"));
-        assertEquals(null, feedIdsToFeedSourceIds.get("unknownFeed"));
+        assertNull(feedIdsToFeedSourceIds.get("unknownFeed"));
     }
 
     @Test
-    void shouldBuildFeedIDToFeedSourceMap() {
+    void shouldMapFeedIdsToFeedSources() {
         FeedSource fs1 = new FeedSource();
         fs1.id = "id-for-first-feed";
         FeedSource fs2 = new FeedSource();
@@ -89,5 +126,56 @@ class FeedUpdaterTest {
         Map<String, FeedSource> feedIdToFeedSource = FeedUpdater.mapFeedIdsToFeedSources(feedIdsToFeedSourceIds, feedSources);
         assertEquals(fs1, feedIdToFeedSource.get("firstFeed"));
         assertEquals(fs2, feedIdToFeedSource.get("otherFeed"));
+    }
+
+    @Test
+    void shouldGetLatestVersionsSentToPublisher() {
+        // Create two feed sources, and two feed versions in each that have different sentToExternalPublisher values.
+        FeedSource source1 = new FeedSource(FEED_SOURCE_1_ID);
+        source1.id = FEED_SOURCE_1_ID;
+        source1.projectId = PROJECT_NAME;
+        Persistence.feedSources.create(source1);
+
+        FeedSource source2 = new FeedSource(FEED_SOURCE_2_ID);
+        source2.id = FEED_SOURCE_2_ID;
+        source2.projectId = PROJECT_NAME;
+        Persistence.feedSources.create(source2);
+
+        Instant now = Instant.now();
+        Date latestSentDate11 = Date.from(now.minusSeconds(30));
+        Date latestSentDate12 = Date.from(now.minusSeconds(50));
+        Date latestSentDate21 = Date.from(now.minusSeconds(70));
+        Date latestSentDate22 = Date.from(now.minusSeconds(20));
+
+        FeedVersion version11 = new FeedVersion();
+        version11.id = "feed-version11";
+        version11.feedSourceId = FEED_SOURCE_1_ID;
+        version11.sentToExternalPublisher = latestSentDate11;
+        Persistence.feedVersions.create(version11);
+
+        FeedVersion version12 = new FeedVersion(source1);
+        version12.id = "feed-version12";
+        version12.feedSourceId = FEED_SOURCE_1_ID;
+        version12.sentToExternalPublisher = latestSentDate12;
+        Persistence.feedVersions.create(version12);
+
+        FeedVersion version21 = new FeedVersion(source2);
+        version21.id = "feed-version21";
+        version21.feedSourceId = FEED_SOURCE_2_ID;
+        version21.sentToExternalPublisher = latestSentDate21;
+        Persistence.feedVersions.create(version21);
+
+        FeedVersion version22 = new FeedVersion(source2);
+        version22.id = "feed-version22";
+        version22.feedSourceId = FEED_SOURCE_2_ID;
+        version22.sentToExternalPublisher = latestSentDate22;
+        Persistence.feedVersions.create(version22);
+
+        Map<String, FeedVersion> latestVersions = FeedUpdater.getLatestVersionsSentForPublishing(
+            Lists.newArrayList(source1, source2)
+        );
+
+        assertEquals(latestSentDate11, latestVersions.get(FEED_SOURCE_1_ID).sentToExternalPublisher);
+        assertEquals(latestSentDate22, latestVersions.get(FEED_SOURCE_2_ID).sentToExternalPublisher);
     }
 }

--- a/src/test/java/com/conveyal/datatools/manager/jobs/FeedUpdaterTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/jobs/FeedUpdaterTest.java
@@ -8,8 +8,9 @@ import com.conveyal.datatools.manager.models.FeedVersion;
 import com.conveyal.datatools.manager.models.Project;
 import com.conveyal.datatools.manager.persistence.Persistence;
 import com.google.common.collect.Lists;
-import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -22,19 +23,24 @@ import static com.conveyal.datatools.manager.extensions.mtc.MtcFeedResource.AGEN
 import static com.mongodb.client.model.Filters.in;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class FeedUpdaterTest {
     public static final String FEED_SOURCE_1_ID = "feed-source1-id";
     public static final String FEED_SOURCE_2_ID = "feed-source2-id";
+    public static final String FIRST_FEED = "firstFeed";
+    public static final String OTHER_FEED = "otherFeed";
     private static Project project;
-
     private static final String PROJECT_NAME = String.format("Test %s", new Date());
 
     @BeforeAll
     public static void setUp() throws IOException {
         // start server if it isn't already running
         DatatoolsTest.setUp();
+    }
 
+    @BeforeEach
+    void beforeEach() {
         // Create a project.
         project = new Project();
         project.id = PROJECT_NAME;
@@ -42,8 +48,9 @@ class FeedUpdaterTest {
         Persistence.projects.create(project);
     }
 
-    @AfterAll
-    public static void tearDown() {
+    @AfterEach
+    void afterEach() {
+        // Delete feed versions, then the project (that will delete feed sources too).
         Persistence.feedVersions.removeFiltered(in("feedSourceId", FEED_SOURCE_1_ID, FEED_SOURCE_2_ID));
         if (project != null) {
             project.delete();
@@ -64,8 +71,8 @@ class FeedUpdaterTest {
             s3Obj3
         );
         List<String> expectedIds = Lists.newArrayList(
-            "firstFeed",
-            "otherFeed"
+            FIRST_FEED,
+            OTHER_FEED
         );
         assertEquals(expectedIds, FeedUpdater.getFeedIds(s3objects));
     }
@@ -74,18 +81,18 @@ class FeedUpdaterTest {
     void shouldMapFeedIdsToFeedSourceIds() {
         ExternalFeedSourceProperty prop1 = new ExternalFeedSourceProperty();
         prop1.name = AGENCY_ID_FIELDNAME;
-        prop1.value = "firstFeed";
-        prop1.feedSourceId = "id-for-first-feed";
+        prop1.value = FIRST_FEED;
+        prop1.feedSourceId = FEED_SOURCE_1_ID;
 
         ExternalFeedSourceProperty prop2 = new ExternalFeedSourceProperty();
         prop2.name = AGENCY_ID_FIELDNAME;
-        prop2.value = "otherFeed";
-        prop2.feedSourceId = "id1-for-other-feed";
+        prop2.value = OTHER_FEED;
+        prop2.feedSourceId = FEED_SOURCE_2_ID;
 
         ExternalFeedSourceProperty prop3 = new ExternalFeedSourceProperty();
         prop3.name = AGENCY_ID_FIELDNAME;
-        prop3.value = "otherFeed";
-        prop3.feedSourceId = "id2-for-other-feed";
+        prop3.value = OTHER_FEED;
+        prop3.feedSourceId = "other-feed-source-id";
 
         List<ExternalFeedSourceProperty> properties = Lists.newArrayList(
             prop1,
@@ -95,37 +102,36 @@ class FeedUpdaterTest {
 
         Map<String, String> feedIdsToFeedSourceIds = FeedUpdater.mapFeedIdsToFeedSourceIds(properties);
 
-        assertEquals("id-for-first-feed", feedIdsToFeedSourceIds.get("firstFeed"));
-        assertEquals("id2-for-other-feed", feedIdsToFeedSourceIds.get("otherFeed"));
+        assertEquals(FEED_SOURCE_1_ID, feedIdsToFeedSourceIds.get(FIRST_FEED));
+        assertEquals("other-feed-source-id", feedIdsToFeedSourceIds.get(OTHER_FEED));
         assertNull(feedIdsToFeedSourceIds.get("unknownFeed"));
     }
 
     @Test
     void shouldMapFeedIdsToFeedSources() {
         FeedSource fs1 = new FeedSource();
-        fs1.id = "id-for-first-feed";
+        fs1.id = FEED_SOURCE_1_ID;
         FeedSource fs2 = new FeedSource();
-        fs2.id = "id-for-other-feed";
-
+        fs2.id = FEED_SOURCE_2_ID;
         List<FeedSource> feedSources = Lists.newArrayList(fs1, fs2);
 
         ExternalFeedSourceProperty prop1 = new ExternalFeedSourceProperty();
         prop1.name = AGENCY_ID_FIELDNAME;
-        prop1.value = "firstFeed";
-        prop1.feedSourceId = "id-for-first-feed";
+        prop1.value = FIRST_FEED;
+        prop1.feedSourceId = FEED_SOURCE_1_ID;
 
         ExternalFeedSourceProperty prop2 = new ExternalFeedSourceProperty();
         prop2.name = AGENCY_ID_FIELDNAME;
-        prop2.value = "otherFeed";
-        prop2.feedSourceId = "id-for-other-feed";
+        prop2.value = OTHER_FEED;
+        prop2.feedSourceId = FEED_SOURCE_2_ID;
 
         List<ExternalFeedSourceProperty> properties = Lists.newArrayList(prop1, prop2);
 
         Map<String, String> feedIdsToFeedSourceIds = FeedUpdater.mapFeedIdsToFeedSourceIds(properties);
 
         Map<String, FeedSource> feedIdToFeedSource = FeedUpdater.mapFeedIdsToFeedSources(feedIdsToFeedSourceIds, feedSources);
-        assertEquals(fs1, feedIdToFeedSource.get("firstFeed"));
-        assertEquals(fs2, feedIdToFeedSource.get("otherFeed"));
+        assertEquals(fs1, feedIdToFeedSource.get(FIRST_FEED));
+        assertEquals(fs2, feedIdToFeedSource.get(OTHER_FEED));
     }
 
     @Test
@@ -142,40 +148,88 @@ class FeedUpdaterTest {
         Persistence.feedSources.create(source2);
 
         Instant now = Instant.now();
-        Date latestSentDate11 = Date.from(now.minusSeconds(30));
-        Date latestSentDate12 = Date.from(now.minusSeconds(50));
-        Date latestSentDate21 = Date.from(now.minusSeconds(70));
-        Date latestSentDate22 = Date.from(now.minusSeconds(20));
+        Date source1LatestSentDate = Date.from(now.minusSeconds(30));
+        Date source1OtherDate = Date.from(now.minusSeconds(50));
+        Date source2LatestSentDate = Date.from(now.minusSeconds(20));
+        Date source2OtherDate = Date.from(now.minusSeconds(70));
 
         FeedVersion version11 = new FeedVersion();
         version11.id = "feed-version11";
         version11.feedSourceId = FEED_SOURCE_1_ID;
-        version11.sentToExternalPublisher = latestSentDate11;
+        version11.sentToExternalPublisher = source1LatestSentDate;
         Persistence.feedVersions.create(version11);
 
         FeedVersion version12 = new FeedVersion(source1);
         version12.id = "feed-version12";
         version12.feedSourceId = FEED_SOURCE_1_ID;
-        version12.sentToExternalPublisher = latestSentDate12;
+        version12.sentToExternalPublisher = source1OtherDate;
         Persistence.feedVersions.create(version12);
 
         FeedVersion version21 = new FeedVersion(source2);
         version21.id = "feed-version21";
         version21.feedSourceId = FEED_SOURCE_2_ID;
-        version21.sentToExternalPublisher = latestSentDate21;
+        version21.sentToExternalPublisher = source2OtherDate;
         Persistence.feedVersions.create(version21);
 
         FeedVersion version22 = new FeedVersion(source2);
         version22.id = "feed-version22";
         version22.feedSourceId = FEED_SOURCE_2_ID;
-        version22.sentToExternalPublisher = latestSentDate22;
+        version22.sentToExternalPublisher = source2LatestSentDate;
         Persistence.feedVersions.create(version22);
 
         Map<String, FeedVersion> latestVersions = FeedUpdater.getLatestVersionsSentForPublishing(
             Lists.newArrayList(source1, source2)
         );
 
-        assertEquals(latestSentDate11, latestVersions.get(FEED_SOURCE_1_ID).sentToExternalPublisher);
-        assertEquals(latestSentDate22, latestVersions.get(FEED_SOURCE_2_ID).sentToExternalPublisher);
+        FeedVersion source1LatestVersion = latestVersions.get(FEED_SOURCE_1_ID);
+        FeedVersion source2LatestVersion = latestVersions.get(FEED_SOURCE_2_ID);
+        assertEquals("feed-version11", source1LatestVersion.id);
+        assertEquals(source1LatestSentDate, source1LatestVersion.sentToExternalPublisher);
+        assertEquals("feed-version22", source2LatestVersion.id);
+        assertEquals(source2LatestSentDate, source2LatestVersion.sentToExternalPublisher);
+    }
+
+    @Test
+    void shouldGetFeedVersionsToMarkAsProcessed() {
+        FeedSource source1 = new FeedSource(FEED_SOURCE_1_ID);
+        source1.id = FEED_SOURCE_1_ID;
+        source1.projectId = PROJECT_NAME;
+        Persistence.feedSources.create(source1);
+
+        Instant now = Instant.now();
+        Date nowDate = Date.from(now);
+        Date previousDate = Date.from(now.minusSeconds(60));
+
+        FeedVersion versionNotSent = new FeedVersion();
+        versionNotSent.id = "version-not-sent";
+        versionNotSent.feedSourceId = FEED_SOURCE_1_ID;
+        versionNotSent.sentToExternalPublisher = null;
+        Persistence.feedVersions.create(versionNotSent);
+
+        FeedVersion versionNotProcessed = new FeedVersion();
+        versionNotProcessed.id = "version-not-processed";
+        versionNotProcessed.feedSourceId = FEED_SOURCE_1_ID;
+        versionNotProcessed.sentToExternalPublisher = nowDate;
+        versionNotProcessed.processedByExternalPublisher = null;
+        Persistence.feedVersions.create(versionNotProcessed);
+
+        FeedVersion versionNewlyProcessed = new FeedVersion();
+        versionNewlyProcessed.id = "version-newly-processed";
+        versionNewlyProcessed.feedSourceId = FEED_SOURCE_1_ID;
+        versionNewlyProcessed.sentToExternalPublisher = previousDate;
+        versionNewlyProcessed.processedByExternalPublisher = nowDate;
+        Persistence.feedVersions.create(versionNewlyProcessed);
+
+        FeedVersion versionNewlySent = new FeedVersion();
+        versionNewlySent.id = "version-newly-sent";
+        versionNewlySent.feedSourceId = FEED_SOURCE_1_ID;
+        versionNewlySent.sentToExternalPublisher = nowDate;
+        versionNewlySent.processedByExternalPublisher = previousDate;
+        Persistence.feedVersions.create(versionNewlySent);
+
+        List<String> versions = FeedUpdater.getFeedVersionsToMarkAsProcessed();
+        assertEquals(2, versions.size());
+        assertTrue(versions.contains("version-not-processed"));
+        assertTrue(versions.contains("version-newly-sent"));
     }
 }

--- a/src/test/java/com/conveyal/datatools/manager/jobs/FeedUpdaterTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/jobs/FeedUpdaterTest.java
@@ -8,9 +8,9 @@ import com.conveyal.datatools.manager.models.FeedVersion;
 import com.conveyal.datatools.manager.models.Project;
 import com.conveyal.datatools.manager.persistence.Persistence;
 import com.google.common.collect.Lists;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -18,58 +18,66 @@ import java.time.Instant;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static com.conveyal.datatools.manager.extensions.mtc.MtcFeedResource.AGENCY_ID_FIELDNAME;
 import static com.mongodb.client.model.Filters.in;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class FeedUpdaterTest {
-    public static final String FEED_SOURCE_1_ID = "feed-source1-id";
-    public static final String FEED_SOURCE_2_ID = "feed-source2-id";
-    public static final String FIRST_FEED = "firstFeed";
-    public static final String OTHER_FEED = "otherFeed";
+    private static final String FEED_SOURCE_1_ID = "feed-source1-id";
+    private static final String FEED_SOURCE_2_ID = "feed-source2-id";
+    private static final String FIRST_FEED = "firstFeed";
+    private static final String OTHER_FEED = "otherFeed";
     private static Project project;
+    private static FeedSource source1;
+    private static FeedSource source2;
     private static final String PROJECT_NAME = String.format("Test %s", new Date());
 
     @BeforeAll
     public static void setUp() throws IOException {
         // start server if it isn't already running
         DatatoolsTest.setUp();
-    }
 
-    @BeforeEach
-    void beforeEach() {
         // Create a project.
         project = new Project();
         project.id = PROJECT_NAME;
         project.name = PROJECT_NAME;
         Persistence.projects.create(project);
+
+        // Create two feed sources.
+        source1 = persistFeedSource(FEED_SOURCE_1_ID);
+        source2 = persistFeedSource(FEED_SOURCE_2_ID);
     }
 
-    @AfterEach
-    void afterEach() {
-        // Delete feed versions, then the project (that will delete feed sources too).
-        Persistence.feedVersions.removeFiltered(in("feedSourceId", FEED_SOURCE_1_ID, FEED_SOURCE_2_ID));
+    @AfterAll
+    static void afterAll() {
         if (project != null) {
             project.delete();
         }
     }
 
+    @AfterEach
+    void afterEach() {
+        // Delete feed versions created in each test.
+        Persistence.feedVersions.removeFiltered(in("feedSourceId", FEED_SOURCE_1_ID, FEED_SOURCE_2_ID));
+    }
+
     @Test
     void shouldGetFeedIdsFromS3ObjectSummaries() {
-        S3ObjectSummary s3Obj1 = new S3ObjectSummary();
-        s3Obj1.setKey("s3bucket/firstFeed.zip");
-        S3ObjectSummary s3Obj2 = new S3ObjectSummary();
-        s3Obj2.setKey("s3bucket/otherFeed.zip");
-        S3ObjectSummary s3Obj3 = new S3ObjectSummary();
-        s3Obj3.setKey("s3bucket/"); // format for S3 bucket top-level folders.
         List<S3ObjectSummary> s3objects = Lists.newArrayList(
-            s3Obj1,
-            s3Obj2,
-            s3Obj3
-        );
+                "s3bucket/firstFeed.zip",
+                "s3bucket/otherFeed.zip",
+                "s3bucket/"
+            )
+            .stream()
+            .map(k -> {
+                S3ObjectSummary s3Obj = new S3ObjectSummary();
+                s3Obj.setKey("s3bucket/firstFeed.zip");
+                return s3Obj;
+            })
+            .collect(Collectors.toList());
         List<String> expectedIds = Lists.newArrayList(
             FIRST_FEED,
             OTHER_FEED
@@ -79,157 +87,95 @@ class FeedUpdaterTest {
 
     @Test
     void shouldMapFeedIdsToFeedSourceIds() {
-        ExternalFeedSourceProperty prop1 = new ExternalFeedSourceProperty();
-        prop1.name = AGENCY_ID_FIELDNAME;
-        prop1.value = FIRST_FEED;
-        prop1.feedSourceId = FEED_SOURCE_1_ID;
-
-        ExternalFeedSourceProperty prop2 = new ExternalFeedSourceProperty();
-        prop2.name = AGENCY_ID_FIELDNAME;
-        prop2.value = OTHER_FEED;
-        prop2.feedSourceId = FEED_SOURCE_2_ID;
-
-        ExternalFeedSourceProperty prop3 = new ExternalFeedSourceProperty();
-        prop3.name = AGENCY_ID_FIELDNAME;
-        prop3.value = OTHER_FEED;
-        prop3.feedSourceId = "other-feed-source-id";
-
         List<ExternalFeedSourceProperty> properties = Lists.newArrayList(
-            prop1,
-            prop2,
-            prop3
+            makeFeedSourceProperty(FIRST_FEED, FEED_SOURCE_1_ID),
+            makeFeedSourceProperty(OTHER_FEED, FEED_SOURCE_2_ID),
+            makeFeedSourceProperty(OTHER_FEED, "other-feed-source-id")
         );
-
         Map<String, String> feedIdsToFeedSourceIds = FeedUpdater.mapFeedIdsToFeedSourceIds(properties);
 
         assertEquals(FEED_SOURCE_1_ID, feedIdsToFeedSourceIds.get(FIRST_FEED));
         assertEquals("other-feed-source-id", feedIdsToFeedSourceIds.get(OTHER_FEED));
-        assertNull(feedIdsToFeedSourceIds.get("unknownFeed"));
     }
 
     @Test
     void shouldMapFeedIdsToFeedSources() {
-        FeedSource fs1 = new FeedSource();
-        fs1.id = FEED_SOURCE_1_ID;
-        FeedSource fs2 = new FeedSource();
-        fs2.id = FEED_SOURCE_2_ID;
-        List<FeedSource> feedSources = Lists.newArrayList(fs1, fs2);
-
-        ExternalFeedSourceProperty prop1 = new ExternalFeedSourceProperty();
-        prop1.name = AGENCY_ID_FIELDNAME;
-        prop1.value = FIRST_FEED;
-        prop1.feedSourceId = FEED_SOURCE_1_ID;
-
-        ExternalFeedSourceProperty prop2 = new ExternalFeedSourceProperty();
-        prop2.name = AGENCY_ID_FIELDNAME;
-        prop2.value = OTHER_FEED;
-        prop2.feedSourceId = FEED_SOURCE_2_ID;
-
-        List<ExternalFeedSourceProperty> properties = Lists.newArrayList(prop1, prop2);
+        List<FeedSource> feedSources = Lists.newArrayList(source1, source2);
+        List<ExternalFeedSourceProperty> properties = Lists.newArrayList(
+            makeFeedSourceProperty(FIRST_FEED, FEED_SOURCE_1_ID),
+            makeFeedSourceProperty(OTHER_FEED, FEED_SOURCE_2_ID)
+        );
 
         Map<String, String> feedIdsToFeedSourceIds = FeedUpdater.mapFeedIdsToFeedSourceIds(properties);
 
         Map<String, FeedSource> feedIdToFeedSource = FeedUpdater.mapFeedIdsToFeedSources(feedIdsToFeedSourceIds, feedSources);
-        assertEquals(fs1, feedIdToFeedSource.get(FIRST_FEED));
-        assertEquals(fs2, feedIdToFeedSource.get(OTHER_FEED));
+        assertEquals(source1, feedIdToFeedSource.get(FIRST_FEED));
+        assertEquals(source2, feedIdToFeedSource.get(OTHER_FEED));
     }
 
     @Test
     void shouldGetLatestVersionsSentToPublisher() {
-        // Create two feed sources, and two feed versions in each that have different sentToExternalPublisher values.
-        FeedSource source1 = new FeedSource(FEED_SOURCE_1_ID);
-        source1.id = FEED_SOURCE_1_ID;
-        source1.projectId = PROJECT_NAME;
-        Persistence.feedSources.create(source1);
-
-        FeedSource source2 = new FeedSource(FEED_SOURCE_2_ID);
-        source2.id = FEED_SOURCE_2_ID;
-        source2.projectId = PROJECT_NAME;
-        Persistence.feedSources.create(source2);
-
+        // In each of the two pre-created feed sources, create and two feed versions
+        // that have different sentToExternalPublisher values.
         Instant now = Instant.now();
         Date source1LatestSentDate = Date.from(now.minusSeconds(30));
         Date source1OtherDate = Date.from(now.minusSeconds(50));
         Date source2LatestSentDate = Date.from(now.minusSeconds(20));
         Date source2OtherDate = Date.from(now.minusSeconds(70));
 
-        FeedVersion version11 = new FeedVersion();
-        version11.id = "feed-version11";
-        version11.feedSourceId = FEED_SOURCE_1_ID;
-        version11.sentToExternalPublisher = source1LatestSentDate;
-        Persistence.feedVersions.create(version11);
-
-        FeedVersion version12 = new FeedVersion(source1);
-        version12.id = "feed-version12";
-        version12.feedSourceId = FEED_SOURCE_1_ID;
-        version12.sentToExternalPublisher = source1OtherDate;
-        Persistence.feedVersions.create(version12);
-
-        FeedVersion version21 = new FeedVersion(source2);
-        version21.id = "feed-version21";
-        version21.feedSourceId = FEED_SOURCE_2_ID;
-        version21.sentToExternalPublisher = source2OtherDate;
-        Persistence.feedVersions.create(version21);
-
-        FeedVersion version22 = new FeedVersion(source2);
-        version22.id = "feed-version22";
-        version22.feedSourceId = FEED_SOURCE_2_ID;
-        version22.sentToExternalPublisher = source2LatestSentDate;
-        Persistence.feedVersions.create(version22);
+        persistFeedVersion("feed-version11", FEED_SOURCE_1_ID, source1LatestSentDate, null);
+        persistFeedVersion("feed-version12", FEED_SOURCE_1_ID, source1OtherDate, null);
+        persistFeedVersion("feed-version21", FEED_SOURCE_2_ID, source2OtherDate, null);
+        persistFeedVersion("feed-version22", FEED_SOURCE_2_ID, source2LatestSentDate, null);
 
         Map<String, FeedVersion> latestVersions = FeedUpdater.getLatestVersionsSentForPublishing(
             Lists.newArrayList(source1, source2)
         );
 
-        FeedVersion source1LatestVersion = latestVersions.get(FEED_SOURCE_1_ID);
-        FeedVersion source2LatestVersion = latestVersions.get(FEED_SOURCE_2_ID);
-        assertEquals("feed-version11", source1LatestVersion.id);
-        assertEquals(source1LatestSentDate, source1LatestVersion.sentToExternalPublisher);
-        assertEquals("feed-version22", source2LatestVersion.id);
-        assertEquals(source2LatestSentDate, source2LatestVersion.sentToExternalPublisher);
+        checkFeedVersionDates("feed-version11", latestVersions.get(FEED_SOURCE_1_ID), source1LatestSentDate);
+        checkFeedVersionDates("feed-version22", latestVersions.get(FEED_SOURCE_2_ID), source2LatestSentDate);
+    }
+
+    private static void checkFeedVersionDates(String versionId, FeedVersion version, Date sentDate) {
+        assertEquals(versionId, version.id);
+        assertEquals(sentDate, version.sentToExternalPublisher);
     }
 
     @Test
     void shouldGetFeedVersionsToMarkAsProcessed() {
-        FeedSource source1 = new FeedSource(FEED_SOURCE_1_ID);
-        source1.id = FEED_SOURCE_1_ID;
-        source1.projectId = PROJECT_NAME;
-        Persistence.feedSources.create(source1);
-
         Instant now = Instant.now();
         Date nowDate = Date.from(now);
         Date previousDate = Date.from(now.minusSeconds(60));
 
-        FeedVersion versionNotSent = new FeedVersion();
-        versionNotSent.id = "version-not-sent";
-        versionNotSent.feedSourceId = FEED_SOURCE_1_ID;
-        versionNotSent.sentToExternalPublisher = null;
-        Persistence.feedVersions.create(versionNotSent);
-
-        FeedVersion versionNotProcessed = new FeedVersion();
-        versionNotProcessed.id = "version-not-processed";
-        versionNotProcessed.feedSourceId = FEED_SOURCE_1_ID;
-        versionNotProcessed.sentToExternalPublisher = nowDate;
-        versionNotProcessed.processedByExternalPublisher = null;
-        Persistence.feedVersions.create(versionNotProcessed);
-
-        FeedVersion versionNewlyProcessed = new FeedVersion();
-        versionNewlyProcessed.id = "version-newly-processed";
-        versionNewlyProcessed.feedSourceId = FEED_SOURCE_1_ID;
-        versionNewlyProcessed.sentToExternalPublisher = previousDate;
-        versionNewlyProcessed.processedByExternalPublisher = nowDate;
-        Persistence.feedVersions.create(versionNewlyProcessed);
-
-        FeedVersion versionNewlySent = new FeedVersion();
-        versionNewlySent.id = "version-newly-sent";
-        versionNewlySent.feedSourceId = FEED_SOURCE_1_ID;
-        versionNewlySent.sentToExternalPublisher = nowDate;
-        versionNewlySent.processedByExternalPublisher = previousDate;
-        Persistence.feedVersions.create(versionNewlySent);
+        persistFeedVersion("version-not-sent", FEED_SOURCE_1_ID, null, null);
+        persistFeedVersion("version-not-processed", FEED_SOURCE_1_ID, nowDate, null);
+        persistFeedVersion("version-newly-processed", FEED_SOURCE_1_ID, previousDate, nowDate);
+        persistFeedVersion("version-newly-sent", FEED_SOURCE_1_ID, nowDate, previousDate);
 
         List<String> versions = FeedUpdater.getFeedVersionsToMarkAsProcessed();
         assertEquals(2, versions.size());
         assertTrue(versions.contains("version-not-processed"));
         assertTrue(versions.contains("version-newly-sent"));
+    }
+
+    private static ExternalFeedSourceProperty makeFeedSourceProperty(String feedId, String feedSourceId) {
+        return new ExternalFeedSourceProperty(feedSourceId, "MTC", AGENCY_ID_FIELDNAME, feedId);
+    }
+
+    private static void persistFeedVersion(String id, String feedSourceId, Date sentDate, Date processedDate) {
+        FeedVersion feedVersion = new FeedVersion();
+        feedVersion.id = id;
+        feedVersion.feedSourceId = feedSourceId;
+        feedVersion.sentToExternalPublisher = sentDate;
+        feedVersion.processedByExternalPublisher = processedDate;
+        Persistence.feedVersions.create(feedVersion);
+    }
+
+    private static FeedSource persistFeedSource(String feedSourceId) {
+        FeedSource source1 = new FeedSource(feedSourceId);
+        source1.id = feedSourceId;
+        source1.projectId = PROJECT_NAME;
+        Persistence.feedSources.create(source1);
+        return source1;
     }
 }

--- a/src/test/java/com/conveyal/datatools/manager/jobs/FeedUpdaterTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/jobs/FeedUpdaterTest.java
@@ -1,0 +1,60 @@
+package com.conveyal.datatools.manager.jobs;
+
+import com.amazonaws.services.s3.model.S3ObjectSummary;
+import com.conveyal.datatools.manager.models.ExternalFeedSourceProperty;
+import com.google.common.collect.Lists;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static com.conveyal.datatools.manager.extensions.mtc.MtcFeedResource.AGENCY_ID_FIELDNAME;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class FeedUpdaterTest {
+    @Test
+    void shouldGetFeedIdsFromS3ObjectSummaries() {
+        S3ObjectSummary s3Obj1 = new S3ObjectSummary();
+        s3Obj1.setKey("s3bucket/firstFeed");
+        S3ObjectSummary s3Obj2 = new S3ObjectSummary();
+        s3Obj2.setKey("s3bucket/otherFeed");
+        S3ObjectSummary s3Obj3 = new S3ObjectSummary();
+        s3Obj3.setKey("s3bucket/"); // format for S3 bucket top-level folders.
+        List<S3ObjectSummary> s3objects = Lists.newArrayList(
+            s3Obj1,
+            s3Obj2,
+            s3Obj3
+        );
+        List<String> expectedIds = Lists.newArrayList(
+            "firstFeed",
+            "otherFeed"
+        );
+        assertEquals(expectedIds, FeedUpdater.getFeedIds(s3objects));
+    }
+
+    @Test
+    void shouldFilterPropertiesForFeedId() {
+        ExternalFeedSourceProperty prop1 = new ExternalFeedSourceProperty();
+        prop1.name = AGENCY_ID_FIELDNAME;
+        prop1.value = "firstFeed";
+        prop1.feedSourceId = "id-for-first-feed";
+
+        ExternalFeedSourceProperty prop2 = new ExternalFeedSourceProperty();
+        prop2.name = AGENCY_ID_FIELDNAME;
+        prop2.value = "otherFeed";
+        prop2.feedSourceId = "id1-for-other-feed";
+
+        ExternalFeedSourceProperty prop3 = new ExternalFeedSourceProperty();
+        prop3.name = AGENCY_ID_FIELDNAME;
+        prop3.value = "otherFeed";
+        prop3.feedSourceId = "id2-for-other-feed";
+
+        List<ExternalFeedSourceProperty> properties = Lists.newArrayList(
+            prop1,
+            prop2,
+            prop3
+        );
+
+        assertEquals(Lists.newArrayList(prop1), FeedUpdater.getPropertiesForFeedId(properties, "firstFeed"));
+        assertEquals(Lists.newArrayList(prop2, prop3), FeedUpdater.getPropertiesForFeedId(properties, "otherFeed"));
+    }
+}


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected => This is a patch on the MTC deployment branch. A similar PR will eventually be issued to the `dev` branch.
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [na] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [ ] All tests and CI builds passing => Semantic release does not pick up the correct Node version.

### Description

This PR improves performance and memory usage of the `FeedUpdater` feature:
- the query that populates/updates `versionsToMarkAsProcessed` uses less memory by only requesting the `id` field (and using `FeedVersionSummaries` instead of `FeedVersion`) (see comparison charts below). A bug in the query is also fixed.
- A single mongo query is performed, instead of one per agency, to get a map of all feed sources by agency (what MTC calls "feed id").
- A single mongo query is performed, instead of one per agency, to get a map of the latest feed version sent to publishing for each feed source.

Screenshots of memory profiles (left: current, right: with PR changes):

<img width="844" alt="image" src="https://user-images.githubusercontent.com/56846598/216437613-5a9859d2-a5df-4c57-8c27-c0203e15f44a.png">
