### PR TITLE
Transformations: Support Missing Fields

### DIFF
--- a/src/main/java/com/conveyal/datatools/manager/models/transform/NormalizeFieldTransformation.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/transform/NormalizeFieldTransformation.java
@@ -198,7 +198,7 @@ public class NormalizeFieldTransformation extends ZipTransformation {
             Field[] fieldsFoundInZip = gtfsTable.getFieldsFromFieldHeaders(headers, null);
             int transformFieldIndex = getFieldIndex(fieldsFoundInZip, fieldName);
 
-            // If the index is -1, this is a new column, and we need to add it accordingly
+            // If the index is -1, this is a new column, and we need to add it accordingly.
             if (transformFieldIndex == -1) {
                 String[] expandedHeaders = new String[headers.length + 1];
                 System.arraycopy(headers, 0, expandedHeaders, 0, headers.length);
@@ -228,7 +228,7 @@ public class NormalizeFieldTransformation extends ZipTransformation {
                 // Re-assemble the CSV line and place in buffer.
                 String[] csvValues = csvReader.getValues();
 
-                // If the index is -1, this is a new column, and we need to add it accordingly
+                // If the index is -1, this is a new column, and we need to add it accordingly.
                 if (transformFieldIndex == -1) {
                     String[] expandedCsvValues = new String[headers.length + 1];
                     System.arraycopy(csvValues, 0, expandedCsvValues, 0, csvValues.length);

--- a/src/main/java/com/conveyal/datatools/manager/models/transform/NormalizeFieldTransformation.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/transform/NormalizeFieldTransformation.java
@@ -200,10 +200,7 @@ public class NormalizeFieldTransformation extends ZipTransformation {
 
             // If the index is -1, this is a new column, and we need to add it accordingly.
             if (transformFieldIndex == -1) {
-                String[] expandedHeaders = new String[headers.length + 1];
-                System.arraycopy(headers, 0, expandedHeaders, 0, headers.length);
-                expandedHeaders[headers.length] = fieldName;
-                writer.write(expandedHeaders);
+                writer.write(expandArray(headers, fieldName));
             } else {
                 writer.write(headers);
             }
@@ -230,10 +227,7 @@ public class NormalizeFieldTransformation extends ZipTransformation {
 
                 // If the index is -1, this is a new column, and we need to add it accordingly.
                 if (transformFieldIndex == -1) {
-                    String[] expandedCsvValues = new String[headers.length + 1];
-                    System.arraycopy(csvValues, 0, expandedCsvValues, 0, csvValues.length);
-                    expandedCsvValues[csvValues.length] = transformedValue;
-                    writer.write(expandedCsvValues);
+                    writer.write(expandArray(csvValues, transformedValue));
                 } else {
                     csvValues[transformFieldIndex] = transformedValue;
 
@@ -303,5 +297,15 @@ public class NormalizeFieldTransformation extends ZipTransformation {
             result = substitution.replaceAll(result);
         }
         return result;
+    }
+
+    /**
+     * Copies a fixed length array, and appends a new element at the end
+     */
+    private String[] expandArray(String[] array, String value) {
+        String[] expanded = new String[array.length + 1];
+        System.arraycopy(array, 0, expanded, 0, array.length);
+        expanded[array.length] = value;
+        return expanded;
     }
 }

--- a/src/main/java/com/conveyal/datatools/manager/models/transform/NormalizeFieldTransformation.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/transform/NormalizeFieldTransformation.java
@@ -300,7 +300,7 @@ public class NormalizeFieldTransformation extends ZipTransformation {
     }
 
     /**
-     * Copies a fixed length array, and appends a new element at the end
+     * Copies a fixed length array, and appends a new element at the end.
      */
     private String[] expandArray(String[] array, String value) {
         String[] expanded = new String[array.length + 1];

--- a/src/test/java/com/conveyal/datatools/manager/models/transform/NormalizeFieldTransformationTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/models/transform/NormalizeFieldTransformationTest.java
@@ -109,7 +109,7 @@ public class NormalizeFieldTransformationTest extends UnitTest {
 
     @ParameterizedTest
     @MethodSource("createCreateNewField")
-    public void testCreateNewField(String input, String expected) {
+    void testCreateNewField(String input, String expected) {
         NormalizeFieldTransformation transform = createTransformation(
                 "table", "new_field",  null, Lists.newArrayList(
                         new Substitution("", "new_value")

--- a/src/test/java/com/conveyal/datatools/manager/models/transform/NormalizeFieldTransformationTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/models/transform/NormalizeFieldTransformationTest.java
@@ -106,6 +106,24 @@ public class NormalizeFieldTransformationTest extends UnitTest {
         );
     }
 
+
+    @ParameterizedTest
+    @MethodSource("createCreateNewField")
+    public void testCreateNewField(String input, String expected) {
+        NormalizeFieldTransformation transform = createTransformation(
+                "table", "new_field",  null, Lists.newArrayList(
+                        new Substitution("", "new_value")
+                ));
+        assertEquals(expected, transform.performSubstitutions(input));
+    }
+
+    private static Stream<Arguments> createCreateNewField() {
+        return Stream.of(
+                Arguments.of("", "new_value")
+        );
+    }
+
+
     /**
      * Proxy to create a transformation
      * (called by {@link com.conveyal.datatools.manager.jobs.NormalizeFieldTransformJobTest}).


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing
- [x] The description lists all relevant PRs included in this release _(remove this if not merging to master)_
- [x] e2e tests are all passing _(remove this if not merging to master)_

### Description

Transforming single fields previously relied on that field being present in the existing GTFS. This caused a crash if one tried to transform a field not present in said gtfs. This PR will automatically add the needed fields if they are not present.