### PR TITLE
Shared Stops Validator SS_01: only consider stops from feed being checked

### DIFF
--- a/src/main/java/com/conveyal/datatools/manager/jobs/validation/SharedStopsValidator.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/validation/SharedStopsValidator.java
@@ -127,17 +127,19 @@ public class SharedStopsValidator extends FeedValidator {
 
                 // Check for SS_01 (stop id appearing in multiple stop groups).
                 // Make sure this error is only returned if we are inside the feed that is being checked.
-                if (seenStopIds.contains(stopId)) {
-                    if (feedId.equals(sharedStopFeedId)) {
+                Stop syntheticStop = new Stop();
+                syntheticStop.stop_id = stopId;
+                if (feedId.equals(sharedStopFeedId)) {
+                    if (seenStopIds.contains(stopId)) {
                         registerError(stops
                             .stream()
                             .filter(stop -> stop.stop_id.equals(stopId))
                             .findFirst()
-                            .orElse(new Stop()), NewGTFSErrorType.MULTIPLE_SHARED_STOPS_GROUPS
+                            .orElse(syntheticStop), NewGTFSErrorType.MULTIPLE_SHARED_STOPS_GROUPS
                         );
+                    }else {
+                        seenStopIds.add(stopId);
                     }
-                } else {
-                    seenStopIds.add(stopId);
                 }
 
                 // Check for SS_02 (multiple primary stops per stop group).

--- a/src/main/java/com/conveyal/datatools/manager/jobs/validation/SharedStopsValidator.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/validation/SharedStopsValidator.java
@@ -137,7 +137,7 @@ public class SharedStopsValidator extends FeedValidator {
                             .findFirst()
                             .orElse(syntheticStop), NewGTFSErrorType.MULTIPLE_SHARED_STOPS_GROUPS
                         );
-                    }else {
+                    } else {
                         seenStopIds.add(stopId);
                     }
                 }


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

The shared stop validator was checking every stop from every feed. This sometimes created insane errors. This PR resolves this issue by adjusting some conditions so that only sensible stops are shown.