### PR TITLE
Don't Autopublish Expired Feeds (MTC)

### DIFF
--- a/src/main/java/com/conveyal/datatools/manager/jobs/AutoPublishJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/AutoPublishJob.java
@@ -52,7 +52,7 @@ public class AutoPublishJob extends MonitorableJobWithResourceLock<FeedSource> {
                     status.fail("Could not publish this feed version because it contains GTFS+ blocking errors.");
                 }
             } catch(Exception e) {
-                status.fail("Could not read GTFS+ zip file", e);
+                status.fail("Could not read GTFS+ zip file.", e);
             }
         }
 
@@ -63,7 +63,7 @@ public class AutoPublishJob extends MonitorableJobWithResourceLock<FeedSource> {
         } else {
             // Notify feed and project subscribed users of failure.
             String message = String.format(
-                "WARNING: Auto-published feed source %s failed to deploy. Error: %s.",
+                "WARNING: Auto-published feed source %s failed to deploy. Error: %s",
                 feedSource.name,
                 status.message
             );

--- a/src/main/java/com/conveyal/datatools/manager/jobs/AutoPublishJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/AutoPublishJob.java
@@ -41,7 +41,9 @@ public class AutoPublishJob extends MonitorableJobWithResourceLock<FeedSource> {
         FeedVersion latestFeedVersion = feedSource.retrieveLatest();
 
         // Validate and check for blocking issues in the feed version to deploy.
-        if (latestFeedVersion.hasBlockingIssuesForPublishing()) {
+        if (latestFeedVersion.hasExpired()) {
+            status.fail("Could not publish this feed version because it has expired.");
+        } else if (latestFeedVersion.hasBlockingIssuesForPublishing()) {
             status.fail("Could not publish this feed version because it contains blocking errors.");
         } else {
             try {

--- a/src/main/java/com/conveyal/datatools/manager/models/FeedVersion.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/FeedVersion.java
@@ -80,7 +80,7 @@ public class FeedVersion extends Model implements Serializable {
     // FIXME: move this out of FeedVersion (also, it should probably not be public)?
     public static FeedStore feedStore = new FeedStore();
 
-    private static LocalDate dateOverride = null;
+    private static LocalDate dateOverrideForTesting = null;
     /**
      * Input feed versions used to create a merged version.
      */
@@ -513,11 +513,11 @@ public class FeedVersion extends Model implements Serializable {
     }
 
     private static LocalDate getNowAsLocalDate() {
-        return dateOverride == null ? LocalDate.now() : dateOverride;
+        return dateOverrideForTesting == null ? LocalDate.now() : dateOverrideForTesting;
     }
 
-    public static void setDateOverride(LocalDate value) {
-        dateOverride = value;
+    public static void setDateOverrideForTesting(LocalDate value) {
+        dateOverrideForTesting = value;
     }
 
     /**

--- a/src/main/java/com/conveyal/datatools/manager/models/FeedVersion.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/FeedVersion.java
@@ -20,12 +20,14 @@ import com.conveyal.gtfs.loader.FeedLoadResult;
 import com.conveyal.gtfs.validator.MTCValidator;
 import com.conveyal.gtfs.validator.ValidationResult;
 import com.conveyal.gtfs.validator.model.Priority;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonView;
 import org.bson.Document;
+import org.bson.codecs.pojo.annotations.BsonIgnore;
 import org.bson.codecs.pojo.annotations.BsonProperty;
 import org.mobilitydata.gtfsvalidator.runner.ApplicationType;
 import org.mobilitydata.gtfsvalidator.runner.ValidationRunner;
@@ -77,6 +79,8 @@ public class FeedVersion extends Model implements Serializable {
     private static final Logger LOG = LoggerFactory.getLogger(FeedVersion.class);
     // FIXME: move this out of FeedVersion (also, it should probably not be public)?
     public static FeedStore feedStore = new FeedStore();
+
+    private static LocalDate dateOverride = null;
     /**
      * Input feed versions used to create a merged version.
      */
@@ -479,7 +483,7 @@ public class FeedVersion extends Model implements Serializable {
      */
     public boolean hasCriticalErrors() {
         return hasValidationAndLoadErrors() ||
-            hasFeedVersionExpired() ||
+            hasExpired() ||
             hasHighSeverityErrorTypes();
     }
 
@@ -501,9 +505,19 @@ public class FeedVersion extends Model implements Serializable {
      * Has this feed expired?
      * @return If the validation result last calendar date is null or has expired return true, else return false.
      */
-    private boolean hasFeedVersionExpired() {
+    @JsonIgnore
+    @BsonIgnore
+    public boolean hasExpired() {
         return validationResult.lastCalendarDate == null ||
-            LocalDate.now().isAfter(validationResult.lastCalendarDate);
+            getNowAsLocalDate().isAfter(validationResult.lastCalendarDate);
+    }
+
+    private static LocalDate getNowAsLocalDate() {
+        return dateOverride == null ? LocalDate.now() : dateOverride;
+    }
+
+    public static void setDateOverride(LocalDate value) {
+        dateOverride = value;
     }
 
     /**

--- a/src/test/java/com/conveyal/datatools/manager/jobs/AutoPublishJobTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/jobs/AutoPublishJobTest.java
@@ -12,6 +12,7 @@ import com.conveyal.datatools.manager.models.Project;
 import com.conveyal.datatools.manager.persistence.Persistence;
 import com.google.common.collect.Lists;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -19,6 +20,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -54,6 +56,8 @@ public class AutoPublishJobTest extends UnitTest {
         // start server if it isn't already running
         DatatoolsTest.setUp();
 
+        FeedVersion.setDateOverride(LocalDate.of(2019, 3, 1));
+
         // Enable MTC extension, but disable the transformations.
         ProcessSingleFeedJob.ENABLE_MTC_TRANSFORMATIONS = false;
         DatatoolsTest.enableMTCExtension();
@@ -81,6 +85,12 @@ public class AutoPublishJobTest extends UnitTest {
         Persistence.externalFeedSourceProperties.create(agencyIdProp);
     }
 
+    @AfterEach
+    void afterEach() {
+        // Reset date overrides.
+        FeedVersion.setDateOverride(null);
+    }
+
     @AfterAll
     public static void tearDown() {
         Auth0Connection.setAuthDisabled(Auth0Connection.getDefaultAuthDisabled());
@@ -97,7 +107,8 @@ public class AutoPublishJobTest extends UnitTest {
      */
     @ParameterizedTest
     @MethodSource("createPublishFeedCases")
-    void shouldProcessFeed(String resourceName, boolean isError, String errorMessage) throws IOException {
+    void shouldProcessFeed(String resourceName, LocalDate nowDate, boolean isError, String errorMessage) throws IOException {
+        FeedVersion.setDateOverride(nowDate);
         // Add the version to the feed source
         FeedVersion originalFeedVersion;
         if (resourceName.endsWith(".zip")) {
@@ -128,21 +139,31 @@ public class AutoPublishJobTest extends UnitTest {
     }
 
     private static Stream<Arguments> createPublishFeedCases() {
+        LocalDate feedValidDate = LocalDate.of(2019, 3, 1);
         return Stream.of(
             Arguments.of(
                 "fake-agency-with-only-calendar-expire-in-2099-with-failed-referential-integrity",
+                feedValidDate,
                 true,
                 "Could not publish this feed version because it contains blocking errors."
             ),
             Arguments.of(
                 "bart_old_lite.zip",
+                feedValidDate,
                 true,
                 "Could not publish this feed version because it contains GTFS+ blocking errors."
             ),
             Arguments.of(
                 "bart_new_lite.zip",
+                feedValidDate,
                 false,
                 null
+            ),
+            Arguments.of(
+                "bart_new_lite.zip",
+                null,
+                true,
+                "Could not publish this feed version because it has expired."
             )
         );
     }
@@ -150,6 +171,8 @@ public class AutoPublishJobTest extends UnitTest {
     @ParameterizedTest
     @MethodSource("createUpdateFeedInfoCases")
     void shouldUpdateFeedInfoAfterPublishComplete(String agencyId, boolean isUnknownFeedId) {
+        FeedVersion.setDateOverride(LocalDate.of(2019, 3, 1));
+
         // Add the version to the feed source
         FeedVersion createdVersion = createFeedVersionFromGtfsZip(feedSource, "bart_new_lite.zip");
 
@@ -229,6 +252,8 @@ public class AutoPublishJobTest extends UnitTest {
      */
     @Test
     void shouldNotUpdateFromAPreviouslyPublishedVersionOnStartup() {
+        FeedVersion.setDateOverride(LocalDate.of(2019, 3, 1));
+
         final int TWO_DAYS_MILLIS = 48 * 3600000;
 
         // Set up a test FeedUpdater instance that fakes an external published date in the past.

--- a/src/test/java/com/conveyal/datatools/manager/jobs/AutoPublishJobTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/jobs/AutoPublishJobTest.java
@@ -56,7 +56,7 @@ public class AutoPublishJobTest extends UnitTest {
         // start server if it isn't already running
         DatatoolsTest.setUp();
 
-        FeedVersion.setDateOverride(LocalDate.of(2019, 3, 1));
+        FeedVersion.setDateOverrideForTesting(LocalDate.of(2019, 3, 1));
 
         // Enable MTC extension, but disable the transformations.
         ProcessSingleFeedJob.ENABLE_MTC_TRANSFORMATIONS = false;
@@ -88,7 +88,7 @@ public class AutoPublishJobTest extends UnitTest {
     @AfterEach
     void afterEach() {
         // Reset date overrides.
-        FeedVersion.setDateOverride(null);
+        FeedVersion.setDateOverrideForTesting(null);
     }
 
     @AfterAll
@@ -108,7 +108,7 @@ public class AutoPublishJobTest extends UnitTest {
     @ParameterizedTest
     @MethodSource("createPublishFeedCases")
     void shouldProcessFeed(String resourceName, LocalDate nowDate, boolean isError, String errorMessage) throws IOException {
-        FeedVersion.setDateOverride(nowDate);
+        FeedVersion.setDateOverrideForTesting(nowDate);
         // Add the version to the feed source
         FeedVersion originalFeedVersion;
         if (resourceName.endsWith(".zip")) {
@@ -171,7 +171,7 @@ public class AutoPublishJobTest extends UnitTest {
     @ParameterizedTest
     @MethodSource("createUpdateFeedInfoCases")
     void shouldUpdateFeedInfoAfterPublishComplete(String agencyId, boolean isUnknownFeedId) {
-        FeedVersion.setDateOverride(LocalDate.of(2019, 3, 1));
+        FeedVersion.setDateOverrideForTesting(LocalDate.of(2019, 3, 1));
 
         // Add the version to the feed source
         FeedVersion createdVersion = createFeedVersionFromGtfsZip(feedSource, "bart_new_lite.zip");
@@ -252,7 +252,7 @@ public class AutoPublishJobTest extends UnitTest {
      */
     @Test
     void shouldNotUpdateFromAPreviouslyPublishedVersionOnStartup() {
-        FeedVersion.setDateOverride(LocalDate.of(2019, 3, 1));
+        FeedVersion.setDateOverrideForTesting(LocalDate.of(2019, 3, 1));
 
         final int TWO_DAYS_MILLIS = 48 * 3600000;
 


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR adds logic to the AutoPublish job to exclude expired feeds from being autopublished.
Subscribers (and app admins) will be notified on attempts to fetch and auto-publish an expired feed.

(Reminder that MTC now uses the dev branch for datatools-server)

Config settings: Any server.yml config that contains all of the below:
```yml
extensions:
  mtc:
    disableAutoPublish: false
    enabled: true
```

