### PR TITLE
feat: support custom feed filenames for deployment

### DIFF
--- a/src/main/java/com/conveyal/datatools/manager/models/Deployment.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/Deployment.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.io.ByteStreams;
 import com.mongodb.client.FindIterable;
+import org.apache.logging.log4j.util.Strings;
 import org.bson.codecs.pojo.annotations.BsonIgnore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -356,17 +357,7 @@ public class Deployment extends Model implements Serializable {
                 throw new RuntimeException(e1);
             }
             // Determine the entry name for the zip file.
-            String entryName;
-            FeedSource fs = v.parentFeedSource();
-            if (fs != null && fs.filename != null && !fs.filename.trim().isEmpty()) {
-                // Use FeedSource filename if available, ensuring it ends with .zip
-                entryName = fs.filename.endsWith(".zip") ? fs.filename : fs.filename + ".zip";
-                LOG.info("Using FeedSource filename for zip entry: {}", entryName);
-            } else {
-                // Fallback to the original GTFS filename derived from FeedVersion
-                entryName = gtfsFile.getName();
-                LOG.info("Using FeedVersion filename for zip entry: {}", entryName);
-            }
+            String entryName = getFeedSourceBundleFilename(v, gtfsFile);
             ZipEntry e = new ZipEntry(entryName);
             out.putNextEntry(e);
             ByteStreams.copy(in, out);
@@ -427,6 +418,31 @@ public class Deployment extends Model implements Serializable {
 
         // Finally close the zip output stream. The dump file is now complete.
         out.close();
+    }
+
+    /**
+     * Determine the entry name for a GTFS file within the deployment bundle.
+     * This prioritizes the FeedSource filename if available and valid, otherwise falls back
+     * to the original GTFS filename derived from the FeedVersion.
+     *
+     * @param feedVersion The FeedVersion being processed.
+     * @param gtfsFile    The GTFS file associated with the FeedVersion.
+     * @return The calculated entry name for the zip file.
+     */
+    public String getFeedSourceBundleFilename(FeedVersion feedVersion, File gtfsFile) {
+        String entryName;
+        FeedSource fs = feedVersion.parentFeedSource();
+
+        if (fs != null && !Strings.isBlank(fs.filename)) {
+            // Use FeedSource filename if available, ensuring it ends with .zip
+            entryName = fs.filename.endsWith(".zip") ? fs.filename : fs.filename + ".zip";
+            LOG.info("Using FeedSource filename for zip entry: {}", entryName);
+        } else {
+            // Fallback to the original GTFS filename derived from FeedVersion
+            entryName = gtfsFile.getName();
+            LOG.info("Using FeedVersion filename for zip entry: {}", entryName);
+        }
+        return entryName;
     }
 
     /** Download config from provided URL. */

--- a/src/main/java/com/conveyal/datatools/manager/models/Deployment.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/Deployment.java
@@ -355,7 +355,19 @@ public class Deployment extends Model implements Serializable {
                 LOG.error("Could not retrieve file for {}", v.name);
                 throw new RuntimeException(e1);
             }
-            ZipEntry e = new ZipEntry(gtfsFile.getName());
+            // Determine the entry name for the zip file.
+            String entryName;
+            FeedSource fs = v.parentFeedSource();
+            if (fs != null && fs.filename != null && !fs.filename.trim().isEmpty()) {
+                // Use FeedSource filename if available, ensuring it ends with .zip
+                entryName = fs.filename.endsWith(".zip") ? fs.filename : fs.filename + ".zip";
+                LOG.info("Using FeedSource filename for zip entry: {}", entryName);
+            } else {
+                // Fallback to the original GTFS filename derived from FeedVersion
+                entryName = gtfsFile.getName();
+                LOG.info("Using FeedVersion filename for zip entry: {}", entryName);
+            }
+            ZipEntry e = new ZipEntry(entryName);
             out.putNextEntry(e);
             ByteStreams.copy(in, out);
             try {

--- a/src/main/java/com/conveyal/datatools/manager/models/Deployment.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/Deployment.java
@@ -430,19 +430,17 @@ public class Deployment extends Model implements Serializable {
      * @return The calculated entry name for the zip file.
      */
     public String getFeedSourceBundleFilename(FeedVersion feedVersion, File gtfsFile) {
-        String entryName;
+        String gtfsFileName = gtfsFile.getName();
         FeedSource fs = feedVersion.parentFeedSource();
 
         if (fs != null && !Strings.isBlank(fs.filename)) {
             // Use FeedSource filename if available, ensuring it ends with .zip
-            entryName = fs.filename.endsWith(".zip") ? fs.filename : fs.filename + ".zip";
-            LOG.info("Using FeedSource filename for zip entry: {}", entryName);
-        } else {
-            // Fallback to the original GTFS filename derived from FeedVersion
-            entryName = gtfsFile.getName();
-            LOG.info("Using FeedVersion filename for zip entry: {}", entryName);
-        }
-        return entryName;
+            LOG.info("Using FeedSource filename for zip entry: {}", gtfsFileName);
+            return fs.filename.endsWith(".zip") ? fs.filename : fs.filename + ".zip";
+        } 
+        // Fallback to the original GTFS filename derived from FeedVersion
+        LOG.info("Using FeedVersion filename for zip entry: {}", gtfsFileName);
+        return gtfsFileName;
     }
 
     /** Download config from provided URL. */

--- a/src/main/java/com/conveyal/datatools/manager/models/FeedSource.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/FeedSource.java
@@ -97,6 +97,9 @@ public class FeedSource extends Model implements Cloneable {
     /** The name of this feed source, e.g. MTA New York City Subway */
     public String name;
 
+    /** An optional display filename for the feed in the bundle, e.g. "agency_transit.zip" */
+    public String filename;
+
     /** Is this feed public, i.e. should it be listed on the
      * public feeds page for download?
      */

--- a/src/main/java/com/conveyal/datatools/manager/models/FeedSourceSummary.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/FeedSourceSummary.java
@@ -42,6 +42,9 @@ public class FeedSourceSummary {
     public boolean deployable;
     public boolean isPublic;
 
+    /** An optional display filename for the feed in the bundle, e.g. "agency_transit.zip" */
+    public String filename;
+
     @JsonSerialize(using = JacksonSerializers.LocalDateIsoSerializer.class)
     @JsonDeserialize(using = JacksonSerializers.LocalDateIsoDeserializer.class)
     public LocalDate lastUpdated;
@@ -89,6 +92,8 @@ public class FeedSourceSummary {
         // Convert to local date type for consistency.
         this.lastUpdated = getLocalDateFromDate(feedSourceDocument.getDate("lastUpdated"));
         this.url = feedSourceDocument.getString("url");
+        // Get optional filename.
+        this.filename = feedSourceDocument.getString("filename");
     }
 
     /**
@@ -131,6 +136,7 @@ public class FeedSourceSummary {
                         "lastUpdated": 1,
                         "labelIds": 1,
                         "url": 1,
+                        "filename": 1,
                         "noteIds": 1
                     }
                 },
@@ -154,6 +160,7 @@ public class FeedSourceSummary {
                     "lastUpdated",
                     "labelIds",
                     "url",
+                    "filename",
                     "noteIds")
                 )
             ),

--- a/src/test/java/com/conveyal/datatools/manager/jobs/DeployJobTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/jobs/DeployJobTest.java
@@ -103,6 +103,7 @@ public class DeployJobTest extends UnitTest {
         feedSource.projectId = project.id;
         FeedVersion feedVersion = new FeedVersion(feedSource);
         File gtfsFile = File.createTempFile("test-gtfs-", ".zip");
+        var gtfsFileName = gtfsFile.getName();
         gtfsFile.deleteOnExit();
 
         feedSource.filename = "gtfs_from_source.zip";
@@ -115,14 +116,14 @@ public class DeployJobTest extends UnitTest {
 
         feedSource.filename = " ";
         Persistence.feedSources.replace(feedSource.id, feedSource);
-        assertEquals(gtfsFile.getName(), deployment.getFeedSourceBundleFilename(feedVersion, gtfsFile));
+        assertEquals(gtfsFileName, deployment.getFeedSourceBundleFilename(feedVersion, gtfsFile));
 
         feedSource.filename = null;
         Persistence.feedSources.replace(feedSource.id, feedSource);
-        assertEquals(gtfsFile.getName(), deployment.getFeedSourceBundleFilename(feedVersion, gtfsFile));
+        assertEquals(gtfsFileName, deployment.getFeedSourceBundleFilename(feedVersion, gtfsFile));
 
         FeedVersion versionWithNullSource = new FeedVersion();
-        assertEquals(gtfsFile.getName(), deployment.getFeedSourceBundleFilename(versionWithNullSource, gtfsFile));
+        assertEquals(gtfsFileName, deployment.getFeedSourceBundleFilename(versionWithNullSource, gtfsFile));
 
         Persistence.feedVersions.removeById(feedVersion.id);
         Persistence.feedSources.removeById(feedSource.id);

--- a/src/test/java/com/conveyal/datatools/manager/jobs/DeployJobTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/jobs/DeployJobTest.java
@@ -9,6 +9,8 @@ import com.conveyal.datatools.common.utils.aws.EC2Utils;
 import com.conveyal.datatools.manager.auth.Auth0UserProfile;
 import com.conveyal.datatools.manager.models.Deployment;
 import com.conveyal.datatools.manager.models.EC2Info;
+import com.conveyal.datatools.manager.models.FeedSource;
+import com.conveyal.datatools.manager.models.FeedVersion;
 import com.conveyal.datatools.manager.models.OtpServer;
 import com.conveyal.datatools.manager.models.Project;
 import com.conveyal.datatools.manager.persistence.Persistence;
@@ -18,6 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Date;
@@ -26,6 +29,7 @@ import java.util.List;
 import static com.conveyal.datatools.TestUtils.getBooleanEnvVar;
 import static com.zenika.snapshotmatcher.SnapshotMatcher.matchesSnapshot;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
@@ -88,6 +92,40 @@ public class DeployJobTest extends UnitTest {
 
         deployment.customRouterConfigUrl = "http://www.google.com";
         assertNotNull(deployment.downloadConfig(deployment.customRouterConfigUrl));
+    }
+
+    /**
+     * Tests that the bundle filename is correctly determined.
+     */
+    @Test
+    public void canGetFeedSourceBundleFilename() throws IOException {
+        FeedSource feedSource = new FeedSource("Test FeedSource");
+        feedSource.projectId = project.id;
+        FeedVersion feedVersion = new FeedVersion(feedSource);
+        File gtfsFile = File.createTempFile("test-gtfs-", ".zip");
+        gtfsFile.deleteOnExit();
+
+        feedSource.filename = "gtfs_from_source.zip";
+        Persistence.feedSources.create(feedSource);
+        assertEquals("gtfs_from_source.zip", deployment.getFeedSourceBundleFilename(feedVersion, gtfsFile));
+
+        feedSource.filename = "gtfs_from_source";
+        Persistence.feedSources.replace(feedSource.id, feedSource);
+        assertEquals("gtfs_from_source.zip", deployment.getFeedSourceBundleFilename(feedVersion, gtfsFile));
+
+        feedSource.filename = " ";
+        Persistence.feedSources.replace(feedSource.id, feedSource);
+        assertEquals(gtfsFile.getName(), deployment.getFeedSourceBundleFilename(feedVersion, gtfsFile));
+
+        feedSource.filename = null;
+        Persistence.feedSources.replace(feedSource.id, feedSource);
+        assertEquals(gtfsFile.getName(), deployment.getFeedSourceBundleFilename(feedVersion, gtfsFile));
+
+        FeedVersion versionWithNullSource = new FeedVersion();
+        assertEquals(gtfsFile.getName(), deployment.getFeedSourceBundleFilename(versionWithNullSource, gtfsFile));
+
+        Persistence.feedVersions.removeById(feedVersion.id);
+        Persistence.feedSources.removeById(feedSource.id);
     }
 
     /**


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [ ] The description lists all applicable issues this PR seeks to resolve
- [ ] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing
- [ ] The description lists all relevant PRs included in this release _(remove this if not merging to master)_
- [ ] e2e tests are all passing _(remove this if not merging to master)_

### Description

This PR adds support for overriding the feed filenames that will be used in the bundle. This feature allows us to override feed specific build settings in the build config.