### PR TITLE
Support pelias synonyms file

### DIFF
--- a/src/main/java/com/conveyal/datatools/manager/jobs/PeliasUpdateJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/PeliasUpdateJob.java
@@ -142,6 +142,7 @@ public class PeliasUpdateJob extends MonitorableJob {
         PeliasWebhookRequestBody peliasWebhookRequestBody = new PeliasWebhookRequestBody();
         peliasWebhookRequestBody.gtfsFeeds = gtfsFeeds;
         peliasWebhookRequestBody.csvFiles = deployment.peliasCsvFiles;
+        peliasWebhookRequestBody.peliasSynonymsBase64 = deployment.peliasSynonymsBase64;
         peliasWebhookRequestBody.logUploadUrl = logUploadS3URI.toString();
         peliasWebhookRequestBody.deploymentId = deployment.id;
         peliasWebhookRequestBody.resetDb = deployment.peliasResetDb;
@@ -218,6 +219,8 @@ public class PeliasUpdateJob extends MonitorableJob {
         public String logUploadUrl;
         public String deploymentId;
         public boolean resetDb;
+
+        public String peliasSynonymsBase64;
     }
 
     /**

--- a/src/main/java/com/conveyal/datatools/manager/models/Deployment.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/Deployment.java
@@ -81,6 +81,8 @@ public class Deployment extends Model implements Serializable {
     public boolean peliasResetDb;
     public List<String> peliasCsvFiles = new ArrayList<>();
 
+    public String peliasSynonymsBase64;
+
     /**
      * Get parent project for deployment. Note: at one point this was a JSON property of this class, but severe
      * performance issues prevent this field from scaling to be fetched/assigned to a large collection of deployments.


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing
- [ ] The description lists all relevant PRs included in this release _(remove this if not merging to master)_
- [x] e2e tests are all passing _(remove this if not merging to master)_

### Description

This PR adds support for datatools to keep track of a Pelias `custom_name.txt` file.

At the moment, we are storing it as a string.