### PR TITLE
Return otpServers with /project endpoint to allow speedup

### DIFF
--- a/src/main/java/com/conveyal/datatools/manager/controllers/api/ProjectController.java
+++ b/src/main/java/com/conveyal/datatools/manager/controllers/api/ProjectController.java
@@ -343,16 +343,17 @@ public class ProjectController {
      */
     public static void register (String apiPrefix) {
         // Construct JSON managers which help serialize the response. Slim JSON is the generic JSON view. Full JSON
-        // contains additional fields (at the moment just #otpServers) and should only be used when the controller
+        // contains additional fields (at the moment just #OtpServerWithoutEc2Instances) and should only be used when the controller
         // returns a single project (slimJson is better suited for a collection). If fullJson is attempted for use
-        // with a collection, massive performance issues will ensure (mainly due to multiple calls to AWS EC2).
+        // with a collection, massive performance issues will ensue (mainly due to multiple calls to AWS EC2).
         JsonManager<Project> slimJson = new JsonManager<>(Project.class, JsonViews.UserInterface.class);
         JsonManager<Project> fullJson = new JsonManager<>(Project.class, JsonViews.UserInterface.class);
         fullJson.addMixin(Project.class, Project.ProjectWithOtpServers.class);
         fullJson.addMixin(OtpServer.class, OtpServer.OtpServerWithoutEc2Instances.class);
+        slimJson.addMixin(Project.class, Project.ProjectWithOtpServers.class);
 
         get(apiPrefix + "secure/project/:id", ProjectController::getProject, fullJson::write);
-        get(apiPrefix + "secure/project", ProjectController::getAllProjects, fullJson::write);
+        get(apiPrefix + "secure/project", ProjectController::getAllProjects, slimJson::write);
         post(apiPrefix + "secure/project", ProjectController::createProject, fullJson::write);
         put(apiPrefix + "secure/project/:id", ProjectController::updateProject, fullJson::write);
         delete(apiPrefix + "secure/project/:id", ProjectController::deleteProject, fullJson::write);

--- a/src/main/java/com/conveyal/datatools/manager/controllers/api/ProjectController.java
+++ b/src/main/java/com/conveyal/datatools/manager/controllers/api/ProjectController.java
@@ -352,7 +352,7 @@ public class ProjectController {
         fullJson.addMixin(OtpServer.class, OtpServer.OtpServerWithoutEc2Instances.class);
 
         get(apiPrefix + "secure/project/:id", ProjectController::getProject, fullJson::write);
-        get(apiPrefix + "secure/project", ProjectController::getAllProjects, slimJson::write);
+        get(apiPrefix + "secure/project", ProjectController::getAllProjects, fullJson::write);
         post(apiPrefix + "secure/project", ProjectController::createProject, fullJson::write);
         put(apiPrefix + "secure/project/:id", ProjectController::updateProject, fullJson::write);
         delete(apiPrefix + "secure/project/:id", ProjectController::deleteProject, fullJson::write);


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Recent front end PRs (https://github.com/ibi-group/datatools-ui/pull/895) have tried to reduce the amount of data that is unnecessarily requested by the front end. This endpoint created a conflict bc the /project and project:id differed in their return structure (specifically in returning otpServers). 

Per the comment in the backend, I'm worried about performance issues with this change: 
<img width="890" alt="image" src="https://user-images.githubusercontent.com/63798641/219787515-1c4cff83-60e3-4fa9-a712-2a11034b52bf.png">

TODO: perhaps the ProjectWithOtpServers should not be a mixin anymore? 

