### PR TITLE
MTC Improve Error Messages for Normalize Transform [DT-409]

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -97,6 +97,10 @@ jobs:
 
       # Run maven-semantic-release to potentially create a new release of datatools-server. The flag --skip-maven-deploy is
       # used to avoid deploying to maven central. So essentially, this just creates a release with a changelog on github.
+      - name: Use Node.js 20.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 20.x
       - name: Run maven-semantic-release
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Use Node.js 20.x
         uses: actions/setup-node@v1
         with:
-          node-version: 20.x
+          node-version: 20.14
       - name: Start MongoDB
         uses: supercharge/mongodb-github-action@1.3.0
         with:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Use Node.js 20.x
         uses: actions/setup-node@v1
         with:
-          node-version: 20.14
+          node-version: 20.x
       - name: Start MongoDB
         uses: supercharge/mongodb-github-action@1.3.0
         with:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -28,11 +28,11 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
-      # Install node 14 for running e2e tests (and for maven-semantic-release).
-      - name: Use Node.js 18.x
+      # Install node for running e2e tests (and for maven-semantic-release).
+      - name: Use Node.js 20.x
         uses: actions/setup-node@v1
         with:
-          node-version: 18.x
+          node-version: 20.x
       - name: Start MongoDB
         uses: supercharge/mongodb-github-action@1.3.0
         with:

--- a/src/main/java/com/conveyal/datatools/manager/jobs/ProcessSingleFeedJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/ProcessSingleFeedJob.java
@@ -97,7 +97,10 @@ public class ProcessSingleFeedJob extends FeedVersionJob {
                 // Run transform job in line so we can monitor the error status before load/validate begins.
                 zipTransform.run();
                 // Short circuit the feed load/validate if a pre-load transform fails.
-                if (zipTransform.status.error) return;
+                if (zipTransform.status.error) {
+                    status.fail("Feed transformation failed, see details below.");
+                    return;
+                }
             }
             // Assign transform result from zip target.
             feedVersion.feedTransformResult = zipTarget.feedTransformResult;

--- a/src/main/java/com/conveyal/datatools/manager/models/transform/NormalizeFieldTransformation.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/transform/NormalizeFieldTransformation.java
@@ -231,7 +231,13 @@ public class NormalizeFieldTransformation extends ZipTransformation {
     }
 
     /** Write csv input stream into the zip file, replacing the existing file. */
-    private void writeCsvContent(FeedTransformZipTarget zipTarget, Path tempZipPath, StringWriter stringWriter, String tableName, int modifiedRowCount) throws IOException {
+    private void writeCsvContent(
+        FeedTransformZipTarget zipTarget,
+        Path tempZipPath,
+        StringWriter stringWriter,
+        String tableName,
+        int modifiedRowCount
+    ) throws IOException {
         try (
             // Modify target zip file that we just read.
             FileSystem targetZipFs = FileSystems.newFileSystem(tempZipPath, (ClassLoader) null);

--- a/src/main/java/com/conveyal/datatools/manager/models/transform/NormalizeFieldTransformation.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/transform/NormalizeFieldTransformation.java
@@ -28,6 +28,7 @@ import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.zip.ZipException;
 import java.util.zip.ZipFile;
 
 import static com.conveyal.datatools.manager.DataManager.getConfigProperty;
@@ -219,6 +220,11 @@ public class NormalizeFieldTransformation extends ZipTransformation {
             // (This should also trigger a system IO update event, so subsequent IO calls pick up the correct file.
             Files.move(tempZipPath, originalZipPath, StandardCopyOption.REPLACE_EXISTING);
             LOG.info("Field normalization transformation successful, {} row(s) changed.", modifiedRowCount);
+        } catch (ZipException ze) {
+            status.fail(
+                String.format("'Normalize Field' failed because the GTFS archive is corrupted (%s).", ze.getMessage()),
+                ze
+            );
         } catch (Exception e) {
             status.fail("Unknown error encountered while transforming zip file", e);
         }


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected => This is a PR against the MTC branch.
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [na] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR improves error messages for common cases when the Normalize Field Transform fails:
- A corrupt ZIP file is submitted for transformation.
- A non-GTFS but valid ZIP file is submitted for transformation.
- A GTFS ZIP file is submitted for transformation but the expected table file or field is missing.
- The field name parameter for the transformation is not set (i.e. a case where someone started adding a Normalize Field transformation but did not finish configuring it and proceeded to import a GTFS feed).  
