### PR TITLE
Add option to export patterns

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -265,10 +265,10 @@
          - AWS S3 SDK - putting/getting objects into/out of S3.
          -->
         <dependency>
-            <groupId>com.github.conveyal</groupId>
+            <groupId>com.conveyal</groupId>
             <artifactId>gtfs-lib</artifactId>
             <!-- Latest dev build on jitpack.io -->
-            <version>80a968cd3a071aa46a994ce2632535303a6e4384</version>
+            <version>7.0.2</version>
             <!-- Exclusions added in order to silence SLF4J warnings about multiple bindings:
                 http://www.slf4j.org/codes.html#multiple_bindings
             -->

--- a/pom.xml
+++ b/pom.xml
@@ -265,10 +265,10 @@
          - AWS S3 SDK - putting/getting objects into/out of S3.
          -->
         <dependency>
-            <groupId>com.conveyal</groupId>
+            <groupId>com.github.conveyal</groupId>
             <artifactId>gtfs-lib</artifactId>
             <!-- Latest dev build on jitpack.io -->
-            <version>7.0.2</version>
+            <version>80a968cd3a071aa46a994ce2632535303a6e4384</version>
             <!-- Exclusions added in order to silence SLF4J warnings about multiple bindings:
                 http://www.slf4j.org/codes.html#multiple_bindings
             -->

--- a/pom.xml
+++ b/pom.xml
@@ -268,7 +268,7 @@
             <groupId>com.github.conveyal</groupId>
             <artifactId>gtfs-lib</artifactId>
             <!-- Latest dev build on jitpack.io -->
-            <version>a5f60417e38043d35148aa6873c93056e69e9c87</version>
+            <version>026599ba4907f4c42b24e883d154e63b0777dd31</version>
             <!-- Exclusions added in order to silence SLF4J warnings about multiple bindings:
                 http://www.slf4j.org/codes.html#multiple_bindings
             -->

--- a/pom.xml
+++ b/pom.xml
@@ -268,7 +268,7 @@
             <groupId>com.github.conveyal</groupId>
             <artifactId>gtfs-lib</artifactId>
             <!-- Latest dev build on jitpack.io -->
-            <version>80a968cd3a071aa46a994ce2632535303a6e4384</version>
+            <version>a5f60417e38043d35148aa6873c93056e69e9c87</version>
             <!-- Exclusions added in order to silence SLF4J warnings about multiple bindings:
                 http://www.slf4j.org/codes.html#multiple_bindings
             -->

--- a/pom.xml
+++ b/pom.xml
@@ -268,7 +268,7 @@
             <groupId>com.github.conveyal</groupId>
             <artifactId>gtfs-lib</artifactId>
             <!-- Latest dev build on jitpack.io -->
-            <version>026599ba4907f4c42b24e883d154e63b0777dd31</version>
+            <version>10307d43c6610d5dd1cc07d30091596816772727</version>
             <!-- Exclusions added in order to silence SLF4J warnings about multiple bindings:
                 http://www.slf4j.org/codes.html#multiple_bindings
             -->

--- a/pom.xml
+++ b/pom.xml
@@ -268,7 +268,7 @@
             <groupId>com.github.conveyal</groupId>
             <artifactId>gtfs-lib</artifactId>
             <!-- Latest dev build on jitpack.io -->
-            <version>10307d43c6610d5dd1cc07d30091596816772727</version>
+            <version>10307d43c6</version>
             <!-- Exclusions added in order to silence SLF4J warnings about multiple bindings:
                 http://www.slf4j.org/codes.html#multiple_bindings
             -->

--- a/src/main/java/com/conveyal/datatools/editor/controllers/api/SnapshotController.java
+++ b/src/main/java/com/conveyal/datatools/editor/controllers/api/SnapshotController.java
@@ -63,6 +63,12 @@ public class SnapshotController {
         return Persistence.snapshots.getById(id);
     }
 
+    private static boolean getPublishProprietaryFiles(Request req) {
+        return Boolean.parseBoolean(
+            req.queryParamOrDefault("publishProprietaryFiles",Boolean.FALSE.toString())
+        );
+    }
+
     /**
      * HTTP endpoint that returns the list of snapshots for a given feed source.
      */
@@ -84,9 +90,7 @@ public class SnapshotController {
         boolean publishNewVersion = Boolean.parseBoolean(
             req.queryParamOrDefault("publishNewVersion", Boolean.FALSE.toString())
         );
-        boolean publishProprietaryFiles = Boolean.parseBoolean(
-            req.queryParamOrDefault("publishProprietaryFiles", Boolean.FALSE.toString())
-        );
+        boolean publishProprietaryFiles = getPublishProprietaryFiles(req);
         FeedSource feedSource = FeedVersionController.requestFeedSourceById(req, Actions.EDIT, "feedId");
         // Take fields from request body for creating snapshot (i.e., feedId/feedSourceId, name, comment).
         Snapshot snapshot = json.read(req.body());
@@ -176,9 +180,10 @@ public class SnapshotController {
     private static String downloadSnapshotAsGTFS(Request req, Response res) {
         Auth0UserProfile userProfile = req.attribute("user");
         Snapshot snapshot = getSnapshotFromRequest(req);
+        boolean publishProprietaryFiles = getPublishProprietaryFiles(req);
         // Create and kick off export job.
         // FIXME: what if a snapshot is already written to S3?
-        ExportSnapshotToGTFSJob exportSnapshotToGTFSJob = new ExportSnapshotToGTFSJob(userProfile,  snapshot);
+        ExportSnapshotToGTFSJob exportSnapshotToGTFSJob = new ExportSnapshotToGTFSJob(userProfile, snapshot, publishProprietaryFiles);
         JobUtils.heavyExecutor.execute(exportSnapshotToGTFSJob);
         return formatJobMessage(exportSnapshotToGTFSJob.jobId, "Exporting snapshot to GTFS.");
     }

--- a/src/main/java/com/conveyal/datatools/editor/controllers/api/SnapshotController.java
+++ b/src/main/java/com/conveyal/datatools/editor/controllers/api/SnapshotController.java
@@ -84,6 +84,9 @@ public class SnapshotController {
         boolean publishNewVersion = Boolean.parseBoolean(
             req.queryParamOrDefault("publishNewVersion", Boolean.FALSE.toString())
         );
+        boolean publishProprietaryFiles = Boolean.parseBoolean(
+            req.queryParamOrDefault("publishProprietaryFiles", Boolean.FALSE.toString())
+        );
         FeedSource feedSource = FeedVersionController.requestFeedSourceById(req, Actions.EDIT, "feedId");
         // Take fields from request body for creating snapshot (i.e., feedId/feedSourceId, name, comment).
         Snapshot snapshot = json.read(req.body());
@@ -99,7 +102,7 @@ public class SnapshotController {
                 new CreateSnapshotJob(userProfile, snapshot, bufferIsEmpty, !bufferIsEmpty, false);
         // Add publish feed version job if specified by request.
         if (publishNewVersion) {
-            createSnapshotJob.addNextJob(new CreateFeedVersionFromSnapshotJob(feedSource, snapshot, userProfile));
+            createSnapshotJob.addNextJob(new CreateFeedVersionFromSnapshotJob(feedSource, snapshot, userProfile, publishProprietaryFiles));
         }
         // Begin asynchronous execution.
         JobUtils.heavyExecutor.execute(createSnapshotJob);

--- a/src/main/java/com/conveyal/datatools/editor/controllers/api/SnapshotController.java
+++ b/src/main/java/com/conveyal/datatools/editor/controllers/api/SnapshotController.java
@@ -65,7 +65,7 @@ public class SnapshotController {
 
     private static boolean getPublishProprietaryFiles(Request req) {
         return Boolean.parseBoolean(
-            req.queryParamOrDefault("publishProprietaryFiles",Boolean.FALSE.toString())
+            req.queryParamOrDefault("publishProprietaryFiles", Boolean.FALSE.toString())
         );
     }
 

--- a/src/main/java/com/conveyal/datatools/editor/jobs/ExportSnapshotToGTFSJob.java
+++ b/src/main/java/com/conveyal/datatools/editor/jobs/ExportSnapshotToGTFSJob.java
@@ -30,14 +30,6 @@ public class ExportSnapshotToGTFSJob extends MonitorableJob {
     private File tempFile;
     private final boolean publishProprietaryFiles;
 
-    public ExportSnapshotToGTFSJob(Auth0UserProfile owner, Snapshot snapshot, FeedVersion feedVersion) {
-        super(owner, "Exporting snapshot " + snapshot.name, JobType.EXPORT_SNAPSHOT_TO_GTFS);
-        this.snapshot = snapshot;
-        this.feedVersion = feedVersion;
-        this.publishProprietaryFiles = false; // DEFAULT. TODO: don't hide this here.
-        status.update("Starting database snapshot...", 10);
-    }
-
     public ExportSnapshotToGTFSJob(Auth0UserProfile owner, Snapshot snapshot, FeedVersion feedVersion, boolean publishProprietaryFiles) {
         super(owner, "Exporting snapshot " + snapshot.name, JobType.EXPORT_SNAPSHOT_TO_GTFS);
         this.snapshot = snapshot;
@@ -46,8 +38,8 @@ public class ExportSnapshotToGTFSJob extends MonitorableJob {
         status.update("Starting database snapshot...", 10);
     }
 
-    public ExportSnapshotToGTFSJob(Auth0UserProfile owner, Snapshot snapshot) {
-        this(owner, snapshot, null);
+    public ExportSnapshotToGTFSJob(Auth0UserProfile owner, Snapshot snapshot, boolean publishProprietaryFiles) {
+        this(owner, snapshot, null, publishProprietaryFiles);
     }
 
     @JsonProperty

--- a/src/main/java/com/conveyal/datatools/editor/jobs/ExportSnapshotToGTFSJob.java
+++ b/src/main/java/com/conveyal/datatools/editor/jobs/ExportSnapshotToGTFSJob.java
@@ -28,11 +28,21 @@ public class ExportSnapshotToGTFSJob extends MonitorableJob {
     private final Snapshot snapshot;
     private final FeedVersion feedVersion;
     private File tempFile;
+    private final boolean publishProprietaryFiles;
 
     public ExportSnapshotToGTFSJob(Auth0UserProfile owner, Snapshot snapshot, FeedVersion feedVersion) {
         super(owner, "Exporting snapshot " + snapshot.name, JobType.EXPORT_SNAPSHOT_TO_GTFS);
         this.snapshot = snapshot;
         this.feedVersion = feedVersion;
+        this.publishProprietaryFiles = false; // DEFAULT. TODO: don't hide this here.
+        status.update("Starting database snapshot...", 10);
+    }
+
+    public ExportSnapshotToGTFSJob(Auth0UserProfile owner, Snapshot snapshot, FeedVersion feedVersion, boolean publishProprietaryFiles) {
+        super(owner, "Exporting snapshot " + snapshot.name, JobType.EXPORT_SNAPSHOT_TO_GTFS);
+        this.snapshot = snapshot;
+        this.feedVersion = feedVersion;
+        this.publishProprietaryFiles = publishProprietaryFiles;
         status.update("Starting database snapshot...", 10);
     }
 
@@ -57,7 +67,7 @@ public class ExportSnapshotToGTFSJob extends MonitorableJob {
             status.fail("Error creating local file for snapshot.", e);
             return;
         }
-        JdbcGtfsExporter exporter = new JdbcGtfsExporter(snapshot.namespace, tempFile.getAbsolutePath(), DataManager.GTFS_DATA_SOURCE, true);
+        JdbcGtfsExporter exporter = new JdbcGtfsExporter(snapshot.namespace, tempFile.getAbsolutePath(), DataManager.GTFS_DATA_SOURCE, true, publishProprietaryFiles);
         FeedLoadResult result = exporter.exportTables();
         if (result.fatalException != null) {
             status.fail(String.format("Error (%s) encountered while exporting database tables.", result.fatalException));

--- a/src/main/java/com/conveyal/datatools/manager/controllers/api/FeedVersionController.java
+++ b/src/main/java/com/conveyal/datatools/manager/controllers/api/FeedVersionController.java
@@ -178,6 +178,7 @@ public class FeedVersionController  {
         if (snapshot == null) {
             logMessageAndHalt(req, 400, "Must provide valid snapshot ID");
         }
+        // TODO: Allow publishing with proprietary files from this endpoint?
         CreateFeedVersionFromSnapshotJob createFromSnapshotJob =
             new CreateFeedVersionFromSnapshotJob(feedSource, snapshot, userProfile, false);
         JobUtils.heavyExecutor.execute(createFromSnapshotJob);

--- a/src/main/java/com/conveyal/datatools/manager/controllers/api/FeedVersionController.java
+++ b/src/main/java/com/conveyal/datatools/manager/controllers/api/FeedVersionController.java
@@ -179,7 +179,7 @@ public class FeedVersionController  {
             logMessageAndHalt(req, 400, "Must provide valid snapshot ID");
         }
         CreateFeedVersionFromSnapshotJob createFromSnapshotJob =
-            new CreateFeedVersionFromSnapshotJob(feedSource, snapshot, userProfile);
+            new CreateFeedVersionFromSnapshotJob(feedSource, snapshot, userProfile, false);
         JobUtils.heavyExecutor.execute(createFromSnapshotJob);
 
         return true;

--- a/src/main/java/com/conveyal/datatools/manager/controllers/api/FeedVersionController.java
+++ b/src/main/java/com/conveyal/datatools/manager/controllers/api/FeedVersionController.java
@@ -178,9 +178,9 @@ public class FeedVersionController  {
         if (snapshot == null) {
             logMessageAndHalt(req, 400, "Must provide valid snapshot ID");
         }
-        // TODO: Allow publishing with proprietary files from this endpoint?
+        // Publishing the proprietary files will preserve the pattern names in the newly published feed version.
         CreateFeedVersionFromSnapshotJob createFromSnapshotJob =
-            new CreateFeedVersionFromSnapshotJob(feedSource, snapshot, userProfile, false);
+            new CreateFeedVersionFromSnapshotJob(feedSource, snapshot, userProfile, true);
         JobUtils.heavyExecutor.execute(createFromSnapshotJob);
 
         return true;

--- a/src/main/java/com/conveyal/datatools/manager/controllers/api/FeedVersionController.java
+++ b/src/main/java/com/conveyal/datatools/manager/controllers/api/FeedVersionController.java
@@ -172,6 +172,7 @@ public class FeedVersionController  {
     private static boolean createFeedVersionFromSnapshot (Request req, Response res) {
 
         Auth0UserProfile userProfile = req.attribute("user");
+        Boolean publishProprietaryFiles = Boolean.parseBoolean(req.queryParams("publishProprietaryFiles"));
         // TODO: Should the ability to create a feedVersion from snapshot be controlled by the 'edit-gtfs' privilege?
         FeedSource feedSource = requestFeedSourceById(req, Actions.MANAGE);
         Snapshot snapshot = Persistence.snapshots.getById(req.queryParams("snapshotId"));
@@ -180,7 +181,7 @@ public class FeedVersionController  {
         }
         // Publishing the proprietary files will preserve the pattern names in the newly published feed version.
         CreateFeedVersionFromSnapshotJob createFromSnapshotJob =
-            new CreateFeedVersionFromSnapshotJob(feedSource, snapshot, userProfile, true);
+            new CreateFeedVersionFromSnapshotJob(feedSource, snapshot, userProfile, publishProprietaryFiles);
         JobUtils.heavyExecutor.execute(createFromSnapshotJob);
 
         return true;

--- a/src/main/java/com/conveyal/datatools/manager/jobs/CreateFeedVersionFromSnapshotJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/CreateFeedVersionFromSnapshotJob.java
@@ -22,11 +22,13 @@ public class CreateFeedVersionFromSnapshotJob extends FeedSourceJob {
 
     private final FeedVersion feedVersion;
     private final Snapshot snapshot;
+    private final boolean publishProprietaryFiles;
 
-    public CreateFeedVersionFromSnapshotJob(FeedSource feedSource, Snapshot snapshot, Auth0UserProfile owner) {
+    public CreateFeedVersionFromSnapshotJob(FeedSource feedSource, Snapshot snapshot, Auth0UserProfile owner, boolean publishProprietaryFiles) {
         super(owner, "Creating Feed Version from Snapshot for " + feedSource.name, JobType.CREATE_FEEDVERSION_FROM_SNAPSHOT);
         this.feedVersion = new FeedVersion(feedSource, snapshot);
         this.snapshot = snapshot;
+        this.publishProprietaryFiles = publishProprietaryFiles;
     }
 
     @Override
@@ -35,7 +37,7 @@ public class CreateFeedVersionFromSnapshotJob extends FeedSourceJob {
         // Add the jobs to handle this operation in order.
         addNextJob(
             // First export the snapshot to GTFS.
-            new ExportSnapshotToGTFSJob(owner, snapshot, feedVersion),
+            new ExportSnapshotToGTFSJob(owner, snapshot, feedVersion, publishProprietaryFiles),
             // Then, process feed version once GTFS file written.
             new ProcessSingleFeedJob(feedVersion, owner, true)
         );

--- a/src/main/java/com/conveyal/datatools/manager/jobs/ProcessSingleFeedJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/ProcessSingleFeedJob.java
@@ -130,7 +130,8 @@ public class ProcessSingleFeedJob extends FeedVersionJob {
             snapshot.feedTransformResult = dbTarget.feedTransformResult;
             // If the user has selected to create a new version from the resulting snapshot, do so here.
             if (rules.createNewVersion) {
-                addNextJob(new CreateFeedVersionFromSnapshotJob(feedSource, snapshot, owner, false));
+                // Publishing the proprietary files will preserve the pattern names in the newly created feed version.
+                addNextJob(new CreateFeedVersionFromSnapshotJob(feedSource, snapshot, owner, true));
             }
         }
 

--- a/src/main/java/com/conveyal/datatools/manager/jobs/ProcessSingleFeedJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/ProcessSingleFeedJob.java
@@ -130,7 +130,7 @@ public class ProcessSingleFeedJob extends FeedVersionJob {
             snapshot.feedTransformResult = dbTarget.feedTransformResult;
             // If the user has selected to create a new version from the resulting snapshot, do so here.
             if (rules.createNewVersion) {
-                addNextJob(new CreateFeedVersionFromSnapshotJob(feedSource, snapshot, owner));
+                addNextJob(new CreateFeedVersionFromSnapshotJob(feedSource, snapshot, owner, false));
             }
         }
 

--- a/src/test/java/com/conveyal/datatools/manager/jobs/ArbitraryTransformJobTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/jobs/ArbitraryTransformJobTest.java
@@ -160,7 +160,7 @@ public class ArbitraryTransformJobTest extends UnitTest {
         );
         // Fetch snapshot where modifications were made and create new version from it.
         Snapshot snapshotWithModifications = feedSource.retrieveSnapshots().iterator().next();
-        CreateFeedVersionFromSnapshotJob newVersionJob = new CreateFeedVersionFromSnapshotJob(feedSource, snapshotWithModifications, user);
+        CreateFeedVersionFromSnapshotJob newVersionJob = new CreateFeedVersionFromSnapshotJob(feedSource, snapshotWithModifications, user, false);
         newVersionJob.run();
         // Grab the modified version and check that the trips count matches expectation.
         FeedVersion newVersion = feedSource.retrieveLatest();


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR facilitates the export of the proprietary `datatools_patterns.txt` file, introduced in https://github.com/conveyal/gtfs-lib/pulls, which allows the preservation of custom pattern names in the editor. 

Front end PR: https://github.com/ibi-group/datatools-ui/compare/add-option-for-publishing-patterns?expand=1
GTFS-lib PR: https://github.com/conveyal/gtfs-lib/pull/394
