### PR TITLE
Bump Node to version 22 in Github action

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -32,11 +32,11 @@ jobs:
         with:
           java-version: 19
           distribution: 'temurin'
-      # Install node 20 for running e2e tests (and for maven-semantic-release).
-      - name: Use Node.js 20.x
+      # Install node 22 for running e2e tests (and for maven-semantic-release).
+      - name: Use Node.js 22.x
         uses: actions/setup-node@v1
         with:
-          node-version: 20.x
+          node-version: 22.x
       - name: Start MongoDB
         uses: supercharge/mongodb-github-action@1.3.0
         with:
@@ -98,10 +98,10 @@ jobs:
 
       # Run maven-semantic-release to potentially create a new release of datatools-server. The flag --skip-maven-deploy is
       # used to avoid deploying to maven central. So essentially, this just creates a release with a changelog on github.
-      - name: Use Node.js 20.x
+      - name: Use Node.js 22.x
         uses: actions/setup-node@v1
         with:
-          node-version: 20.x
+          node-version: 22.x
       - name: Run maven-semantic-release
         if: env.SAVE_JAR_TO_S3 == 'true'
         env:


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

GitHub actions no longer work with Node version 20 so updating to version 22.
