### PR TITLE
Support Stop Time Interpolation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -268,7 +268,7 @@
             <groupId>com.github.conveyal</groupId>
             <artifactId>gtfs-lib</artifactId>
             <!-- Latest dev build on jitpack.io -->
-            <version>5f34e048ab92936b98e344e69d8a41c9cf978dc4</version>
+            <version>b657dfe7d7c75eacfbc165cf37c0c0ff3f8cd23e</version>
             <!-- Exclusions added in order to silence SLF4J warnings about multiple bindings:
                 http://www.slf4j.org/codes.html#multiple_bindings
             -->

--- a/pom.xml
+++ b/pom.xml
@@ -268,7 +268,7 @@
             <groupId>com.github.conveyal</groupId>
             <artifactId>gtfs-lib</artifactId>
             <!-- Latest dev build on jitpack.io -->
-            <version>b657dfe7d7c75eacfbc165cf37c0c0ff3f8cd23e</version>
+            <version>b657dfe7d7</version>
             <!-- Exclusions added in order to silence SLF4J warnings about multiple bindings:
                 http://www.slf4j.org/codes.html#multiple_bindings
             -->

--- a/pom.xml
+++ b/pom.xml
@@ -268,7 +268,7 @@
             <groupId>com.github.conveyal</groupId>
             <artifactId>gtfs-lib</artifactId>
             <!-- Latest dev build on jitpack.io -->
-            <version>80a968cd3a071aa46a994ce2632535303a6e4384</version>
+            <version>5f34e048ab92936b98e344e69d8a41c9cf978dc4</version>
             <!-- Exclusions added in order to silence SLF4J warnings about multiple bindings:
                 http://www.slf4j.org/codes.html#multiple_bindings
             -->

--- a/src/main/java/com/conveyal/datatools/editor/controllers/api/EditorController.java
+++ b/src/main/java/com/conveyal/datatools/editor/controllers/api/EditorController.java
@@ -313,7 +313,7 @@ public abstract class EditorController<T extends Entity> {
                         int stopSequence = patternStop.getValue();
                         // Begin with the stop prior to the one deleted, unless at the beginning.
                         int beginWithSequence = (stopSequence != 0) ? stopSequence - 1 : stopSequence;
-                        tableWriter.normalizeStopTimesForPattern(patternStop.getKey(), beginWithSequence);
+                        tableWriter.normalizeStopTimesForPattern(patternStop.getKey(), beginWithSequence, false);
                     }
                 }
             }
@@ -406,8 +406,9 @@ public abstract class EditorController<T extends Entity> {
         int patternId = getIdFromRequest(req);
         try {
             int beginStopSequence = Integer.parseInt(req.queryParams("stopSequence"));
+            boolean interpolateStopTimes = Boolean.parseBoolean(req.queryParams("interpolateStopTimes"));
             JdbcTableWriter tableWriter = new JdbcTableWriter(table, datasource, namespace);
-            int stopTimesUpdated = tableWriter.normalizeStopTimesForPattern(patternId, beginStopSequence);
+            int stopTimesUpdated = tableWriter.normalizeStopTimesForPattern(patternId, beginStopSequence, interpolateStopTimes);
             return SparkUtils.formatJSON("updateResult", stopTimesUpdated + " stop times updated.");
         } catch (Exception e) {
             logMessageAndHalt(req, 400, "Error normalizing stop times", e);


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing


### Description

Backend PR to add support for interpolating stop times in the normalizeStopTimes method. 
Front end PR: https://github.com/ibi-group/datatools-ui/pull/998
GTFS-lib PR: https://github.com/conveyal/gtfs-lib/pull/399
