### PR TITLE
remove dependence on OTP REST API

### DIFF
--- a/src/main/java/com/conveyal/datatools/manager/jobs/MonitorServerStatusJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/MonitorServerStatusJob.java
@@ -136,7 +136,7 @@ public class MonitorServerStatusJob extends MonitorableJob {
             // become available.
             TimeTracker routerCheckTracker = new TimeTracker(20, TimeUnit.MINUTES);
 
-            String routerUrl = String.join("/", ipUrl, deployment.tripPlannerVersion.equals(TripPlannerVersion.OTP_2) ? "otp/actuators/health" : "otp/routers/default");
+            String routerUrl = String.join("/", ipUrl, TripPlannerVersion.getUptimeCheckUrl(deployment.tripPlannerVersion));
             boolean routerIsAvailable = false;
             while (!routerIsAvailable) {
                 // If the request was successful, the graph build is complete!

--- a/src/main/java/com/conveyal/datatools/manager/jobs/MonitorServerStatusJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/MonitorServerStatusJob.java
@@ -134,7 +134,7 @@ public class MonitorServerStatusJob extends MonitorableJob {
             // load has completed successfully. Wait a maximum of 20 minutes to load the graph and for the router to
             // become available.
             TimeTracker routerCheckTracker = new TimeTracker(20, TimeUnit.MINUTES);
-            String routerUrl = String.join("/", ipUrl, "otp/routers/default");
+            String routerUrl = String.join("/", ipUrl, "otp/actuators/health");
             boolean routerIsAvailable = false;
             while (!routerIsAvailable) {
                 // If the request was successful, the graph build is complete!

--- a/src/main/java/com/conveyal/datatools/manager/jobs/MonitorServerStatusJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/MonitorServerStatusJob.java
@@ -13,6 +13,7 @@ import com.amazonaws.services.elasticloadbalancingv2.model.TargetHealthDescripti
 import com.conveyal.datatools.common.status.MonitorableJob;
 import com.conveyal.datatools.manager.auth.Auth0UserProfile;
 import com.conveyal.datatools.manager.models.Deployment;
+import com.conveyal.datatools.manager.models.Deployment.TripPlannerVersion;
 import com.conveyal.datatools.manager.models.OtpServer;
 import com.conveyal.datatools.manager.utils.ErrorUtils;
 import com.conveyal.datatools.manager.utils.SimpleHttpResponse;
@@ -134,7 +135,8 @@ public class MonitorServerStatusJob extends MonitorableJob {
             // load has completed successfully. Wait a maximum of 20 minutes to load the graph and for the router to
             // become available.
             TimeTracker routerCheckTracker = new TimeTracker(20, TimeUnit.MINUTES);
-            String routerUrl = String.join("/", ipUrl, "otp/actuators/health");
+
+            String routerUrl = String.join("/", ipUrl, deployment.tripPlannerVersion.equals(TripPlannerVersion.OTP_2) ? "otp/actuators/health" : "otp/routers/default");
             boolean routerIsAvailable = false;
             while (!routerIsAvailable) {
                 // If the request was successful, the graph build is complete!

--- a/src/main/java/com/conveyal/datatools/manager/models/Deployment.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/Deployment.java
@@ -666,7 +666,18 @@ public class Deployment extends Model implements Serializable {
     }
 
     public enum TripPlannerVersion {
-        OTP_1, OTP_2
+        OTP_1("otp/routers/default"),
+        OTP_2("otp/actuators/health");
+
+        private final String uptimeCheckUrl;
+
+        TripPlannerVersion(String uptimeCheckUrl) {
+            this.uptimeCheckUrl = uptimeCheckUrl;
+        }
+
+        public static String getUptimeCheckUrl(TripPlannerVersion version) {
+            return (version == OTP_2) ? OTP_2.uptimeCheckUrl : OTP_1.uptimeCheckUrl;
+        }
     }
 
     /**


### PR DESCRIPTION
We previously used the REST API to determine OTP uptime. This is now corrected and we use the https://docs.opentripplanner.org/en/latest/sandbox/ActuatorAPI/ instead. However, this means the actuator api has to be enabled for deployments to succeed.