### PR TITLE
Add validation for directions.txt

### DIFF
--- a/src/main/java/com/conveyal/datatools/manager/gtfsplus/GtfsPlusValidation.java
+++ b/src/main/java/com/conveyal/datatools/manager/gtfsplus/GtfsPlusValidation.java
@@ -188,7 +188,7 @@ public class GtfsPlusValidation implements Serializable {
 
         if (tableIsDirections && !gtfsRoutes.isEmpty()) {
             // After we're done validating all the table values, check if every route was checked off in directions.txt
-            issues.add(new ValidationIssue(tableId, "route_id", -1, "Directions table does not define direction names for all routes."));
+            issues.add(new ValidationIssue(tableId, null, -1, "Directions file doesn't define directions for all routes listed in routes.txt"));
         }
         // Add issues for wrong number of columns and for empty rows after processing all rows.
         // Note: We considered adding an issue for each row, but opted for the single error approach because there's no

--- a/src/main/java/com/conveyal/datatools/manager/gtfsplus/GtfsPlusValidation.java
+++ b/src/main/java/com/conveyal/datatools/manager/gtfsplus/GtfsPlusValidation.java
@@ -335,13 +335,7 @@ public class GtfsPlusValidation implements Serializable {
         if (specField == null) return;
         validateTableValue(issues, tableId, rowIndex, allValues, value, specFieldsFound, specField, gtfsFeed);
 
-        if (!gtfsRoutes.containsKey(value)) {
-            if (!gtfsFeed.routes.containsKey(value)) {
-                issues.add(new ValidationIssue(tableId, specField.get("name").asText(), rowIndex, "Duplicate route entry in directions table."));
-            } else {
-                return;
-            }
-        }
+        if (!gtfsRoutes.containsKey(value)) return;
         // "Check off" the route_id from the list to verify every route id has a direction
         gtfsRoutes.remove(value);
     }

--- a/src/main/java/com/conveyal/datatools/manager/gtfsplus/GtfsPlusValidation.java
+++ b/src/main/java/com/conveyal/datatools/manager/gtfsplus/GtfsPlusValidation.java
@@ -25,7 +25,6 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
@@ -129,7 +128,7 @@ public class GtfsPlusValidation implements Serializable {
 
         Set<String> gtfsRoutes = new HashSet<>();
         if (tableIsDirections) {
-            // Copy the gtfs routes into a map we can "check them off" in (remove them). Stream is required in order to copy keys.
+            // Copy the gtfs routes into a set so that we can "check them off" (remove them).
             gtfsRoutes.addAll(gtfsFeed.routes.keySet());
         }
 

--- a/src/main/java/com/conveyal/datatools/manager/gtfsplus/GtfsPlusValidation.java
+++ b/src/main/java/com/conveyal/datatools/manager/gtfsplus/GtfsPlusValidation.java
@@ -5,7 +5,6 @@ import com.conveyal.datatools.manager.models.FeedVersion;
 import com.conveyal.datatools.manager.persistence.FeedStore;
 import com.conveyal.datatools.manager.persistence.Persistence;
 import com.conveyal.gtfs.GTFSFeed;
-import com.conveyal.gtfs.model.Route;
 import com.csvreader.CsvReader;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -22,10 +21,11 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Enumeration;
-import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
@@ -125,12 +125,12 @@ public class GtfsPlusValidation implements Serializable {
         GTFSFeed gtfsFeed
     ) throws IOException {
         String tableId = specTable.get("id").asText();
-        Boolean tableIsDirections = tableId.equals("directions");
+        boolean tableIsDirections = tableId.equals("directions");
 
-        Map<String, Route> gtfsRoutes = new HashMap<>();
+        Set<String> gtfsRoutes = new HashSet<>();
         if (tableIsDirections) {
-            // Copy the gtfs routes into a map we can "check them off" in (remove them)
-            gtfsRoutes.putAll(gtfsFeed.routes);
+            // Copy the gtfs routes into a map we can "check them off" in (remove them). Stream is required in order to copy keys.
+            gtfsRoutes.addAll(gtfsFeed.routes.keySet());
         }
 
         // Read in table data from input stream.
@@ -180,19 +180,15 @@ public class GtfsPlusValidation implements Serializable {
                     JsonNode specField = fieldsFound[f];
                     // If value exists for index, use that. Otherwise, default to null to avoid out of bounds exception.
                     String val = f < recordColumnCount ? rowValues[f] : null;
-                    if (tableIsDirections && specField.get("name").asText().equals("route_id")) {
-                        validateTableValue(issues, tableId, rowIndex, rowValues, val, fieldsFound, specField, gtfsFeed, gtfsRoutes);
-                    } else {
-                        validateTableValue(issues, tableId, rowIndex, rowValues, val, fieldsFound, specField, gtfsFeed);
-                    }
+                    validateTableValue(issues, tableId, rowIndex, rowValues, val, fieldsFound, specField, gtfsFeed, gtfsRoutes, tableIsDirections);
                 }
-                // After we're done validating all the table values, check if every route was checked off in directions.txt
             }
             rowIndex++;
         }
         csvReader.close();
 
         if (tableIsDirections && !gtfsRoutes.isEmpty()) {
+            // After we're done validating all the table values, check if every route was checked off in directions.txt
             issues.add(new ValidationIssue(tableId, "route_id", -1, "Directions table does not define direction names for all routes."));
         }
         // Add issues for wrong number of columns and for empty rows after processing all rows.
@@ -224,7 +220,9 @@ public class GtfsPlusValidation implements Serializable {
         String value,
         JsonNode[] specFieldsFound,
         JsonNode specField,
-        GTFSFeed gtfsFeed
+        GTFSFeed gtfsFeed,
+        Set<String> gtfsRoutes,
+        boolean tableIsDirections
     ) {
         if (specField == null) return;
         String fieldName = specField.get("name").asText();
@@ -318,26 +316,9 @@ public class GtfsPlusValidation implements Serializable {
                 }
                 break;
         }
-    }
 
-    /** Validate a single route_id value for the directions.txt GTFS+ table. */
-    private static void validateTableValue(
-            Collection<ValidationIssue> issues,
-            String tableId,
-            int rowIndex,
-            String[] allValues,
-            String value,
-            JsonNode[] specFieldsFound,
-            JsonNode specField,
-            GTFSFeed gtfsFeed,
-            Map<String, Route> gtfsRoutes
-    ) {
-        if (specField == null) return;
-        validateTableValue(issues, tableId, rowIndex, allValues, value, specFieldsFound, specField, gtfsFeed);
-
-        if (!gtfsRoutes.containsKey(value)) return;
-        // "Check off" the route_id from the list to verify every route id has a direction
-        gtfsRoutes.remove(value);
+        // "Check off" the route_id in directions.txt from the list to verify every route id has a direction
+        if (tableIsDirections && fieldName.equals("route_id")) gtfsRoutes.remove(value);
     }
 
     /** Construct missing ID text for validation issue description. */

--- a/src/test/java/com/conveyal/datatools/manager/gtfsplus/GtfsPlusValidationTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/gtfsplus/GtfsPlusValidationTest.java
@@ -75,8 +75,8 @@ public class GtfsPlusValidationTest extends UnitTest {
     void canValidateCleanGtfsPlus() throws Exception {
         LOG.info("Validation BART GTFS+");
         GtfsPlusValidation validation = GtfsPlusValidation.validate(bartVersion1.id);
-        // Expect issues to be zero.
-        assertThat("Issues count for clean BART feed is zero", validation.issues.size(), equalTo(0));
+        // Expect issues to be only one with directions.txt file
+        assertThat("Issues count for clean BART feed is zero", validation.issues.size(), equalTo(1));
     }
 
     @Test
@@ -85,8 +85,8 @@ public class GtfsPlusValidationTest extends UnitTest {
         GtfsPlusValidation validation = GtfsPlusValidation.validate(bartVersion1WithQuotedValues.id);
         // Expect issues to be zero.
         assertThat(
-            "Issues count for clean BART feed (quoted values) is zero",
-            validation.issues.size(), equalTo(0)
+            "Issues count for clean BART feed (quoted values) is equal to 1 (as above)",
+            validation.issues.size(), equalTo(1)
         );
     }
 

--- a/src/test/java/com/conveyal/datatools/manager/gtfsplus/GtfsPlusValidationTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/gtfsplus/GtfsPlusValidationTest.java
@@ -76,7 +76,7 @@ public class GtfsPlusValidationTest extends UnitTest {
         LOG.info("Validation BART GTFS+");
         GtfsPlusValidation validation = GtfsPlusValidation.validate(bartVersion1.id);
         // Expect issues to be only one with directions.txt file
-        assertThat("Issues count for clean BART feed is zero", validation.issues.size(), equalTo(1));
+        assertThat("Clean BART feed and incomplete directions.txt results in one issue", validation.issues.size(), equalTo(1));
     }
 
     @Test


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing


### Description

It has recently been pointed out that a lack of route records in the GTFS+ directions.txt can cause direction data to become unavailable in downstream systems. This PR provides validation of the GTFS+ directions.txt table to ensure that every route has a corresponding entry. 
