### PR TITLE
Disable auth for tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -268,7 +268,7 @@
             <groupId>com.github.conveyal</groupId>
             <artifactId>gtfs-lib</artifactId>
             <!-- Latest dev build on jitpack.io -->
-            <version>f2ceb59</version>
+            <version>f2ceb59027</version>
             <!-- Exclusions added in order to silence SLF4J warnings about multiple bindings:
                 http://www.slf4j.org/codes.html#multiple_bindings
             -->

--- a/src/test/java/com/conveyal/datatools/HandleCorruptGTFSFileTest.java
+++ b/src/test/java/com/conveyal/datatools/HandleCorruptGTFSFileTest.java
@@ -1,6 +1,7 @@
 package com.conveyal.datatools;
 
 import com.conveyal.datatools.common.status.MonitorableJob;
+import com.conveyal.datatools.manager.auth.Auth0Connection;
 import com.conveyal.datatools.manager.jobs.LoadFeedJob;
 import com.conveyal.datatools.manager.jobs.ProcessSingleFeedJob;
 import com.conveyal.datatools.manager.jobs.ValidateFeedJob;
@@ -30,10 +31,12 @@ public class HandleCorruptGTFSFileTest {
     public static void setUp() throws IOException {
         // start server if it isn't already running
         DatatoolsTest.setUp();
+        Auth0Connection.setAuthDisabled(true);
     }
 
     @AfterAll
     public static void tearDown() {
+        Auth0Connection.setAuthDisabled(Auth0Connection.getDefaultAuthDisabled());
         mockProject.delete();
     }
 

--- a/src/test/java/com/conveyal/datatools/manager/extensions/mtc/MtcFeedResourceTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/extensions/mtc/MtcFeedResourceTest.java
@@ -2,6 +2,7 @@ package com.conveyal.datatools.manager.extensions.mtc;
 
 import com.conveyal.datatools.DatatoolsTest;
 import com.conveyal.datatools.UnitTest;
+import com.conveyal.datatools.manager.auth.Auth0Connection;
 import com.conveyal.datatools.manager.models.ExternalFeedSourceProperty;
 import com.conveyal.datatools.manager.models.FeedSource;
 import com.conveyal.datatools.manager.models.FeedVersion;
@@ -50,6 +51,7 @@ class MtcFeedResourceTest extends UnitTest {
     static void setUp() throws IOException {
         // start server if it isn't already running
         DatatoolsTest.setUp();
+        Auth0Connection.setAuthDisabled(true);
         // Create a project, feed sources.
         project = new Project();
         project.name = String.format("Test %s", new Date());
@@ -69,6 +71,7 @@ class MtcFeedResourceTest extends UnitTest {
 
     @AfterAll
     static void tearDown() {
+        Auth0Connection.setAuthDisabled(Auth0Connection.getDefaultAuthDisabled());
         wireMockServer.stop();
         if (project != null) {
             project.delete();

--- a/src/test/java/com/conveyal/datatools/manager/gtfsplus/GtfsPlusValidationTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/gtfsplus/GtfsPlusValidationTest.java
@@ -3,6 +3,7 @@ package com.conveyal.datatools.manager.gtfsplus;
 import com.conveyal.datatools.DatatoolsTest;
 import com.conveyal.datatools.UnitTest;
 import com.conveyal.datatools.manager.DataManager;
+import com.conveyal.datatools.manager.auth.Auth0Connection;
 import com.conveyal.datatools.manager.jobs.MergeFeedsJobTest;
 import com.conveyal.datatools.manager.models.FeedSource;
 import com.conveyal.datatools.manager.models.FeedVersion;
@@ -44,6 +45,7 @@ public class GtfsPlusValidationTest extends UnitTest {
     public static void setUp() throws IOException {
         // Start server if it isn't already running.
         DatatoolsTest.setUp();
+        Auth0Connection.setAuthDisabled(true);
         // Create a project, feed sources, and feed versions to merge.
         project = new Project();
         project.name = String.format("Test %s", new Date());
@@ -65,6 +67,7 @@ public class GtfsPlusValidationTest extends UnitTest {
 
     @AfterAll
     static void tearDown() {
+        Auth0Connection.setAuthDisabled(Auth0Connection.getDefaultAuthDisabled());
         project.delete();
     }
 

--- a/src/test/java/com/conveyal/datatools/manager/jobs/ArbitraryTransformJobTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/jobs/ArbitraryTransformJobTest.java
@@ -2,6 +2,7 @@ package com.conveyal.datatools.manager.jobs;
 
 import com.conveyal.datatools.DatatoolsTest;
 import com.conveyal.datatools.UnitTest;
+import com.conveyal.datatools.manager.auth.Auth0Connection;
 import com.conveyal.datatools.manager.auth.Auth0UserProfile;
 import com.conveyal.datatools.manager.models.FeedRetrievalMethod;
 import com.conveyal.datatools.manager.models.FeedSource;
@@ -65,6 +66,7 @@ public class ArbitraryTransformJobTest extends UnitTest {
     public static void setUp() throws IOException {
         // start server if it isn't already running
         DatatoolsTest.setUp();
+        Auth0Connection.setAuthDisabled(true);
 
         // Create a project, feed sources, and feed versions to merge.
         project = new Project();
@@ -81,6 +83,7 @@ public class ArbitraryTransformJobTest extends UnitTest {
      */
     @AfterAll
     public static void tearDown() {
+        Auth0Connection.setAuthDisabled(Auth0Connection.getDefaultAuthDisabled());
         // Project delete cascades to feed sources.
         project.delete();
     }

--- a/src/test/java/com/conveyal/datatools/manager/jobs/AutoPublishJobTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/jobs/AutoPublishJobTest.java
@@ -3,6 +3,7 @@ package com.conveyal.datatools.manager.jobs;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 import com.conveyal.datatools.DatatoolsTest;
 import com.conveyal.datatools.UnitTest;
+import com.conveyal.datatools.manager.auth.Auth0Connection;
 import com.conveyal.datatools.manager.auth.Auth0UserProfile;
 import com.conveyal.datatools.manager.models.ExternalFeedSourceProperty;
 import com.conveyal.datatools.manager.models.FeedSource;
@@ -52,6 +53,7 @@ public class AutoPublishJobTest extends UnitTest {
     public static void setUp() throws IOException {
         // start server if it isn't already running
         DatatoolsTest.setUp();
+        Auth0Connection.setAuthDisabled(true);
 
         // Create a project, feed sources, and feed versions to merge.
         project = new Project();
@@ -76,6 +78,7 @@ public class AutoPublishJobTest extends UnitTest {
 
     @AfterAll
     public static void tearDown() {
+        Auth0Connection.setAuthDisabled(Auth0Connection.getDefaultAuthDisabled());
         if (project != null) {
             project.delete();
         }

--- a/src/test/java/com/conveyal/datatools/manager/jobs/DeploymentGisExportJobTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/jobs/DeploymentGisExportJobTest.java
@@ -1,11 +1,13 @@
 package com.conveyal.datatools.manager.jobs;
 
 import com.conveyal.datatools.DatatoolsTest;
+import com.conveyal.datatools.manager.auth.Auth0Connection;
 import com.conveyal.datatools.manager.auth.Auth0UserProfile;
 import com.conveyal.datatools.manager.models.*;
 import com.conveyal.datatools.manager.persistence.Persistence;
 import com.google.common.io.Files;
 
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -63,6 +65,7 @@ public class DeploymentGisExportJobTest extends GisExportJobTest {
     @BeforeAll
     public static void setUp() throws IOException {
         DatatoolsTest.setUp();
+        Auth0Connection.setAuthDisabled(true);
         // Calling GisExportJobTest.setUp() creates project and feeds
         GisExportJobTest.setUp();
         user = Auth0UserProfile.createTestAdminUser();
@@ -70,6 +73,11 @@ public class DeploymentGisExportJobTest extends GisExportJobTest {
         deployment.feedVersionIds.add(calTrainVersion.id);
         deployment.feedVersionIds.add(hawaiiVersion.id);
         Persistence.deployments.create(deployment);
+    }
+
+    @AfterAll
+    public static void tearDown() {
+        Auth0Connection.setAuthDisabled(Auth0Connection.getDefaultAuthDisabled());
     }
 
     /**

--- a/src/test/java/com/conveyal/datatools/manager/jobs/FetchLoadFeedCombinationTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/jobs/FetchLoadFeedCombinationTest.java
@@ -3,6 +3,7 @@ package com.conveyal.datatools.manager.jobs;
 import com.conveyal.datatools.DatatoolsTest;
 import com.conveyal.datatools.UnitTest;
 import com.conveyal.datatools.common.status.MonitorableJob;
+import com.conveyal.datatools.manager.auth.Auth0Connection;
 import com.conveyal.datatools.manager.auth.Auth0UserProfile;
 import com.conveyal.datatools.manager.models.FeedSource;
 import com.conveyal.datatools.manager.models.FeedVersion;
@@ -53,6 +54,7 @@ public class FetchLoadFeedCombinationTest extends UnitTest {
     public static void setUp() throws IOException {
         // start server if it isn't already running
         DatatoolsTest.setUp();
+        Auth0Connection.setAuthDisabled(true);
 
         // Create a project and feed sources.
         project = new Project();
@@ -70,6 +72,7 @@ public class FetchLoadFeedCombinationTest extends UnitTest {
 
     @AfterAll
     public static void tearDown() {
+        Auth0Connection.setAuthDisabled(Auth0Connection.getDefaultAuthDisabled());
         wireMockServer.stop();
         if (project != null) {
             project.delete();

--- a/src/test/java/com/conveyal/datatools/manager/jobs/GisExportJobTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/jobs/GisExportJobTest.java
@@ -2,6 +2,7 @@ package com.conveyal.datatools.manager.jobs;
 
 import com.conveyal.datatools.DatatoolsTest;
 import com.conveyal.datatools.UnitTest;
+import com.conveyal.datatools.manager.auth.Auth0Connection;
 import com.conveyal.datatools.manager.auth.Auth0UserProfile;
 import com.conveyal.datatools.manager.models.FeedRetrievalMethod;
 import com.conveyal.datatools.manager.models.FeedSource;
@@ -11,6 +12,7 @@ import com.conveyal.datatools.manager.persistence.Persistence;
 import com.conveyal.datatools.manager.utils.SqlAssert;
 import com.google.common.base.Strings;
 import com.google.common.io.Files;
+import org.junit.jupiter.api.AfterAll;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.MultiLineString;
 import org.locationtech.jts.geom.Point;
@@ -149,6 +151,7 @@ public class GisExportJobTest extends UnitTest {
     @BeforeAll
     public static void setUp() throws IOException {
         DatatoolsTest.setUp();
+        Auth0Connection.setAuthDisabled(true);
         LOG.info("{} setup", GisExportJobTest.class.getSimpleName());
 
         // Create a project, feed sources, and feed versions to merge.
@@ -163,6 +166,11 @@ public class GisExportJobTest extends UnitTest {
         hawaii.deployable = true; //Set feedsources to be deployable for DeploymentGisExportJobTest
         Persistence.feedSources.create(hawaii);
         hawaiiVersion = createFeedVersionFromGtfsZip(hawaii, "hawaii_fake_no_shapes.zip");
+    }
+
+    @AfterAll
+    public static void tearDown() {
+        Auth0Connection.setAuthDisabled(Auth0Connection.getDefaultAuthDisabled());
     }
 
     /**

--- a/src/test/java/com/conveyal/datatools/manager/jobs/MergeFeedsJobTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/jobs/MergeFeedsJobTest.java
@@ -2,6 +2,7 @@ package com.conveyal.datatools.manager.jobs;
 
 import com.conveyal.datatools.DatatoolsTest;
 import com.conveyal.datatools.UnitTest;
+import com.conveyal.datatools.manager.auth.Auth0Connection;
 import com.conveyal.datatools.manager.auth.Auth0UserProfile;
 import com.conveyal.datatools.manager.gtfsplus.GtfsPlusValidation;
 import com.conveyal.datatools.manager.jobs.feedmerge.MergeFeedsType;
@@ -86,6 +87,7 @@ public class MergeFeedsJobTest extends UnitTest {
     public static void setUp() throws IOException {
         // start server if it isn't already running
         DatatoolsTest.setUp();
+        Auth0Connection.setAuthDisabled(true);
 
         // Create a project, feed sources, and feed versions to merge.
         project = new Project();
@@ -157,6 +159,7 @@ public class MergeFeedsJobTest extends UnitTest {
      */
     @AfterAll
     public static void tearDown() {
+        Auth0Connection.setAuthDisabled(Auth0Connection.getDefaultAuthDisabled());
         if (project != null) {
             project.delete();
         }

--- a/src/test/java/com/conveyal/datatools/manager/jobs/NormalizeFieldTransformJobTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/jobs/NormalizeFieldTransformJobTest.java
@@ -1,6 +1,7 @@
 package com.conveyal.datatools.manager.jobs;
 
 import com.conveyal.datatools.DatatoolsTest;
+import com.conveyal.datatools.manager.auth.Auth0Connection;
 import com.conveyal.datatools.manager.models.FeedRetrievalMethod;
 import com.conveyal.datatools.manager.models.FeedSource;
 import com.conveyal.datatools.manager.models.FeedVersion;
@@ -48,6 +49,7 @@ public class NormalizeFieldTransformJobTest extends DatatoolsTest {
     public static void setUp() throws IOException {
         // start server if it isn't already running
         DatatoolsTest.setUp();
+        Auth0Connection.setAuthDisabled(true);
 
         // Create a project.
         project = createProject();
@@ -58,6 +60,7 @@ public class NormalizeFieldTransformJobTest extends DatatoolsTest {
      */
     @AfterAll
     public static void tearDown() {
+        Auth0Connection.setAuthDisabled(Auth0Connection.getDefaultAuthDisabled());
         // Project delete cascades to feed sources.
         project.delete();
     }

--- a/src/test/java/com/conveyal/datatools/manager/models/FeedVersionTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/models/FeedVersionTest.java
@@ -2,6 +2,7 @@ package com.conveyal.datatools.manager.models;
 
 import com.conveyal.datatools.DatatoolsTest;
 import com.conveyal.datatools.UnitTest;
+import com.conveyal.datatools.manager.auth.Auth0Connection;
 import com.conveyal.datatools.manager.persistence.Persistence;
 import com.conveyal.gtfs.error.NewGTFSError;
 import com.conveyal.gtfs.error.NewGTFSErrorType;
@@ -35,6 +36,7 @@ public class FeedVersionTest extends UnitTest {
     public static void setUp() throws Exception {
         // start server if it isn't already running
         DatatoolsTest.setUp();
+        Auth0Connection.setAuthDisabled(true);
 
         // set up project
         project = new Project();
@@ -48,6 +50,7 @@ public class FeedVersionTest extends UnitTest {
 
     @AfterAll
     public static void tearDown() {
+        Auth0Connection.setAuthDisabled(Auth0Connection.getDefaultAuthDisabled());
         if (project != null) {
             project.delete();
         }

--- a/src/test/java/com/conveyal/datatools/manager/utils/sql/SqlSchemaUpdaterTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/utils/sql/SqlSchemaUpdaterTest.java
@@ -3,6 +3,7 @@ package com.conveyal.datatools.manager.utils.sql;
 import com.conveyal.datatools.DatatoolsTest;
 import com.conveyal.datatools.UnitTest;
 import com.conveyal.datatools.manager.DataManager;
+import com.conveyal.datatools.manager.auth.Auth0Connection;
 import com.conveyal.datatools.manager.models.FeedSource;
 import com.conveyal.datatools.manager.models.FeedVersion;
 import com.conveyal.datatools.manager.models.Project;
@@ -40,6 +41,7 @@ class SqlSchemaUpdaterTest extends UnitTest {
     public static void setUp() throws IOException {
         // start server if it isn't already running.
         DatatoolsTest.setUp();
+        Auth0Connection.setAuthDisabled(true);
 
         // Create a project and feed sources.
         project = new Project();
@@ -60,6 +62,7 @@ class SqlSchemaUpdaterTest extends UnitTest {
      */
     @AfterAll
     public static void tearDown() {
+        Auth0Connection.setAuthDisabled(Auth0Connection.getDefaultAuthDisabled());
         // Project delete cascades to feed sources.
         project.delete();
     }


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

73 exceptions are logged as part of CI for failed authentication. Auth isn't needed for the majority of unit tests, so where the exception is thrown, auth has been disabled. It is re-enabled once the test has completed so as not to impact tests that do require auth. 

This PR (where applicable) disables auth which will remove the exceptions logged and speed up testing... a little.
