### PR TITLE
Upgrade MobilityData Validator to 7.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -262,7 +262,7 @@
         <dependency>
             <groupId>org.mobilitydata.gtfs-validator</groupId>
             <artifactId>gtfs-validator-main</artifactId>
-            <version>6.0.0</version>
+            <version>7.0.0</version>
         </dependency>
         <!-- Used for loading/fetching/validating/writing GTFS entities. gtfs-lib also provides access to:
          - commons-io - generic utilities


### PR DESCRIPTION
Upgrades MD validator to https://github.com/MobilityData/gtfs-validator/releases/tag/v7.0.0