### PR TITLE
support new `prefer_s3_links` config property

### DIFF
--- a/configurations/default/server.yml.tmp
+++ b/configurations/default/server.yml.tmp
@@ -18,6 +18,8 @@ application:
 modules:
   enterprise:
     enabled: false
+    # Setting this to true will upload all feeds to S3 instead of linking to their URL
+    prefer_s3_links: false
   editor:
     enabled: true
   deployment:

--- a/src/main/java/com/conveyal/datatools/manager/jobs/PublishProjectFeedsJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/PublishProjectFeedsJob.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 import java.text.SimpleDateFormat;
 
 import static com.conveyal.datatools.manager.DataManager.getConfigPropertyAsText;
+import static com.conveyal.datatools.manager.DataManager.hasConfigProperty;
 
 /**
  * Publish the latest GTFS files for all public feeds in a project.
@@ -67,7 +68,7 @@ public class PublishProjectFeedsJob extends MonitorableJob {
                 .forEach(fs -> {
                     // generate list item for feed source
                     String url;
-                    if (fs.url != null) {
+                    if (fs.url != null && !hasConfigProperty("modules.enterprise.prefer_s3_links")) {
                         url = fs.url.toString();
                     }
                     else {


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing
- [x] The description lists all relevant PRs included in this release _(remove this if not merging to master)_
- [x] e2e tests are all passing _(remove this if not merging to master)_

### Description

The new property changes the generated HTML to use s3 urls instead of the auto fetch URLS. All optional, no defaults changed.