### PR TITLE
Longer githash on gtfs-lib

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -268,7 +268,7 @@
             <groupId>com.github.conveyal</groupId>
             <artifactId>gtfs-lib</artifactId>
             <!-- Latest dev build on jitpack.io -->
-            <version>f2ceb59</version>
+            <version>9837b64997</version>
             <!-- Exclusions added in order to silence SLF4J warnings about multiple bindings:
                 http://www.slf4j.org/codes.html#multiple_bindings
             -->


### PR DESCRIPTION
### Checklist

- [ ] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [ ] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [ ] The description lists all applicable issues this PR seeks to resolve
- [ ] The description lists any configuration setting(s) that differ from the default settings
- [ ] All tests and CI builds passing
- [ ] The description lists all relevant PRs included in this release _(remove this if not merging to master)_
- [ ] e2e tests are all passing _(remove this if not merging to master)_

### Description

jitpack.io now requires 10 character long git hashes. For example https://jitpack.io/com/github/conveyal/gtfs-lib/f2ceb59027/gtfs-lib-f2ceb59.jar works, but https://jitpack.io/com/github/conveyal/gtfs-lib/9837b6/gtfs-lib-9837b6.jar does not work. 
