### PR TITLE
Add custom file and preserve fields transformations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -415,13 +415,6 @@
             <version>1.26</version>
         </dependency>
 
-        <!-- CSV library for reading / writing in custom fields transformation -->
-        <dependency>
-            <groupId>com.opencsv</groupId>
-            <artifactId>opencsv</artifactId>
-            <version>5.7.1</version>
-        </dependency>
-
         <!-- Used for writing csv for merged feeds. Note: this appears to be one of the only
           CSV libraries that will only quote values when necessary (e.g., there is a comma character
           contained within the value) and that will work with an output stream writer when writing

--- a/pom.xml
+++ b/pom.xml
@@ -268,7 +268,7 @@
             <groupId>com.github.conveyal</groupId>
             <artifactId>gtfs-lib</artifactId>
             <!-- Latest dev build on jitpack.io -->
-            <version>41a6503</version>
+            <version>a3e5707</version>
             <!-- Exclusions added in order to silence SLF4J warnings about multiple bindings:
                 http://www.slf4j.org/codes.html#multiple_bindings
             -->

--- a/pom.xml
+++ b/pom.xml
@@ -414,7 +414,6 @@
             <artifactId>snakeyaml</artifactId>
             <version>1.26</version>
         </dependency>
-
         <!-- Used for writing csv for merged feeds. Note: this appears to be one of the only
           CSV libraries that will only quote values when necessary (e.g., there is a comma character
           contained within the value) and that will work with an output stream writer when writing

--- a/pom.xml
+++ b/pom.xml
@@ -268,7 +268,7 @@
             <groupId>com.github.conveyal</groupId>
             <artifactId>gtfs-lib</artifactId>
             <!-- Latest dev build on jitpack.io -->
-            <version>3d79493</version>
+            <version>41a6503</version>
             <!-- Exclusions added in order to silence SLF4J warnings about multiple bindings:
                 http://www.slf4j.org/codes.html#multiple_bindings
             -->
@@ -414,6 +414,14 @@
             <artifactId>snakeyaml</artifactId>
             <version>1.26</version>
         </dependency>
+
+        <!-- CSV library for reading / writing in custom fields transformation -->
+        <dependency>
+            <groupId>com.opencsv</groupId>
+            <artifactId>opencsv</artifactId>
+            <version>5.7.1</version>
+        </dependency>
+
         <!-- Used for writing csv for merged feeds. Note: this appears to be one of the only
           CSV libraries that will only quote values when necessary (e.g., there is a comma character
           contained within the value) and that will work with an output stream writer when writing

--- a/src/main/java/com/conveyal/datatools/manager/models/TableTransformResult.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/TableTransformResult.java
@@ -11,6 +11,7 @@ public class TableTransformResult implements Serializable {
     public int deletedCount;
     public int updatedCount;
     public int addedCount;
+    public int customColumnsAdded;
     public TransformType transformType;
     public String tableName;
 
@@ -19,6 +20,22 @@ public class TableTransformResult implements Serializable {
     public TableTransformResult(String tableName, TransformType transformType) {
         this.tableName = tableName;
         this.transformType = transformType;
+    }
+
+    public TableTransformResult(
+            String tableName,
+            TransformType transformType,
+            int deletedCount,
+            int updatedCount,
+            int addedCount,
+            int customColumnsAdded
+    ) {
+        this.tableName = tableName;
+        this.transformType = transformType;
+        this.deletedCount = deletedCount;
+        this.updatedCount = updatedCount;
+        this.addedCount = addedCount;
+        this.customColumnsAdded = customColumnsAdded;
     }
 
     public TableTransformResult(String tableName, int deletedCount, int updatedCount, int addedCount) {

--- a/src/main/java/com/conveyal/datatools/manager/models/TableTransformResult.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/TableTransformResult.java
@@ -11,6 +11,7 @@ public class TableTransformResult implements Serializable {
     public int deletedCount;
     public int updatedCount;
     public int addedCount;
+    public int customColumnsAdded;
     public TransformType transformType;
     public String tableName;
 
@@ -19,6 +20,22 @@ public class TableTransformResult implements Serializable {
     public TableTransformResult(String tableName, TransformType transformType) {
         this.tableName = tableName;
         this.transformType = transformType;
+    }
+
+    public TableTransformResult(
+        String tableName,
+        TransformType transformType,
+        int deletedCount,
+        int updatedCount,
+        int addedCount,
+        int customColumnsAdded
+    ) {
+        this.tableName = tableName;
+        this.transformType = transformType;
+        this.deletedCount = deletedCount;
+        this.updatedCount = updatedCount;
+        this.addedCount = addedCount;
+        this.customColumnsAdded = customColumnsAdded;
     }
 
     public TableTransformResult(String tableName, int deletedCount, int updatedCount, int addedCount) {

--- a/src/main/java/com/conveyal/datatools/manager/models/TableTransformResult.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/TableTransformResult.java
@@ -11,7 +11,6 @@ public class TableTransformResult implements Serializable {
     public int deletedCount;
     public int updatedCount;
     public int addedCount;
-    public int customColumnsAdded;
     public TransformType transformType;
     public String tableName;
 
@@ -20,22 +19,6 @@ public class TableTransformResult implements Serializable {
     public TableTransformResult(String tableName, TransformType transformType) {
         this.tableName = tableName;
         this.transformType = transformType;
-    }
-
-    public TableTransformResult(
-        String tableName,
-        TransformType transformType,
-        int deletedCount,
-        int updatedCount,
-        int addedCount,
-        int customColumnsAdded
-    ) {
-        this.tableName = tableName;
-        this.transformType = transformType;
-        this.deletedCount = deletedCount;
-        this.updatedCount = updatedCount;
-        this.addedCount = addedCount;
-        this.customColumnsAdded = customColumnsAdded;
     }
 
     public TableTransformResult(String tableName, int deletedCount, int updatedCount, int addedCount) {

--- a/src/main/java/com/conveyal/datatools/manager/models/transform/AddCustomFileFromStringTransformation.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/transform/AddCustomFileFromStringTransformation.java
@@ -4,6 +4,16 @@ import com.conveyal.datatools.common.status.MonitorableJob;
 
 public class AddCustomFileFromStringTransformation extends StringTransformation {
 
+    // Additional create method required to ensure transformation type is AddCustomFile in tests.
+    // Otherwise, we'd use the StringTransformation#create which doesn't differentiate types and hence
+    // would fail table name tests.
+    public static AddCustomFileFromStringTransformation create(String csvData, String table) {
+        AddCustomFileFromStringTransformation transformation = new AddCustomFileFromStringTransformation();
+        transformation.csvData = csvData;
+        transformation.table = table;
+        return transformation;
+    }
+
     @Override
     public void validateTableName(MonitorableJob.Status status) {
         if (table.contains(".txt")) {

--- a/src/main/java/com/conveyal/datatools/manager/models/transform/AddCustomFileFromStringTransformation.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/transform/AddCustomFileFromStringTransformation.java
@@ -1,4 +1,5 @@
 package com.conveyal.datatools.manager.models.transform;
+
 import com.conveyal.datatools.common.status.MonitorableJob;
 
 public class AddCustomFileFromStringTransformation extends StringTransformation {

--- a/src/main/java/com/conveyal/datatools/manager/models/transform/AddCustomFileFromStringTransformation.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/transform/AddCustomFileFromStringTransformation.java
@@ -1,0 +1,13 @@
+package com.conveyal.datatools.manager.models.transform;
+import com.conveyal.datatools.common.status.MonitorableJob;
+
+public class AddCustomFileFromStringTransformation extends ReplaceFileFromStringTransformation {
+
+    @Override
+    public void validateTableName(MonitorableJob.Status status) {
+        if (table.contains(".txt")) {
+            status.fail("CSV Table name should not contain .txt");
+        }
+    }
+
+}

--- a/src/main/java/com/conveyal/datatools/manager/models/transform/AddCustomFileFromStringTransformation.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/transform/AddCustomFileFromStringTransformation.java
@@ -1,7 +1,7 @@
 package com.conveyal.datatools.manager.models.transform;
 import com.conveyal.datatools.common.status.MonitorableJob;
 
-public class AddCustomFileFromStringTransformation extends ReplaceFileFromStringTransformation {
+public class AddCustomFileFromStringTransformation extends StringTransformation {
 
     @Override
     public void validateTableName(MonitorableJob.Status status) {

--- a/src/main/java/com/conveyal/datatools/manager/models/transform/FeedTransformation.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/transform/FeedTransformation.java
@@ -27,12 +27,12 @@ import java.io.Serializable;
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME)
 @JsonSubTypes({
-        @JsonSubTypes.Type(value = DeleteRecordsTransformation.class, name = "DeleteRecordsTransformation"),
-        @JsonSubTypes.Type(value = NormalizeFieldTransformation.class, name = "NormalizeFieldTransformation"),
-        @JsonSubTypes.Type(value = ReplaceFileFromVersionTransformation.class, name = "ReplaceFileFromVersionTransformation"),
-        @JsonSubTypes.Type(value = ReplaceFileFromStringTransformation.class, name = "ReplaceFileFromStringTransformation"),
-        @JsonSubTypes.Type(value = PreserveCustomFieldsTransformation.class, name = "PreserveCustomFieldsTransformation"),
-        @JsonSubTypes.Type(value = AddCustomFileFromStringTransformation.class, name = "AddCustomFileTransformation")
+    @JsonSubTypes.Type(value = DeleteRecordsTransformation.class, name = "DeleteRecordsTransformation"),
+    @JsonSubTypes.Type(value = NormalizeFieldTransformation.class, name = "NormalizeFieldTransformation"),
+    @JsonSubTypes.Type(value = ReplaceFileFromVersionTransformation.class, name = "ReplaceFileFromVersionTransformation"),
+    @JsonSubTypes.Type(value = ReplaceFileFromStringTransformation.class, name = "ReplaceFileFromStringTransformation"),
+    @JsonSubTypes.Type(value = PreserveCustomFieldsTransformation.class, name = "PreserveCustomFieldsTransformation"),
+    @JsonSubTypes.Type(value = AddCustomFileFromStringTransformation.class, name = "AddCustomFileTransformation")
 })
 public abstract class FeedTransformation<Target extends FeedTransformTarget> implements Serializable {
     private static final long serialVersionUID = 1L;

--- a/src/main/java/com/conveyal/datatools/manager/models/transform/FeedTransformation.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/transform/FeedTransformation.java
@@ -27,10 +27,11 @@ import java.io.Serializable;
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME)
 @JsonSubTypes({
-    @JsonSubTypes.Type(value = DeleteRecordsTransformation.class, name = "DeleteRecordsTransformation"),
-    @JsonSubTypes.Type(value = NormalizeFieldTransformation.class, name = "NormalizeFieldTransformation"),
-    @JsonSubTypes.Type(value = ReplaceFileFromVersionTransformation.class, name = "ReplaceFileFromVersionTransformation"),
-    @JsonSubTypes.Type(value = ReplaceFileFromStringTransformation.class, name = "ReplaceFileFromStringTransformation")
+        @JsonSubTypes.Type(value = DeleteRecordsTransformation.class, name = "DeleteRecordsTransformation"),
+        @JsonSubTypes.Type(value = NormalizeFieldTransformation.class, name = "NormalizeFieldTransformation"),
+        @JsonSubTypes.Type(value = ReplaceFileFromVersionTransformation.class, name = "ReplaceFileFromVersionTransformation"),
+        @JsonSubTypes.Type(value = ReplaceFileFromStringTransformation.class, name = "ReplaceFileFromStringTransformation"),
+        @JsonSubTypes.Type(value = PreserveCustomFieldsTransformation.class, name = "PreserveCustomFieldsTransformation")
 })
 public abstract class FeedTransformation<Target extends FeedTransformTarget> implements Serializable {
     private static final long serialVersionUID = 1L;

--- a/src/main/java/com/conveyal/datatools/manager/models/transform/FeedTransformation.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/transform/FeedTransformation.java
@@ -31,7 +31,8 @@ import java.io.Serializable;
         @JsonSubTypes.Type(value = NormalizeFieldTransformation.class, name = "NormalizeFieldTransformation"),
         @JsonSubTypes.Type(value = ReplaceFileFromVersionTransformation.class, name = "ReplaceFileFromVersionTransformation"),
         @JsonSubTypes.Type(value = ReplaceFileFromStringTransformation.class, name = "ReplaceFileFromStringTransformation"),
-        @JsonSubTypes.Type(value = PreserveCustomFieldsTransformation.class, name = "PreserveCustomFieldsTransformation")
+        @JsonSubTypes.Type(value = PreserveCustomFieldsTransformation.class, name = "PreserveCustomFieldsTransformation"),
+        @JsonSubTypes.Type(value = AddCustomFileFromStringTransformation.class, name = "AddCustomFileTransformation")
 })
 public abstract class FeedTransformation<Target extends FeedTransformTarget> implements Serializable {
     private static final long serialVersionUID = 1L;

--- a/src/main/java/com/conveyal/datatools/manager/models/transform/FeedTransformation.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/transform/FeedTransformation.java
@@ -70,6 +70,8 @@ public abstract class FeedTransformation<Target extends FeedTransformTarget> imp
             status.fail(
                 String.format("Transformation must be of type '%s'.", getTransformationTypeName())
             );
+        } catch (Exception e) {
+            status.fail(e.toString());
         }
     }
 
@@ -80,7 +82,7 @@ public abstract class FeedTransformation<Target extends FeedTransformTarget> imp
      * @param target The database-bound or ZIP-file-bound target the transformation will operate on.
      * @param status Used to report success or failure status and details.
      */
-    public abstract void transform(Target target, MonitorableJob.Status status);
+    public abstract void transform(Target target, MonitorableJob.Status status) throws Exception;
 
     /**
      * At the moment, used by DbTransformation to validate field names.
@@ -100,7 +102,6 @@ public abstract class FeedTransformation<Target extends FeedTransformTarget> imp
         // Validate fields before running transform.
         if (GtfsUtils.getGtfsTable(table) == null) {
             status.fail("Table must be valid GTFS spec table name (without .txt).");
-            return;
         }
     }
 }

--- a/src/main/java/com/conveyal/datatools/manager/models/transform/PreserveCustomFieldsTransformation.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/transform/PreserveCustomFieldsTransformation.java
@@ -41,18 +41,11 @@ public class PreserveCustomFieldsTransformation extends ZipTransformation {
         }
     }
 
-    public static <T> Collector<T, ?, T> toSingleton() {
-        return Collectors.collectingAndThen(
-                Collectors.toList(),
-                list -> {
-                    if (list.size() != 1) {
-                        throw new IllegalStateException();
-                    }
-                    return list.get(0);
-                }
-        );
-    }
-
+    /**
+     * This method creates a hash map of the GTFS table keys to the custom CSV values for efficient lookup of custom values.
+     * The hash map key is the key values of the GTFS table (e.g. stop_id for stops) concatenated by an underscore.
+     * The hash map value is the CsvMapReader (mapping of column to row value)
+     */
     private static HashMap<String, Map<String, String>> createCsvHashMap(CsvMapReader reader, String[] headers) throws IOException {
         HashMap<String, Map<String, String>> lookup = new HashMap<>();
         Map<String, String> nextLine;
@@ -69,61 +62,61 @@ public class PreserveCustomFieldsTransformation extends ZipTransformation {
         String tableName = table + ".txt";
         Path targetZipPath = Paths.get(zipTarget.gtfsFile.getAbsolutePath());
 
-        // TODO: is there a better way to do this than using a Singleton collector?
         specTable = Arrays.stream(Table.tablesInOrder)
-                .filter(t -> t.name.equals(table))
-                .collect(toSingleton());
+            .filter(t -> t.name.equals(table))
+            .findFirst()
+            .get();
+        List<String> specTableFields = specTable.specFields().stream().map(f -> f.name).collect(Collectors.toList());
         tablePrimaryKeys = specTable.getPrimaryKeyNames();
 
-        try( FileSystem targetZipFs = FileSystems.newFileSystem(targetZipPath, (ClassLoader) null) ){
-            List<String> specTableFields = specTable.specFields().stream().map(f -> f.name).collect(Collectors.toList());
+        try(FileSystem targetZipFs = FileSystems.newFileSystem( targetZipPath,(ClassLoader) null)){
             Path targetTxtFilePath = getTablePathInZip(tableName, targetZipFs);
 
-            // TODO: There must be a better way to do this.
             InputStream is = Files.newInputStream(targetTxtFilePath);
             final File tempFile = File.createTempFile(tableName + "-temp", ".txt");
             File output = File.createTempFile(tableName + "-output-temp", ".txt");
-            FileOutputStream out = new FileOutputStream(tempFile);
-            IOUtils.copy(is, out);
 
-            CsvMapReader newEditorFileReader = new CsvMapReader(new FileReader(tempFile), CsvPreference.STANDARD_PREFERENCE);
-            CsvMapReader newCustomFileReader = new CsvMapReader(new StringReader(csvData), CsvPreference.STANDARD_PREFERENCE);
+            try (
+                CsvMapReader customFileReader = new CsvMapReader(new StringReader(csvData), CsvPreference.STANDARD_PREFERENCE);
+                CsvMapReader editorFileReader = new CsvMapReader(new InputStreamReader(is), CsvPreference.STANDARD_PREFERENCE);
+                CsvMapWriter writer = new CsvMapWriter(new FileWriter(output), CsvPreference.STANDARD_PREFERENCE);
+            ){
 
-            String[] customHeaders = newCustomFileReader.getHeader(true);
-            final String[] editorHeaders = newEditorFileReader.getHeader(true);
+                String[] customHeaders = customFileReader.getHeader(true);
+                final String[] editorHeaders = editorFileReader.getHeader(true);
 
-            List<String> customFields = Arrays.stream(customHeaders).filter(h -> !specTableFields.contains(h)).collect(Collectors.toList());
-            if (customFields.size() == 0) return;
-            String[] fullHeaders = ArrayUtils.addAll(editorHeaders, customFields.toArray(new String[0]));
+                List<String> customFields = Arrays.stream(customHeaders).filter(h -> !specTableFields.contains(h)).collect(Collectors.toList());
+                if (customFields.size() == 0) return;
+                String[] fullHeaders = ArrayUtils.addAll(editorHeaders, customFields.toArray(new String[0]));
 
-            HashMap<String, Map<String, String>> lookup = createCsvHashMap(newCustomFileReader, customHeaders);
-            CsvMapWriter writer = new CsvMapWriter(new FileWriter(output), CsvPreference.STANDARD_PREFERENCE);
-            writer.writeHeader(fullHeaders);
+                HashMap<String, Map<String, String>> customFieldsLookup = createCsvHashMap(customFileReader, customHeaders);
+                writer.writeHeader(fullHeaders);
 
-            Map<String, String> row;
-            while ((row = newEditorFileReader.read(editorHeaders)) != null) {
-                List<String> editorCsvPrimaryKeyValues = tablePrimaryKeys.stream()
-                    .map(row::get)
-                    .collect(Collectors.toList());
+                Map<String, String> row;
+                while ((row = editorFileReader.read(editorHeaders)) != null) {
+                    List<String> editorCsvPrimaryKeyValues = tablePrimaryKeys.stream()
+                            .map(row::get)
+                            .collect(Collectors.toList());
 
-                String hashKey = StringUtils.join(editorCsvPrimaryKeyValues, "_");
-                Map<String, String> customCsvValues = lookup.get(hashKey);
-                Map<String, String> finalRow = row;
-                customFields.stream().forEach(customField -> {
-                    String value = customCsvValues == null ? null : customCsvValues.get(customField);
-                    finalRow.put(customField, value);
-                });
-                writer.write(finalRow, fullHeaders);
+                    String hashKey = StringUtils.join(editorCsvPrimaryKeyValues, "_");
+                    Map<String, String> customCsvValues = customFieldsLookup.get(hashKey);
+                    Map<String, String> finalRow = row;
+                    customFields.stream().forEach(customField -> {
+                        String value = customCsvValues == null ? null : customCsvValues.get(customField);
+                        finalRow.put(customField, value);
+                    });
+                    writer.write(finalRow, fullHeaders);
+                }
+                writer.close();
+
+                Files.copy(output.toPath(), targetTxtFilePath, StandardCopyOption.REPLACE_EXISTING);
+                tempFile.deleteOnExit();
+                output.deleteOnExit();
+                zipTarget.feedTransformResult.tableTransformResults.add(new TableTransformResult(tableName, TransformType.TABLE_MODIFIED));
             }
-            writer.close();
-
-            Files.copy(output.toPath(), targetTxtFilePath, StandardCopyOption.REPLACE_EXISTING);
-            tempFile.deleteOnExit();
-            output.deleteOnExit();
-            zipTarget.feedTransformResult.tableTransformResults.add(new TableTransformResult(tableName, TransformType.TABLE_MODIFIED));
         } catch (NoSuchFileException e) {
             status.fail("Source version does not contain table: " + tableName, e);
-        } catch(IOException e) {
+        } catch (IOException e) {
             status.fail("An exception occurred when writing output with custom fields", e);
         } catch (Exception e) {
             status.fail("Unknown error encountered while transforming zip file", e);

--- a/src/main/java/com/conveyal/datatools/manager/models/transform/PreserveCustomFieldsTransformation.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/transform/PreserveCustomFieldsTransformation.java
@@ -1,0 +1,184 @@
+package com.conveyal.datatools.manager.models.transform;
+
+import com.conveyal.datatools.common.status.MonitorableJob;
+import com.conveyal.datatools.manager.models.TableTransformResult;
+import com.conveyal.datatools.manager.models.TransformType;
+import com.opencsv.CSVReader;
+import com.opencsv.CSVWriter;
+import com.opencsv.exceptions.CsvValidationException;
+import org.apache.commons.io.input.BOMInputStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import com.conveyal.gtfs.loader.Table;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.*;
+import java.util.*;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.text.WordUtils;
+
+
+
+/**
+ * This feed transformation will attempt to preserve any custom fields from an entered csv in the final GTFS output.
+ */
+public class PreserveCustomFieldsTransformation extends ZipTransformation {
+    private static final Logger LOG = LoggerFactory.getLogger(PreserveCustomFieldsTransformation.class);
+    private static List<String> tablePrimaryKeys = new ArrayList<>();
+    private static Table specTable;
+    /** no-arg constructor for de/serialization */
+    public PreserveCustomFieldsTransformation() {}
+
+    public static PreserveCustomFieldsTransformation create(String sourceVersionId, String table) {
+        PreserveCustomFieldsTransformation transformation = new PreserveCustomFieldsTransformation();
+        transformation.sourceVersionId = sourceVersionId;
+        transformation.table = table;
+        return transformation;
+    }
+
+    @Override
+    public void validateParameters(MonitorableJob.Status status) {
+        if (csvData == null) {
+            status.fail("CSV data must not be null (delete table not yet supported)");
+        }
+    }
+
+    public static <T> Collector<T, ?, T> toSingleton() {
+        return Collectors.collectingAndThen(
+                Collectors.toList(),
+                list -> {
+                    if (list.size() != 1) {
+                        throw new IllegalStateException();
+                    }
+                    return list.get(0);
+                }
+        );
+    }
+
+    private static HashMap<String, String[]> createCsvHashMap(CSVReader reader, List<Integer> primaryKeys) throws CsvValidationException, IOException {
+        HashMap<String, String[]> lookup = new HashMap<>();
+
+        String[] nextLine;
+        while ((nextLine = reader.readNext()) != null) {
+            final String[] finalNextLine = nextLine;
+            List<String> customCsvKeyValues = primaryKeys.stream().map(column -> finalNextLine[column]).collect(Collectors.toList());
+
+            // Concatenate keys to make a lookup hash and add to the hash map
+            String hashKey = StringUtils.join(customCsvKeyValues, "_");
+            lookup.put(hashKey, finalNextLine);
+        }
+
+        return lookup;
+    }
+
+    private static void writeLine(CSVWriter writer, String[] row, List<String> customFields, Map<String, Integer> customHeaders, String[] customValues) {
+        // Add new custom fields to the editor csv rows
+        String[] newRow = Arrays.copyOf(row, row.length + customFields.size());
+        if (customValues != null) {
+            // Write the custom values, if we have a match
+            for (int columnDiff = 0; columnDiff < customFields.size(); columnDiff++) {
+                String customField = customFields.get(columnDiff);
+                int customFieldIndex = customHeaders.get(customField);
+                newRow[row.length + columnDiff] = customValues[customFieldIndex];
+            }
+        }
+        writer.writeNext(newRow);
+    }
+
+    private static Map<String, Integer> mapHeaderColumns(String[] headers) {
+        Map<String, Integer> headersMapping = new HashMap<>();
+        for (int i = 0; i < headers.length; i++) headersMapping.put(headers[i], i);
+        return headersMapping;
+    }
+
+    private static String getClassNameFromTable (String table) {
+        String underscoreRemoved = table.replace("_", " ");
+        String capitalized = WordUtils.capitalize(underscoreRemoved);
+        String oneWordName = capitalized.replace(" ", "");
+        if (oneWordName.substring(oneWordName.length() - 1).equals("s")) {
+            oneWordName = oneWordName.substring(0, oneWordName.length() - 1);
+        }
+        return "com.conveyal.model." + oneWordName + "DTO";
+    }
+
+    @Override
+    public void transform(FeedTransformZipTarget zipTarget, MonitorableJob.Status status) {
+        String tableName = table + ".txt";
+        Path targetZipPath = Paths.get(zipTarget.gtfsFile.getAbsolutePath());
+        // Try to dynamically load the class for CSVBean
+        //        String csvDataClassName = getClassNameFromTable(table);
+//            Class<?> csvDataClass = Class.forName(csvDataClassName);
+
+        // TODO: is there a better way to do this than using a Singleton collector?
+        specTable = Arrays.stream(Table.tablesInOrder)
+                .filter(t -> t.name.equals(table))
+                .collect(toSingleton());
+        tablePrimaryKeys = specTable.getPrimaryKeyNames();
+
+        try( FileSystem targetZipFs = FileSystems.newFileSystem(targetZipPath, (ClassLoader) null) ){
+            List<String> specTableFields = specTable.specFields().stream().map(f -> f.name).collect(Collectors.toList());
+            Path targetTxtFilePath = getTablePathInZip(tableName, targetZipFs);
+
+            // TODO: There must be a better way to do this.
+            InputStream is = Files.newInputStream(targetTxtFilePath);
+            final File tempFile = File.createTempFile(tableName + "-temp", ".txt");
+            File output = File.createTempFile(tableName + "-output-temp", ".txt");
+            FileOutputStream out = new FileOutputStream(tempFile);
+            IOUtils.copy(is, out);
+
+            FileInputStream fileInputStream = new FileInputStream(tempFile);
+            // BOMInputStream to avoid any Byte Order Marks at the start of files.
+            CSVReader editorFileReader = new CSVReader(new InputStreamReader(new BOMInputStream(fileInputStream), StandardCharsets.UTF_8));
+            CSVReader customFileReader = new CSVReader(new StringReader(csvData));
+
+            // Store the headers with their indices in CSV for later lookups
+            String[] customHeaders = customFileReader.readNext();
+            String[] editorHeaders = editorFileReader.readNext();
+            Map<String, Integer> customCsvHeaders = mapHeaderColumns(customHeaders);
+            Map<String, Integer> editorCsvHeaders = mapHeaderColumns(editorHeaders);
+
+            // Find the customFields in the input csv
+            List<String> customFields = Arrays.stream(customHeaders).filter(h -> !specTableFields.contains(h)).collect(Collectors.toList());
+            if (customFields.size() == 0) return;
+
+            // Find the key columns in the custom CSV
+            List<Integer> customCsvKeyColumns = tablePrimaryKeys.stream()
+                .map(customCsvHeaders::get)
+                .collect(Collectors.toList());
+
+            HashMap<String, String[]> lookup = createCsvHashMap(customFileReader, customCsvKeyColumns);
+            CSVWriter writer = new CSVWriter(new FileWriter(output));
+            writeLine(writer, editorHeaders, customFields, customCsvHeaders, customHeaders);  // Write headers before starting lookups
+
+            String[] nextLine;
+            while((nextLine = editorFileReader.readNext()) != null) {
+                String[] finalNextLine = nextLine; // TODO: there must be some way around this.
+                List<String> editorCsvPrimaryKeyValues = tablePrimaryKeys.stream()
+                        .map(key -> finalNextLine[editorCsvHeaders.get(key)])
+                        .collect(Collectors.toList()); // Map the keys to the values for the row
+
+                String hashKey = StringUtils.join(editorCsvPrimaryKeyValues, "_");
+                String[] customCsvLine = lookup.get(hashKey);
+                writeLine(writer, nextLine, customFields, customCsvHeaders, customCsvLine);
+            }
+            writer.close();
+
+            Files.copy(output.toPath(), targetTxtFilePath, StandardCopyOption.REPLACE_EXISTING);
+            tempFile.deleteOnExit();
+            output.deleteOnExit();
+            zipTarget.feedTransformResult.tableTransformResults.add(new TableTransformResult(tableName, TransformType.TABLE_MODIFIED));
+        } catch (NoSuchFileException e) {
+            status.fail("Source version does not contain table: " + tableName, e);
+        } catch(IOException e) {
+            status.fail("An exception occurred when writing output with custom fields", e);
+        } catch (CsvValidationException ex) {
+            ex.printStackTrace();
+        } catch (Exception e) {
+            status.fail("Unknown error encountered while transforming zip file", e);
+        }
+    }
+}

--- a/src/main/java/com/conveyal/datatools/manager/models/transform/PreserveCustomFieldsTransformation.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/transform/PreserveCustomFieldsTransformation.java
@@ -3,31 +3,25 @@ package com.conveyal.datatools.manager.models.transform;
 import com.conveyal.datatools.common.status.MonitorableJob;
 import com.conveyal.datatools.manager.models.TableTransformResult;
 import com.conveyal.datatools.manager.models.TransformType;
-import com.opencsv.CSVReader;
-import com.opencsv.CSVWriter;
-import com.opencsv.exceptions.CsvValidationException;
-import org.apache.commons.io.input.BOMInputStream;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.supercsv.io.CsvMapReader;
 import com.conveyal.gtfs.loader.Table;
 
 import java.io.*;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
 import java.util.*;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.text.WordUtils;
-
+import org.apache.commons.lang3.ArrayUtils;
+import org.supercsv.io.CsvMapWriter;
+import org.supercsv.prefs.CsvPreference;
 
 
 /**
  * This feed transformation will attempt to preserve any custom fields from an entered csv in the final GTFS output.
  */
 public class PreserveCustomFieldsTransformation extends ZipTransformation {
-    private static final Logger LOG = LoggerFactory.getLogger(PreserveCustomFieldsTransformation.class);
     private static List<String> tablePrimaryKeys = new ArrayList<>();
     private static Table specTable;
     /** no-arg constructor for de/serialization */
@@ -59,59 +53,21 @@ public class PreserveCustomFieldsTransformation extends ZipTransformation {
         );
     }
 
-    private static HashMap<String, String[]> createCsvHashMap(CSVReader reader, List<Integer> primaryKeys) throws CsvValidationException, IOException {
-        HashMap<String, String[]> lookup = new HashMap<>();
-
-        String[] nextLine;
-        while ((nextLine = reader.readNext()) != null) {
-            final String[] finalNextLine = nextLine;
-            List<String> customCsvKeyValues = primaryKeys.stream().map(column -> finalNextLine[column]).collect(Collectors.toList());
-
-            // Concatenate keys to make a lookup hash and add to the hash map
+    private static HashMap<String, Map<String, String>> createCsvHashMap(CsvMapReader reader, String[] headers) throws IOException {
+        HashMap<String, Map<String, String>> lookup = new HashMap<>();
+        Map<String, String> nextLine;
+        while ((nextLine = reader.read(headers)) != null) {
+            List<String> customCsvKeyValues = tablePrimaryKeys.stream().map(nextLine::get).collect(Collectors.toList());
             String hashKey = StringUtils.join(customCsvKeyValues, "_");
-            lookup.put(hashKey, finalNextLine);
+            lookup.put(hashKey, nextLine);
         }
-
         return lookup;
-    }
-
-    private static void writeLine(CSVWriter writer, String[] row, List<String> customFields, Map<String, Integer> customHeaders, String[] customValues) {
-        // Add new custom fields to the editor csv rows
-        String[] newRow = Arrays.copyOf(row, row.length + customFields.size());
-        if (customValues != null) {
-            // Write the custom values, if we have a match
-            for (int columnDiff = 0; columnDiff < customFields.size(); columnDiff++) {
-                String customField = customFields.get(columnDiff);
-                int customFieldIndex = customHeaders.get(customField);
-                newRow[row.length + columnDiff] = customValues[customFieldIndex];
-            }
-        }
-        writer.writeNext(newRow);
-    }
-
-    private static Map<String, Integer> mapHeaderColumns(String[] headers) {
-        Map<String, Integer> headersMapping = new HashMap<>();
-        for (int i = 0; i < headers.length; i++) headersMapping.put(headers[i], i);
-        return headersMapping;
-    }
-
-    private static String getClassNameFromTable (String table) {
-        String underscoreRemoved = table.replace("_", " ");
-        String capitalized = WordUtils.capitalize(underscoreRemoved);
-        String oneWordName = capitalized.replace(" ", "");
-        if (oneWordName.substring(oneWordName.length() - 1).equals("s")) {
-            oneWordName = oneWordName.substring(0, oneWordName.length() - 1);
-        }
-        return "com.conveyal.model." + oneWordName + "DTO";
     }
 
     @Override
     public void transform(FeedTransformZipTarget zipTarget, MonitorableJob.Status status) {
         String tableName = table + ".txt";
         Path targetZipPath = Paths.get(zipTarget.gtfsFile.getAbsolutePath());
-        // Try to dynamically load the class for CSVBean
-        //        String csvDataClassName = getClassNameFromTable(table);
-//            Class<?> csvDataClass = Class.forName(csvDataClassName);
 
         // TODO: is there a better way to do this than using a Singleton collector?
         specTable = Arrays.stream(Table.tablesInOrder)
@@ -130,40 +86,34 @@ public class PreserveCustomFieldsTransformation extends ZipTransformation {
             FileOutputStream out = new FileOutputStream(tempFile);
             IOUtils.copy(is, out);
 
-            FileInputStream fileInputStream = new FileInputStream(tempFile);
-            // BOMInputStream to avoid any Byte Order Marks at the start of files.
-            CSVReader editorFileReader = new CSVReader(new InputStreamReader(new BOMInputStream(fileInputStream), StandardCharsets.UTF_8));
-            CSVReader customFileReader = new CSVReader(new StringReader(csvData));
+            CsvMapReader newEditorFileReader = new CsvMapReader(new FileReader(tempFile), CsvPreference.STANDARD_PREFERENCE);
+            CsvMapReader newCustomFileReader = new CsvMapReader(new StringReader(csvData), CsvPreference.STANDARD_PREFERENCE);
 
-            // Store the headers with their indices in CSV for later lookups
-            String[] customHeaders = customFileReader.readNext();
-            String[] editorHeaders = editorFileReader.readNext();
-            Map<String, Integer> customCsvHeaders = mapHeaderColumns(customHeaders);
-            Map<String, Integer> editorCsvHeaders = mapHeaderColumns(editorHeaders);
+            String[] customHeaders = newCustomFileReader.getHeader(true);
+            final String[] editorHeaders = newEditorFileReader.getHeader(true);
 
-            // Find the customFields in the input csv
             List<String> customFields = Arrays.stream(customHeaders).filter(h -> !specTableFields.contains(h)).collect(Collectors.toList());
             if (customFields.size() == 0) return;
+            String[] fullHeaders = ArrayUtils.addAll(editorHeaders, customFields.toArray(new String[0]));
 
-            // Find the key columns in the custom CSV
-            List<Integer> customCsvKeyColumns = tablePrimaryKeys.stream()
-                .map(customCsvHeaders::get)
-                .collect(Collectors.toList());
+            HashMap<String, Map<String, String>> lookup = createCsvHashMap(newCustomFileReader, customHeaders);
+            CsvMapWriter writer = new CsvMapWriter(new FileWriter(output), CsvPreference.STANDARD_PREFERENCE);
+            writer.writeHeader(fullHeaders);
 
-            HashMap<String, String[]> lookup = createCsvHashMap(customFileReader, customCsvKeyColumns);
-            CSVWriter writer = new CSVWriter(new FileWriter(output));
-            writeLine(writer, editorHeaders, customFields, customCsvHeaders, customHeaders);  // Write headers before starting lookups
-
-            String[] nextLine;
-            while((nextLine = editorFileReader.readNext()) != null) {
-                String[] finalNextLine = nextLine; // TODO: there must be some way around this.
+            Map<String, String> row;
+            while ((row = newEditorFileReader.read(editorHeaders)) != null) {
                 List<String> editorCsvPrimaryKeyValues = tablePrimaryKeys.stream()
-                        .map(key -> finalNextLine[editorCsvHeaders.get(key)])
-                        .collect(Collectors.toList()); // Map the keys to the values for the row
+                    .map(row::get)
+                    .collect(Collectors.toList());
 
                 String hashKey = StringUtils.join(editorCsvPrimaryKeyValues, "_");
-                String[] customCsvLine = lookup.get(hashKey);
-                writeLine(writer, nextLine, customFields, customCsvHeaders, customCsvLine);
+                Map<String, String> customCsvValues = lookup.get(hashKey);
+                Map<String, String> finalRow = row;
+                customFields.stream().forEach(customField -> {
+                    String value = customCsvValues == null ? null : customCsvValues.get(customField);
+                    finalRow.put(customField, value);
+                });
+                writer.write(finalRow, fullHeaders);
             }
             writer.close();
 
@@ -175,8 +125,6 @@ public class PreserveCustomFieldsTransformation extends ZipTransformation {
             status.fail("Source version does not contain table: " + tableName, e);
         } catch(IOException e) {
             status.fail("An exception occurred when writing output with custom fields", e);
-        } catch (CsvValidationException ex) {
-            ex.printStackTrace();
         } catch (Exception e) {
             status.fail("Unknown error encountered while transforming zip file", e);
         }

--- a/src/main/java/com/conveyal/datatools/manager/models/transform/PreserveCustomFieldsTransformation.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/transform/PreserveCustomFieldsTransformation.java
@@ -70,7 +70,7 @@ public class PreserveCustomFieldsTransformation extends ZipTransformation {
         List<String> specTableFields = specTable.specFields().stream().map(f -> f.name).collect(Collectors.toList());
         List<String> tablePrimaryKeys = specTable.getPrimaryKeyNames();
 
-        try (FileSystem targetZipFs = FileSystems.newFileSystem( targetZipPath, (ClassLoader) null )){
+        try (FileSystem targetZipFs = FileSystems.newFileSystem( targetZipPath, (ClassLoader) null )) {
             Path targetTxtFilePath = getTablePathInZip(tableName, targetZipFs);
 
             final File tempFile = File.createTempFile(tableName + "-temp", ".txt");

--- a/src/main/java/com/conveyal/datatools/manager/models/transform/PreserveCustomFieldsTransformation.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/transform/PreserveCustomFieldsTransformation.java
@@ -86,7 +86,7 @@ public class PreserveCustomFieldsTransformation extends ZipTransformation {
             ){
 
                 String[] customHeaders = customFileReader.getHeader(true);
-                final String[] editorHeaders = editorFileReader.getHeader(true);
+                String[] editorHeaders = editorFileReader.getHeader(true);
 
                 customFields = Arrays.stream(customHeaders).filter(h -> !specTableFields.contains(h)).collect(Collectors.toList());
                 if (customFields.isEmpty()) return;

--- a/src/main/java/com/conveyal/datatools/manager/models/transform/PreserveCustomFieldsTransformation.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/transform/PreserveCustomFieldsTransformation.java
@@ -66,7 +66,9 @@ public class PreserveCustomFieldsTransformation extends ZipTransformation {
                 .filter(t -> t.name.equals(table))
                 .findFirst();
 
-        if (!streamResult.isPresent()) {throw new Exception(String.format("could not find specTable for table %s", table));}
+        if (!streamResult.isPresent()) {
+            throw new Exception(String.format("could not find specTable for table %s", table));
+        }
         Table specTable = streamResult.get();
 
         try (FileSystem targetZipFs = FileSystems.newFileSystem(targetZipPath, (ClassLoader) null)) {

--- a/src/main/java/com/conveyal/datatools/manager/models/transform/PreserveCustomFieldsTransformation.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/transform/PreserveCustomFieldsTransformation.java
@@ -77,6 +77,7 @@ public class PreserveCustomFieldsTransformation extends ZipTransformation {
 
             final File tempFile = File.createTempFile(tableName + "-temp", ".txt");
             File output = File.createTempFile(tableName + "-output-temp", ".txt");
+            int rowsModified = 0;
             List<String> customFields;
 
             try (
@@ -109,13 +110,21 @@ public class PreserveCustomFieldsTransformation extends ZipTransformation {
                         String value = customCsvValues == null ? null : customCsvValues.get(customField);
                         finalRow.put(customField, value);
                     });
+                    if (customCsvValues != null) rowsModified++;
                     writer.write(finalRow, fullHeaders);
                 }
             }
             Files.copy(output.toPath(), targetTxtFilePath, StandardCopyOption.REPLACE_EXISTING);
             tempFile.deleteOnExit();
             output.deleteOnExit();
-            zipTarget.feedTransformResult.tableTransformResults.add(new TableTransformResult(tableName, TransformType.TABLE_MODIFIED));
+            zipTarget.feedTransformResult.tableTransformResults.add(new TableTransformResult(
+                    tableName,
+                    TransformType.TABLE_MODIFIED,
+                    0,
+                    rowsModified,
+                    0,
+                    customFields.size()
+            ));
         } catch (NoSuchFileException e) {
             status.fail("Source version does not contain table: " + tableName, e);
         } catch (IOException e) {

--- a/src/main/java/com/conveyal/datatools/manager/models/transform/PreserveCustomFieldsTransformation.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/transform/PreserveCustomFieldsTransformation.java
@@ -98,8 +98,8 @@ public class PreserveCustomFieldsTransformation extends ZipTransformation {
                 Map<String, String> row;
                 while ((row = editorFileReader.read(editorHeaders)) != null) {
                     List<String> editorCsvPrimaryKeyValues = tablePrimaryKeys.stream()
-                            .map(row::get)
-                            .collect(Collectors.toList());
+                        .map(row::get)
+                        .collect(Collectors.toList());
 
                     String hashKey = StringUtils.join(editorCsvPrimaryKeyValues, "_");
                     Map<String, String> customCsvValues = customFieldsLookup.get(hashKey);

--- a/src/main/java/com/conveyal/datatools/manager/models/transform/ReplaceFileFromStringTransformation.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/transform/ReplaceFileFromStringTransformation.java
@@ -1,60 +1,16 @@
 package com.conveyal.datatools.manager.models.transform;
 
 import com.conveyal.datatools.common.status.MonitorableJob;
-import com.conveyal.datatools.manager.models.TableTransformResult;
-import com.conveyal.datatools.manager.models.TransformType;
-
-import java.io.ByteArrayInputStream;
-import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.FileSystem;
-import java.nio.file.FileSystems;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.nio.file.StandardCopyOption;
 
 /**
  * This feed transformation will replace a file in the target zip (table) with the provided csv data.
  */
-public class ReplaceFileFromStringTransformation extends ZipTransformation {
-
-    public static ReplaceFileFromStringTransformation create(String csvData, String table) {
-        ReplaceFileFromStringTransformation transformation = new ReplaceFileFromStringTransformation();
-        transformation.csvData = csvData;
-        transformation.table = table;
-        return transformation;
-    }
+public class ReplaceFileFromStringTransformation extends StringTransformation {
 
     @Override
     public void validateParameters(MonitorableJob.Status status) {
         if (csvData == null) {
             status.fail("CSV data must not be null (delete table not yet supported)");
-        }
-    }
-
-    @Override
-    public void transform(FeedTransformZipTarget zipTarget, MonitorableJob.Status status) {
-        // if (csvData == null) {
-        //     TODO: If this is a null value, delete the table (not yet supported).
-        // }
-
-        String tableName = table + ".txt";
-        // Run the replace transformation
-        Path targetZipPath = Paths.get(zipTarget.gtfsFile.getAbsolutePath());
-        try( FileSystem targetZipFs = FileSystems.newFileSystem(targetZipPath, (ClassLoader) null) ){
-            // Convert csv data to input stream.
-            InputStream inputStream = new ByteArrayInputStream(csvData.getBytes(StandardCharsets.UTF_8));
-            Path targetTxtFilePath = getTablePathInZip(tableName, targetZipFs);
-            // Set transform type according to whether target file exists.
-            TransformType type = Files.exists(targetTxtFilePath)
-                ? TransformType.TABLE_REPLACED
-                : TransformType.TABLE_ADDED;
-            // Copy csv input stream into the zip file, replacing it if it already exists.
-            Files.copy(inputStream, targetTxtFilePath, StandardCopyOption.REPLACE_EXISTING);
-            zipTarget.feedTransformResult.tableTransformResults.add(new TableTransformResult(tableName, type));
-        } catch (Exception e) {
-            status.fail("Unknown error encountered while transforming zip file", e);
         }
     }
 }

--- a/src/main/java/com/conveyal/datatools/manager/models/transform/ReplaceFileFromStringTransformation.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/transform/ReplaceFileFromStringTransformation.java
@@ -6,11 +6,4 @@ import com.conveyal.datatools.common.status.MonitorableJob;
  * This feed transformation will replace a file in the target zip (table) with the provided csv data.
  */
 public class ReplaceFileFromStringTransformation extends StringTransformation {
-
-    @Override
-    public void validateParameters(MonitorableJob.Status status) {
-        if (csvData == null) {
-            status.fail("CSV data must not be null (delete table not yet supported)");
-        }
-    }
 }

--- a/src/main/java/com/conveyal/datatools/manager/models/transform/StringTransformation.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/transform/StringTransformation.java
@@ -48,7 +48,14 @@ public class StringTransformation extends ZipTransformation {
             int lineCount = (int) csvData.chars().filter(c -> c == NEW_LINE_CHARACTER_CODE).count();
             int addedCount = type == TransformType.TABLE_ADDED ? lineCount : 0;
             int updatedCount = type == TransformType.TABLE_MODIFIED ? lineCount : 0;
-            zipTarget.feedTransformResult.tableTransformResults.add(new TableTransformResult(tableName, type, 0, updatedCount, addedCount, 0));
+            zipTarget.feedTransformResult.tableTransformResults.add(new TableTransformResult(
+                tableName,
+                type,
+                0,
+                updatedCount,
+                addedCount,
+                0
+            ));
         } catch (Exception e) {
             status.fail("Unknown error encountered while transforming zip file", e);
         }

--- a/src/main/java/com/conveyal/datatools/manager/models/transform/StringTransformation.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/transform/StringTransformation.java
@@ -44,7 +44,12 @@ public class StringTransformation extends ZipTransformation {
                     : TransformType.TABLE_ADDED;
             // Copy csv input stream into the zip file, replacing it if it already exists.
             Files.copy(inputStream, targetTxtFilePath, StandardCopyOption.REPLACE_EXISTING);
-            zipTarget.feedTransformResult.tableTransformResults.add(new TableTransformResult(tableName, type));
+            // Added or updated Count is the number of lines in the CSV.
+            int NEW_LINE_CHARACTER_CODE = 10;
+            int lineCount = (int) csvData.chars().filter(c -> c == NEW_LINE_CHARACTER_CODE).count();
+            int addedCount = type == TransformType.TABLE_ADDED ? lineCount : 0;
+            int updatedCount = type == TransformType.TABLE_MODIFIED ? lineCount : 0;
+            zipTarget.feedTransformResult.tableTransformResults.add(new TableTransformResult(tableName, type, 0,updatedCount,addedCount, 0));
         } catch (Exception e) {
             status.fail("Unknown error encountered while transforming zip file", e);
         }

--- a/src/main/java/com/conveyal/datatools/manager/models/transform/StringTransformation.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/transform/StringTransformation.java
@@ -49,7 +49,7 @@ public class StringTransformation extends ZipTransformation {
             int lineCount = (int) csvData.chars().filter(c -> c == newLineCharacterCode).count();
             int addedCount = type == TransformType.TABLE_ADDED ? lineCount : 0;
             int updatedCount = type == TransformType.TABLE_MODIFIED ? lineCount : 0;
-            zipTarget.feedTransformResult.tableTransformResults.add(new TableTransformResult(tableName, type, 0,updatedCount,addedCount, 0));
+            zipTarget.feedTransformResult.tableTransformResults.add(new TableTransformResult(tableName, type, 0, updatedCount, addedCount, 0));
         } catch (Exception e) {
             status.fail("Unknown error encountered while transforming zip file", e);
         }

--- a/src/main/java/com/conveyal/datatools/manager/models/transform/StringTransformation.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/transform/StringTransformation.java
@@ -34,22 +34,17 @@ public class StringTransformation extends ZipTransformation {
     public void transform(FeedTransformZipTarget zipTarget, MonitorableJob.Status status) {
         String tableName = table + ".txt";
         Path targetZipPath = Paths.get(zipTarget.gtfsFile.getAbsolutePath());
-        try ( FileSystem targetZipFs = FileSystems.newFileSystem(targetZipPath, (ClassLoader) null) ) {
-            // Convert csv data to input stream.
+        try (
+            FileSystem targetZipFs = FileSystems.newFileSystem(targetZipPath, (ClassLoader) null);
             InputStream inputStream = new ByteArrayInputStream(csvData.getBytes(StandardCharsets.UTF_8));
+        ) {
             Path targetTxtFilePath = getTablePathInZip(tableName, targetZipFs);
-            // Set transform type according to whether target file exists.
             TransformType type = Files.exists(targetTxtFilePath)
                 ? TransformType.TABLE_REPLACED
                 : TransformType.TABLE_ADDED;
             // Copy csv input stream into the zip file, replacing it if it already exists.
             Files.copy(inputStream, targetTxtFilePath, StandardCopyOption.REPLACE_EXISTING);
-            // Added or updated Count is the number of lines in the CSV.
-            final int NEW_LINE_CHARACTER_CODE = 10;
-            int lineCount = (int) csvData.chars().filter(c -> c == NEW_LINE_CHARACTER_CODE).count();
-            int addedCount = type == TransformType.TABLE_ADDED ? lineCount : 0;
-            int updatedCount = type == TransformType.TABLE_MODIFIED ? lineCount : 0;
-            zipTarget.feedTransformResult.tableTransformResults.add(new TableTransformResult(tableName, type, 0, updatedCount, addedCount, 0));
+            zipTarget.feedTransformResult.tableTransformResults.add(new TableTransformResult(tableName, type));
         } catch (Exception e) {
             status.fail("Unknown error encountered while transforming zip file", e);
         }

--- a/src/main/java/com/conveyal/datatools/manager/models/transform/StringTransformation.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/transform/StringTransformation.java
@@ -7,7 +7,12 @@ import com.conveyal.datatools.manager.models.TransformType;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.*;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 
 public class StringTransformation extends ZipTransformation {
 
@@ -27,14 +32,9 @@ public class StringTransformation extends ZipTransformation {
 
     @Override
     public void transform(FeedTransformZipTarget zipTarget, MonitorableJob.Status status) {
-        // if (csvData == null) {
-        //     TODO: If this is a null value, delete the table (not yet supported).
-        // }
-
         String tableName = table + ".txt";
-        // Run the replace transformation
         Path targetZipPath = Paths.get(zipTarget.gtfsFile.getAbsolutePath());
-        try( FileSystem targetZipFs = FileSystems.newFileSystem(targetZipPath, (ClassLoader) null) ){
+        try ( FileSystem targetZipFs = FileSystems.newFileSystem(targetZipPath, (ClassLoader) null) ){
             // Convert csv data to input stream.
             InputStream inputStream = new ByteArrayInputStream(csvData.getBytes(StandardCharsets.UTF_8));
             Path targetTxtFilePath = getTablePathInZip(tableName, targetZipFs);

--- a/src/main/java/com/conveyal/datatools/manager/models/transform/StringTransformation.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/transform/StringTransformation.java
@@ -1,0 +1,52 @@
+package com.conveyal.datatools.manager.models.transform;
+
+import com.conveyal.datatools.common.status.MonitorableJob;
+import com.conveyal.datatools.manager.models.TableTransformResult;
+import com.conveyal.datatools.manager.models.TransformType;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.*;
+
+public class StringTransformation extends ZipTransformation {
+
+    public static StringTransformation create(String csvData, String table) {
+        StringTransformation transformation = new StringTransformation();
+        transformation.csvData = csvData;
+        transformation.table = table;
+        return transformation;
+    }
+
+    @Override
+    public void validateParameters(MonitorableJob.Status status) {
+        if (csvData == null) {
+            status.fail("CSV data must not be null");
+        }
+    }
+
+    @Override
+    public void transform(FeedTransformZipTarget zipTarget, MonitorableJob.Status status) {
+        // if (csvData == null) {
+        //     TODO: If this is a null value, delete the table (not yet supported).
+        // }
+
+        String tableName = table + ".txt";
+        // Run the replace transformation
+        Path targetZipPath = Paths.get(zipTarget.gtfsFile.getAbsolutePath());
+        try( FileSystem targetZipFs = FileSystems.newFileSystem(targetZipPath, (ClassLoader) null) ){
+            // Convert csv data to input stream.
+            InputStream inputStream = new ByteArrayInputStream(csvData.getBytes(StandardCharsets.UTF_8));
+            Path targetTxtFilePath = getTablePathInZip(tableName, targetZipFs);
+            // Set transform type according to whether target file exists.
+            TransformType type = Files.exists(targetTxtFilePath)
+                    ? TransformType.TABLE_REPLACED
+                    : TransformType.TABLE_ADDED;
+            // Copy csv input stream into the zip file, replacing it if it already exists.
+            Files.copy(inputStream, targetTxtFilePath, StandardCopyOption.REPLACE_EXISTING);
+            zipTarget.feedTransformResult.tableTransformResults.add(new TableTransformResult(tableName, type));
+        } catch (Exception e) {
+            status.fail("Unknown error encountered while transforming zip file", e);
+        }
+    }
+}

--- a/src/main/java/com/conveyal/datatools/manager/models/transform/StringTransformation.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/transform/StringTransformation.java
@@ -45,8 +45,8 @@ public class StringTransformation extends ZipTransformation {
             // Copy csv input stream into the zip file, replacing it if it already exists.
             Files.copy(inputStream, targetTxtFilePath, StandardCopyOption.REPLACE_EXISTING);
             // Added or updated Count is the number of lines in the CSV.
-            int newLineCharacterCode = 10;
-            int lineCount = (int) csvData.chars().filter(c -> c == newLineCharacterCode).count();
+            final int NEW_LINE_CHARACTER_CODE = 10;
+            int lineCount = (int) csvData.chars().filter(c -> c == NEW_LINE_CHARACTER_CODE).count();
             int addedCount = type == TransformType.TABLE_ADDED ? lineCount : 0;
             int updatedCount = type == TransformType.TABLE_MODIFIED ? lineCount : 0;
             zipTarget.feedTransformResult.tableTransformResults.add(new TableTransformResult(tableName, type, 0, updatedCount, addedCount, 0));

--- a/src/main/java/com/conveyal/datatools/manager/models/transform/StringTransformation.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/transform/StringTransformation.java
@@ -34,19 +34,19 @@ public class StringTransformation extends ZipTransformation {
     public void transform(FeedTransformZipTarget zipTarget, MonitorableJob.Status status) {
         String tableName = table + ".txt";
         Path targetZipPath = Paths.get(zipTarget.gtfsFile.getAbsolutePath());
-        try ( FileSystem targetZipFs = FileSystems.newFileSystem(targetZipPath, (ClassLoader) null) ){
+        try ( FileSystem targetZipFs = FileSystems.newFileSystem(targetZipPath, (ClassLoader) null) ) {
             // Convert csv data to input stream.
             InputStream inputStream = new ByteArrayInputStream(csvData.getBytes(StandardCharsets.UTF_8));
             Path targetTxtFilePath = getTablePathInZip(tableName, targetZipFs);
             // Set transform type according to whether target file exists.
             TransformType type = Files.exists(targetTxtFilePath)
-                    ? TransformType.TABLE_REPLACED
-                    : TransformType.TABLE_ADDED;
+                ? TransformType.TABLE_REPLACED
+                : TransformType.TABLE_ADDED;
             // Copy csv input stream into the zip file, replacing it if it already exists.
             Files.copy(inputStream, targetTxtFilePath, StandardCopyOption.REPLACE_EXISTING);
             // Added or updated Count is the number of lines in the CSV.
-            int NEW_LINE_CHARACTER_CODE = 10;
-            int lineCount = (int) csvData.chars().filter(c -> c == NEW_LINE_CHARACTER_CODE).count();
+            int newLineCharacterCode = 10;
+            int lineCount = (int) csvData.chars().filter(c -> c == newLineCharacterCode).count();
             int addedCount = type == TransformType.TABLE_ADDED ? lineCount : 0;
             int updatedCount = type == TransformType.TABLE_MODIFIED ? lineCount : 0;
             zipTarget.feedTransformResult.tableTransformResults.add(new TableTransformResult(tableName, type, 0,updatedCount,addedCount, 0));

--- a/src/main/java/com/conveyal/datatools/manager/models/transform/StringTransformation.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/transform/StringTransformation.java
@@ -44,7 +44,11 @@ public class StringTransformation extends ZipTransformation {
                 : TransformType.TABLE_ADDED;
             // Copy csv input stream into the zip file, replacing it if it already exists.
             Files.copy(inputStream, targetTxtFilePath, StandardCopyOption.REPLACE_EXISTING);
-            zipTarget.feedTransformResult.tableTransformResults.add(new TableTransformResult(tableName, type));
+            final int NEW_LINE_CHARACTER_CODE = 10;
+            int lineCount = (int) csvData.chars().filter(c -> c == NEW_LINE_CHARACTER_CODE).count();
+            int addedCount = type == TransformType.TABLE_ADDED ? lineCount : 0;
+            int updatedCount = type == TransformType.TABLE_MODIFIED ? lineCount : 0;
+            zipTarget.feedTransformResult.tableTransformResults.add(new TableTransformResult(tableName, type, 0, updatedCount, addedCount, 0));
         } catch (Exception e) {
             status.fail("Unknown error encountered while transforming zip file", e);
         }

--- a/src/test/java/com/conveyal/datatools/manager/jobs/ArbitraryTransformJobTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/jobs/ArbitraryTransformJobTest.java
@@ -219,12 +219,7 @@ public class ArbitraryTransformJobTest extends UnitTest {
 
     @Test
     public void canPreserveCustomFieldsInStops() throws IOException {
-        // Generate random UUID for feedId, which gets placed into the csv data.
         String stops = generateStopsWithCustomFields();
-        sourceVersion = createFeedVersion(
-                feedSource,
-                zipFolderFiles("fake-agency-with-only-calendar")
-        );
         FeedTransformation transformation = PreserveCustomFieldsTransformation.create(stops, "stops");
         FeedTransformRules transformRules = new FeedTransformRules(transformation);
         feedSource.transformRules.add(transformRules);
@@ -250,10 +245,6 @@ public class ArbitraryTransformJobTest extends UnitTest {
     @Test
     public void canAddCustomFile() throws IOException {
         String customCsv = generateCustomCsvData();
-        sourceVersion = createFeedVersion(
-                feedSource,
-                zipFolderFiles("fake-agency-with-only-calendar")
-        );
         FeedTransformation transformation = AddCustomFileFromStringTransformation.create(customCsv, "custom-file");
         FeedTransformRules transformRules = new FeedTransformRules(transformation);
         feedSource.transformRules.add(transformRules);
@@ -287,7 +278,7 @@ public class ArbitraryTransformJobTest extends UnitTest {
 
     private static String generateCustomCsvData() {
         return "custom_column1, custom_column2, custom_column3"
-            + "customValue1, customValue2, customValue3"
-            + "customValue1, customValue2, customValue3";
+            + "\ncustomValue1, customValue2, customValue3"
+            + "\ncustomValue1, customValue2, customValue3";
     }
 }

--- a/src/test/java/com/conveyal/datatools/manager/jobs/ArbitraryTransformJobTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/jobs/ArbitraryTransformJobTest.java
@@ -8,6 +8,7 @@ import com.conveyal.datatools.manager.models.FeedSource;
 import com.conveyal.datatools.manager.models.FeedVersion;
 import com.conveyal.datatools.manager.models.Project;
 import com.conveyal.datatools.manager.models.Snapshot;
+import com.conveyal.datatools.manager.models.TableTransformResult;
 import com.conveyal.datatools.manager.models.transform.AddCustomFileFromStringTransformation;
 import com.conveyal.datatools.manager.models.transform.DeleteRecordsTransformation;
 import com.conveyal.datatools.manager.models.transform.FeedTransformRules;
@@ -234,17 +235,15 @@ public class ArbitraryTransformJobTest extends UnitTest {
             feedSource,
             zipFolderFiles("fake-agency-with-only-calendar-dates")
         );
-        LOG.info("Checking assertions.");
-
+        TableTransformResult transformResult = targetVersion.feedTransformResult.tableTransformResults.get(0);
         assertEquals(
                 2,
-                targetVersion.feedTransformResult.tableTransformResults.get(0).customColumnsAdded,
+                transformResult.customColumnsAdded,
                 "stops.txt custom column count should equal input csv data # of custom columns"
         );
-
         assertEquals(
                 2,
-                targetVersion.feedTransformResult.tableTransformResults.get(0).updatedCount,
+                transformResult.updatedCount,
                 "stops.txt row count modified with custom content should equal input csv data # of custom columns"
         );
     }
@@ -260,8 +259,6 @@ public class ArbitraryTransformJobTest extends UnitTest {
             feedSource,
             zipFolderFiles("fake-agency-with-only-calendar-dates")
         );
-
-        LOG.info("Checking assertions.");
         assertEquals(
                 2,
                 targetVersion.feedTransformResult.tableTransformResults.get(0).addedCount,

--- a/src/test/java/com/conveyal/datatools/manager/jobs/ArbitraryTransformJobTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/jobs/ArbitraryTransformJobTest.java
@@ -103,7 +103,7 @@ public class ArbitraryTransformJobTest extends UnitTest {
      * into the target version's GTFS file.
      */
     @Test
-    public void canReplaceGtfsPlusFileFromVersion() throws IOException {
+    void canReplaceGtfsPlusFileFromVersion() throws IOException {
         final String table = "stop_attributes";
         // Create source version (folder contains stop_attributes file).
         sourceVersion = createFeedVersion(
@@ -128,7 +128,7 @@ public class ArbitraryTransformJobTest extends UnitTest {
     }
 
     @Test
-    public void canDeleteTrips() throws IOException {
+    void canDeleteTrips() throws IOException {
         // Add delete trips transformation.
         List<String> routeIds = new ArrayList<>();
         // Collect route_id values.
@@ -162,7 +162,7 @@ public class ArbitraryTransformJobTest extends UnitTest {
     }
 
     @Test
-    public void replaceGtfsPlusFileFailsIfSourceIsMissing() throws IOException {
+    void replaceGtfsPlusFileFailsIfSourceIsMissing() throws IOException {
         sourceVersion = createFeedVersion(
             feedSource,
             zipFolderFiles("fake-agency-with-only-calendar")
@@ -183,7 +183,7 @@ public class ArbitraryTransformJobTest extends UnitTest {
     }
 
     @Test
-    public void canReplaceFeedInfo() throws SQLException, IOException {
+    void canReplaceFeedInfo() throws SQLException, IOException {
         // Generate random UUID for feedId, which gets placed into the csv data.
         final String feedId = UUID.randomUUID().toString();
         final String feedInfoContent = generateFeedInfo(feedId);
@@ -218,47 +218,47 @@ public class ArbitraryTransformJobTest extends UnitTest {
     }
 
     @Test
-    public void canPreserveCustomFieldsInStops() throws IOException {
+    void canPreserveCustomFieldsInStops() throws IOException {
         String stops = generateStopsWithCustomFields();
         FeedTransformation transformation = PreserveCustomFieldsTransformation.create(stops, "stops");
         FeedTransformRules transformRules = new FeedTransformRules(transformation);
         feedSource.transformRules.add(transformRules);
         Persistence.feedSources.replace(feedSource.id, feedSource);
         targetVersion = createFeedVersion(
-                feedSource,
-                zipFolderFiles("fake-agency-with-only-calendar-dates")
+            feedSource,
+            zipFolderFiles("fake-agency-with-only-calendar-dates")
         );
         LOG.info("Checking assertions.");
         assertEquals(
-                2,
-                targetVersion.feedTransformResult.tableTransformResults.get(0).customColumnsAdded,
-                "stops.txt custom column count should equal input csv data # of custom columns"
+            2,
+            targetVersion.feedTransformResult.tableTransformResults.get(0).customColumnsAdded,
+            "stops.txt custom column count should equal input csv data # of custom columns"
         );
 
         assertEquals(
-                2,
-                targetVersion.feedTransformResult.tableTransformResults.get(0).updatedCount,
-                "stops.txt row count modified with custom content should equal input csv data # of custom columns"
+            2,
+            targetVersion.feedTransformResult.tableTransformResults.get(0).updatedCount,
+            "stops.txt row count modified with custom content should equal input csv data # of custom columns"
         );
     }
 
     @Test
-    public void canAddCustomFile() throws IOException {
+    void canAddCustomFile() throws IOException {
         String customCsv = generateCustomCsvData();
         FeedTransformation transformation = AddCustomFileFromStringTransformation.create(customCsv, "custom-file");
         FeedTransformRules transformRules = new FeedTransformRules(transformation);
         feedSource.transformRules.add(transformRules);
         Persistence.feedSources.replace(feedSource.id, feedSource);
         targetVersion = createFeedVersion(
-                feedSource,
-                zipFolderFiles("fake-agency-with-only-calendar-dates")
+            feedSource,
+            zipFolderFiles("fake-agency-with-only-calendar-dates")
         );
 
         LOG.info("Checking assertions.");
         assertEquals(
-                2,
-                targetVersion.feedTransformResult.tableTransformResults.get(0).addedCount,
-                "custom-file.txt custom row count should equal input csv data # of rows"
+            2,
+            targetVersion.feedTransformResult.tableTransformResults.get(0).addedCount,
+            "custom-file.txt custom row count should equal input csv data # of rows"
         );
 
     }
@@ -273,12 +273,12 @@ public class ArbitraryTransformJobTest extends UnitTest {
     private static String generateStopsWithCustomFields() {
         return "stop_id, custom_column1, custom_column2"
             + "\n4u6g, customValue1, customValue2"
-            + "\n1234567, customValue1, customValue2";
+            + "\n1234567, customValue3, customValue4";
     }
 
     private static String generateCustomCsvData() {
         return "custom_column1, custom_column2, custom_column3"
             + "\ncustomValue1, customValue2, customValue3"
-            + "\ncustomValue1, customValue2, customValue3";
+            + "\ncustomValue4, customValue5, customValue6";
     }
 }

--- a/src/test/java/com/conveyal/datatools/manager/jobs/ArbitraryTransformJobTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/jobs/ArbitraryTransformJobTest.java
@@ -239,31 +239,35 @@ public class ArbitraryTransformJobTest extends UnitTest {
             zipFolderFiles("fake-agency-with-only-calendar-dates")
         );
         LOG.info("Checking assertions.");
-        CsvMapReader finalStopsReader = getCsvMapReaderFromZip(targetVersion.retrieveGtfsFile(), "stops.txt");
-        CsvMapReader originalStopsReader = getCsvMapReaderFromZip(sourceVersion.retrieveGtfsFile(), "stops.txt");
-        String[] finalHeaders = finalStopsReader.getHeader(true);
-        String[] originalHeaders = originalStopsReader.getHeader(true);
-        int columnsAdded = finalHeaders.length - originalHeaders.length;
+        try (
+            CsvMapReader finalStopsReader = getCsvMapReaderFromZip(targetVersion.retrieveGtfsFile(), "stops.txt");
+            CsvMapReader originalStopsReader = getCsvMapReaderFromZip(sourceVersion.retrieveGtfsFile(), "stops.txt")
+        ) {
+            String[] finalHeaders = finalStopsReader.getHeader(true);
+            String[] originalHeaders = originalStopsReader.getHeader(true);
+            int columnsAdded = finalHeaders.length - originalHeaders.length;
 
-        // Get the number of rows that have been modified with custom fields
-        Map<String, String> row;
-        int updatedRowCount = 0;
-        while ((row = finalStopsReader.read(finalHeaders)) != null) {
-            // Count the number of cases where the custom column is not null, that's the number modified.
-            // *** Assumes that our sample data below includes values for every customColumn for every row.
-            if (row.get("custom_column1") != null) updatedRowCount++;
+            // Get the number of rows that have been modified with custom fields
+            Map<String, String> row;
+            int updatedRowCount = 0;
+            while ((row = finalStopsReader.read(finalHeaders)) != null) {
+                // Count the number of cases where the custom column is not null, that's the number modified.
+                // *** Assumes that our sample data below includes values for every customColumn for every row.
+                if (row.get("custom_column1") != null) updatedRowCount++;
+
+                assertEquals(
+                        2,
+                        columnsAdded,
+                        "stops.txt custom column count should equal input csv data # of custom columns"
+                );
+
+                assertEquals(
+                        2,
+                        updatedRowCount,
+                        "stops.txt row count modified with custom content should equal input csv data # of custom columns"
+                );
+            }
         }
-        assertEquals(
-            2,
-            columnsAdded,
-            "stops.txt custom column count should equal input csv data # of custom columns"
-        );
-
-        assertEquals(
-            2,
-            updatedRowCount,
-            "stops.txt row count modified with custom content should equal input csv data # of custom columns"
-        );
     }
 
     @Test
@@ -277,25 +281,25 @@ public class ArbitraryTransformJobTest extends UnitTest {
             feedSource,
             zipFolderFiles("fake-agency-with-only-calendar-dates")
         );
+        try (CsvMapReader customCsvReader = getCsvMapReaderFromZip(targetVersion.retrieveGtfsFile(), "custom-file.txt")) {
+            String[] customHeaders = customCsvReader.getHeader(true);
+            int rowCount = 0;
+            while(customCsvReader.read(customHeaders) != null) rowCount++;
 
-        CsvMapReader customCsvReader = getCsvMapReaderFromZip(targetVersion.retrieveGtfsFile(), "custom-file.txt");
-        String[] customHeaders = customCsvReader.getHeader(true);
-        int rowCount = 0;
-        while(customCsvReader.read(customHeaders) != null) rowCount++;
-
-        LOG.info("Checking assertions.");
-        assertEquals(
-            2,
-            rowCount,
-            "custom-file.txt custom row count should equal input csv data # of rows"
-        );
-
+            LOG.info("Checking assertions.");
+            assertEquals(
+                    2,
+                    rowCount,
+                    "custom-file.txt custom row count should equal input csv data # of rows"
+            );
+        }
     }
     private static CsvMapReader getCsvMapReaderFromZip(File gtfsFile, String table) throws IOException {
         ZipFile zipFile = new ZipFile(gtfsFile);
         ZipEntry entry = zipFile.getEntry(table);
-        InputStream is = zipFile.getInputStream(entry);
-        return new CsvMapReader(new InputStreamReader(is), CsvPreference.STANDARD_PREFERENCE);
+        try (InputStream is = zipFile.getInputStream(entry)) {
+            return new CsvMapReader(new InputStreamReader(is), CsvPreference.STANDARD_PREFERENCE);
+        }
     }
 
     private static String generateFeedInfo(String feedId) {


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description
For testing, the front end PR can be found here: https://github.com/ibi-group/datatools-ui/pull/950. 
Watch out for your mongo database once new transformations have been created you'll need to remove those when returning to run dev normally. 

This PR adds two new transformations:
1. Preserve (or add) custom fields to existing GTFS files:
    Allows a user to specify custom fields within existing GTFS tables which will be added after a new version is produced.
    For example, certain producers include a `platform_track` field within the `stop_times` table. With this PR, that can be 
    specified using a mapping in the csv input data, and the custom field will be conditionally added to the final 
    `stop_times` file. 

2. Add a custom file to the GTFS
    Allows a user to take csv data and dump it into a custom txt file in the final GTFS product. Essentially uses the 
    ReplaceFileFromString transformation but does not restrict the table to an existing GTFS table. 

I think this PR is still pretty rough and it's a big feature so looking for feedback on: 
- performance (I could store the csv output data in memory and do one big write operation which could speed things up). 
- general architecture

After some initial review, I'll write some tests as well. 