### PR TITLE
fix(FeedUpdater): allow mongo query to use disk space

### DIFF
--- a/src/main/java/com/conveyal/datatools/manager/jobs/FeedUpdater.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/FeedUpdater.java
@@ -384,6 +384,7 @@ public class FeedUpdater {
             return Persistence.feedVersions
                 .getMongoCollection()
                 .aggregate(stages)
+                .allowDiskUse(true)
                 .into(new ArrayList<>())
                 .stream()
                 .collect(Collectors.toMap(v -> v.feedSourceId, Function.identity()));


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing


### Description

FeedUpdater mongo $group queries can get complicated quickly based on numbers of FeedVersions and are, by default, limited to 100MB of RAM. This PR allows the query that is failing due to memory limits to use disk space (temporary files) to finish the query. 