### PR TITLE
support new `Url` config fields

### DIFF
--- a/src/main/java/com/conveyal/datatools/manager/models/Deployment.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/Deployment.java
@@ -24,8 +24,6 @@ import org.slf4j.LoggerFactory;
 
 import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
-import java.io.BufferedInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;

--- a/src/main/java/com/conveyal/datatools/manager/models/Deployment.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/Deployment.java
@@ -421,9 +421,10 @@ public class Deployment extends Model implements Serializable {
     public String downloadConfig(String configUrl) throws IOException {
         if (configUrl != null) {
             try {
+                // TODO: validate JSON?
                 return new String(downloadFileFromURL(new URL(configUrl)), StandardCharsets.UTF_8);
             } catch (IOException e) {
-                String message = String.format("Could not download file from %s.", configUrl);
+                String message = String.format("Could not download config file from %s.", configUrl);
                 LOG.error(message);
                 throw new IOException(message, e);
             }

--- a/src/main/java/com/conveyal/datatools/manager/models/Deployment.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/Deployment.java
@@ -433,9 +433,14 @@ public class Deployment extends Model implements Serializable {
         return null;
     }
 
-    /** Generate build config for deployment as byte array (for writing to file output stream). */
+    /** Generate build config for deployment as byte array (for writing to file output stream). If an external build
+     * config is available and is successfully downloaded, use this instead of the deployment build config. If there is
+     * no deployment build config, use the project build config. */
     public byte[] generateBuildConfig() throws IOException {
-        customBuildConfig = downloadConfig(customBuildConfigUrl);
+        String downloadedConfig = downloadConfig(customBuildConfigUrl);
+        if (downloadedConfig != null) {
+            customBuildConfig = downloadedConfig;
+        }
         return customBuildConfig != null
             ? customBuildConfig.getBytes(StandardCharsets.UTF_8)
             : getProjectBuildConfig();
@@ -478,7 +483,10 @@ public class Deployment extends Model implements Serializable {
 
     /** Generate router config for deployment as string. */
     public byte[] generateRouterConfig() throws IOException {
-        customRouterConfig = downloadConfig(customRouterConfigUrl);
+        String downloadedConfig = downloadConfig(customRouterConfigUrl);
+        if (downloadedConfig != null) {
+            customRouterConfig = downloadedConfig;
+        }
 
         byte[] customRouterConfigString = customRouterConfig != null
             ? customRouterConfig.getBytes(StandardCharsets.UTF_8)

--- a/src/main/java/com/conveyal/datatools/manager/utils/HttpUtils.java
+++ b/src/main/java/com/conveyal/datatools/manager/utils/HttpUtils.java
@@ -14,9 +14,12 @@ import org.apache.http.impl.client.HttpClients;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -111,6 +114,23 @@ public class HttpUtils {
         } catch (IOException e) {
             LOG.error("An exception occurred while making a request to {}", uri, e);
             return null;
+        }
+    }
+
+    /**
+     * Download a file from a URL and return as a byte array.
+     */
+    public static byte[] downloadFileFromURL(URL url) throws IOException {
+        try (
+            InputStream inputStream = url.openStream();
+            ByteArrayOutputStream outputStream = new ByteArrayOutputStream()
+        ) {
+            byte[] chunk = new byte[4096];
+            int bytesRead;
+            while ((bytesRead = inputStream.read(chunk)) >= 0) {
+                outputStream.write(chunk, 0, bytesRead);
+            }
+            return outputStream.toByteArray();
         }
     }
 }

--- a/src/test/java/com/conveyal/datatools/manager/jobs/DeployJobTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/jobs/DeployJobTest.java
@@ -27,6 +27,8 @@ import static com.conveyal.datatools.TestUtils.getBooleanEnvVar;
 import static com.zenika.snapshotmatcher.SnapshotMatcher.matchesSnapshot;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
@@ -78,6 +80,15 @@ public class DeployJobTest extends UnitTest {
         deployment.customRouterConfig = "{ \"hi\": \"th\ne'r\te\" }";
         deployment.customBuildConfig = "{ \"hello\": \"th\ne'r\te\" }";
         Persistence.deployments.create(deployment);
+    }
+
+    @Test
+    void canDownloadConfigs() throws IOException {
+        deployment.customBuildConfigUrl = "http://www.google.com";
+        assertNotNull(deployment.downloadConfig(deployment.customBuildConfigUrl));
+
+        deployment.customRouterConfigUrl = "http://www.google.com";
+        assertNotNull(deployment.downloadConfig(deployment.customRouterConfigUrl));
     }
 
     /**

--- a/src/test/java/com/conveyal/datatools/manager/jobs/DeployJobTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/jobs/DeployJobTest.java
@@ -28,7 +28,6 @@ import static com.zenika.snapshotmatcher.SnapshotMatcher.matchesSnapshot;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing
- [ ] The description lists all relevant PRs included in this release _(remove this if not merging to master)_
- [x] e2e tests are all passing _(remove this if not merging to master)_

### Description

Adds 2 new fields to `Deployment` that allow for downloading the router/build config from a URL. If the URL field is present, the old field is _ignored_, and a new file downloaded instead. Downloaded file is parsed only by Java's bulit-in toString method, so safety-wise we should be ok.

#### Looking for feedback
Should mongo be updated when we download the data? Are errors handled well? How should we test this?