### PR TITLE
fix(MobilityDataValidation): slow on large gtfs files

### DIFF
--- a/src/main/java/com/conveyal/datatools/manager/models/FeedVersion.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/FeedVersion.java
@@ -393,8 +393,8 @@ public class FeedVersion extends Model implements Serializable {
             status.update("MobilityData Analysis...", 11);
 
             // Wait for the file to be entirely copied into the directory.
-            // TODO: base this on the file being completely saved rather than a fixed amount of time.
-            Thread.sleep(5000);
+            // 5 seconds + ~1 second per 10mb
+            Thread.sleep(5000 + (this.fileSize / 10000));
             File gtfsZip = this.retrieveGtfsFile();
             // Namespace based folders avoid clash for validation being run on multiple versions of a feed.
             // TODO: do we know that there will always be a namespace?

--- a/src/main/java/com/conveyal/datatools/manager/models/FeedVersion.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/FeedVersion.java
@@ -393,7 +393,7 @@ public class FeedVersion extends Model implements Serializable {
             status.update("MobilityData Analysis...", 11);
 
             // Wait for the file to be entirely copied into the directory.
-            // 5 seconds + ~1 second per 10mb
+            // 5 seconds + ~1 second per 100kb
             Thread.sleep(5000 + (this.fileSize / 10000));
             File gtfsZip = this.retrieveGtfsFile();
             // Namespace based folders avoid clash for validation being run on multiple versions of a feed.

--- a/src/main/java/com/conveyal/datatools/manager/models/FeedVersion.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/FeedVersion.java
@@ -393,7 +393,7 @@ public class FeedVersion extends Model implements Serializable {
             status.update("MobilityData Analysis...", 11);
 
             // Wait for the file to be entirely copied into the directory.
-            // 5 seconds + ~1 second per 100kb
+            // 5 seconds + ~1 second per 10mb
             Thread.sleep(5000 + (this.fileSize / 10000));
             File gtfsZip = this.retrieveGtfsFile();
             // Namespace based folders avoid clash for validation being run on multiple versions of a feed.


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

The MobilityData validator takes a while between finishing and saving results. There is no way to check when this process completes using their api. The solution is to do a wait, currently 5 seconds. However, on large feeds this is not enough. The solution is to adjust the wait depending on file size.

Closes #524 

Looking to try this fix on as wide a variety of systems as possible to make sure the values are correct