### PR TITLE
Add config option for support email

### DIFF
--- a/configurations/default/server.yml.tmp
+++ b/configurations/default/server.yml.tmp
@@ -8,6 +8,7 @@ application:
   notifications_enabled: false
   docs_url: http://conveyal-data-tools.readthedocs.org
   support_email: support@ibigroup.com
+  public_gtfs_contact_email: public-gtfs-support-email@yourdomain.com
   port: 4000
   data:
     gtfs: /tmp

--- a/src/main/java/com/conveyal/datatools/manager/jobs/PublishProjectFeedsJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/PublishProjectFeedsJob.java
@@ -16,6 +16,8 @@ import java.io.File;
 import java.io.IOException;
 import java.text.SimpleDateFormat;
 
+import static com.conveyal.datatools.manager.DataManager.getConfigPropertyAsText;
+
 /**
  * Publish the latest GTFS files for all public feeds in a project.
  */
@@ -23,6 +25,7 @@ public class PublishProjectFeedsJob extends MonitorableJob {
     public static final Logger LOG = LoggerFactory.getLogger(PublishProjectFeedsJob.class);
 
     private Project project;
+    private static final String dataSupportEmail = getConfigPropertyAsText("application.public_gtfs_contact_email");
 
     public PublishProjectFeedsJob(Project project, Auth0UserProfile owner) {
         super(owner, "Generating public html for " + project.name, JobType.MAKE_PROJECT_PUBLIC);
@@ -54,6 +57,9 @@ public class PublishProjectFeedsJob extends MonitorableJob {
         r.append("<body>\n");
         r.append("<h1>" + title + "</h1>\n");
         r.append("The following feeds, in GTFS format, are available for download and use.\n");
+        if (dataSupportEmail != null) {
+            r.append(String.format("If you have inquiries, please contact us at: <a href=\"mailto:%1$s\">%1$s</a>", dataSupportEmail));
+        }
         r.append("<ul>\n");
         status.update("Ensuring public GTFS files are up-to-date.", 50);
         project.retrieveProjectFeedSources().stream()


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR adds support for including a contact email for any inquiries about the GTFS feeds posted publicly. This email is often different from the support email included within the application if a separate entity is managing the GTFS feeds themselves.
