### PR TITLE
Fix GTFS+ downloads on Firefox

### DIFF
--- a/src/main/java/com/conveyal/datatools/common/utils/SparkUtils.java
+++ b/src/main/java/com/conveyal/datatools/common/utils/SparkUtils.java
@@ -55,7 +55,7 @@ public class SparkUtils {
         raw.setContentType("application/octet-stream");
         raw.setHeader("Content-Disposition", "attachment; filename=" + filename);
         // Override the gzip content encoding applied to standard API responses.
-        res.header("Content-Encoding", "identity");
+        raw.setHeader("Content-Encoding", "identity");
         try (
             FileInputStream fileInputStream = new FileInputStream(file);
             ServletOutputStream outputStream = raw.getOutputStream()


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected  => This PR addresses an issue with MTC
- [na] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Fix #609, where the implementation of GTFS+ download was * adding * a `Content-encoding: identity` header in addition to the gzip encoding, instead of overwriting the header.
