### PR TITLE
Auto fetch memory leak

### DIFF
--- a/src/main/java/com/conveyal/datatools/manager/models/FeedSource.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/FeedSource.java
@@ -35,6 +35,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -232,11 +233,12 @@ public class FeedSource extends Model implements Cloneable {
             conn.connect();
             return processFetchResponse(status, optionalUrlOverride, version, latest, new HttpURLConnectionResponse(conn));
         } catch (IOException e) {
-            String message = String.format("Unable to connect to %s; not fetching %s feed", conn.getURL(), this.name); // url, this.name);
-            LOG.error(message);
+            String message = String.format("Unable to connect to %s; not fetching %s feed", conn.getURL(), this.name);
+            LOG.error(message, e);
             status.fail(message);
-            e.printStackTrace();
             return null;
+        } finally {
+            conn.disconnect();
         }
     }
 
@@ -322,7 +324,9 @@ public class FeedSource extends Model implements Cloneable {
                     status.update(message, 75.0);
                     // Create new file from input stream (this also handles hashing the file and other version fields
                     // calculated from the GTFS file.
-                    newGtfsFile = version.newGtfsFile(response.getInputStream());
+                    try (InputStream inputStream = response.getInputStream()) {
+                        newGtfsFile = version.newGtfsFile(inputStream);
+                    }
                     break;
                 case HttpURLConnection.HTTP_MOVED_TEMP:
                 case HttpURLConnection.HTTP_MOVED_PERM:

--- a/src/main/java/com/conveyal/datatools/manager/persistence/FeedStore.java
+++ b/src/main/java/com/conveyal/datatools/manager/persistence/FeedStore.java
@@ -139,7 +139,9 @@ public class FeedStore {
         // NOTE: depending on the feed store, there may not be a feedSource provided (e.g., gtfsplus)
         File file = new File(path, id);
         LOG.info("Writing file to {}", file.getAbsolutePath());
-        ByteStreams.copy(inputStream, new FileOutputStream(file));
+        try (InputStream stream = inputStream; FileOutputStream outputStream = new FileOutputStream(file)) {
+            ByteStreams.copy(stream, outputStream);
+        }
         if (feedSource != null && !DataManager.useS3) {
             // Store latest as feed-source-id.zip if feedSource provided and if not using s3
             copyVersionToLatest(file, feedSource);


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Update to close connection and input streams used in the process of fetching a feed version. If there are any issues with the connection e.g. bad SSL, the only potential issue would be not closing the connection (which is addressed here). It is more likely that the issue (if it is in this area) is related to the feed being downloaded and input streams, overtime, not being closed. Again, this is addressed here.
