### PR TITLE
Add external properties to FeedSourceSummary

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -3,7 +3,7 @@ name: Create and publish a Docker image
 
 on:
   push:
-    branches: ['dev', 'master', 'dev-flex', 'mtc-deploy']
+    branches: ['dev', 'master', 'dev-flex', 'mtc-deploy', 'mtc-props-in-feed-summaries']
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -3,7 +3,7 @@ name: Create and publish a Docker image
 
 on:
   push:
-    branches: ['dev', 'master', 'dev-flex', 'mtc-deploy', 'mtc-props-in-feed-summaries']
+    branches: ['dev', 'master', 'dev-flex', 'mtc-deploy']
 
 env:
   REGISTRY: ghcr.io

--- a/src/main/java/com/conveyal/datatools/manager/extensions/ExternalPropertiesRetriever.java
+++ b/src/main/java/com/conveyal/datatools/manager/extensions/ExternalPropertiesRetriever.java
@@ -13,11 +13,16 @@ import static com.mongodb.client.model.Filters.eq;
  * Class for retrieving external properties for a feed source.
  */
 public class ExternalPropertiesRetriever {
-    public Map<String, Map<String, String>> retrieveFeedSourceExternalProperties(String feedSourceId) {
+
+    private ExternalPropertiesRetriever() {
+        // This hides the public constructor.
+    }
+
+    public static Map<String, Map<String, String>> retrieveFeedSourceExternalProperties(String feedSourceId) {
 
         Map<String, Map<String, String>> resourceTable = new HashMap<>();
 
-        for(String resourceType : DataManager.feedResources.keySet()) {
+        for (String resourceType : DataManager.feedResources.keySet()) {
             Map<String, String> propTable = new HashMap<>();
 
             // Get all external properties for the feed source/resource type and fill prop table.

--- a/src/main/java/com/conveyal/datatools/manager/extensions/ExternalPropertiesRetriever.java
+++ b/src/main/java/com/conveyal/datatools/manager/extensions/ExternalPropertiesRetriever.java
@@ -1,0 +1,32 @@
+package com.conveyal.datatools.manager.extensions;
+
+import com.conveyal.datatools.manager.DataManager;
+import com.conveyal.datatools.manager.persistence.Persistence;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.mongodb.client.model.Filters.and;
+import static com.mongodb.client.model.Filters.eq;
+
+/**
+ * Class for retrieving external properties for a feed source.
+ */
+public class ExternalPropertiesRetriever {
+    public Map<String, Map<String, String>> retrieveFeedSourceExternalProperties(String feedSourceId) {
+
+        Map<String, Map<String, String>> resourceTable = new HashMap<>();
+
+        for(String resourceType : DataManager.feedResources.keySet()) {
+            Map<String, String> propTable = new HashMap<>();
+
+            // Get all external properties for the feed source/resource type and fill prop table.
+            Persistence.externalFeedSourceProperties
+                .getFiltered(and(eq("feedSourceId", feedSourceId), eq("resourceType", resourceType)))
+                .forEach(prop -> propTable.put(prop.name, prop.value));
+
+            resourceTable.put(resourceType, propTable);
+        }
+        return resourceTable;
+    }
+}

--- a/src/main/java/com/conveyal/datatools/manager/models/FeedSource.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/FeedSource.java
@@ -515,7 +515,7 @@ public class FeedSource extends Model implements Cloneable {
     @JsonView(JsonViews.UserInterface.class)
     @JsonProperty("externalProperties")
     public Map<String, Map<String, String>> externalProperties() {
-        return new ExternalPropertiesRetriever().retrieveFeedSourceExternalProperties(this.id);
+        return ExternalPropertiesRetriever.retrieveFeedSourceExternalProperties(id);
     }
 
     /**

--- a/src/main/java/com/conveyal/datatools/manager/models/FeedSource.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/FeedSource.java
@@ -10,6 +10,7 @@ import com.conveyal.datatools.common.utils.Scheduler;
 import com.conveyal.datatools.common.utils.aws.CheckedAWSException;
 import com.conveyal.datatools.common.utils.aws.S3Utils;
 import com.conveyal.datatools.manager.DataManager;
+import com.conveyal.datatools.manager.extensions.ExternalPropertiesRetriever;
 import com.conveyal.datatools.manager.jobs.CreateFeedVersionFromSnapshotJob;
 import com.conveyal.datatools.manager.jobs.FetchSingleFeedJob;
 import com.conveyal.datatools.manager.jobs.MergeFeedsJob;
@@ -42,7 +43,6 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -515,20 +515,7 @@ public class FeedSource extends Model implements Cloneable {
     @JsonView(JsonViews.UserInterface.class)
     @JsonProperty("externalProperties")
     public Map<String, Map<String, String>> externalProperties() {
-
-        Map<String, Map<String, String>> resourceTable = new HashMap<>();
-
-        for(String resourceType : DataManager.feedResources.keySet()) {
-            Map<String, String> propTable = new HashMap<>();
-
-            // Get all external properties for the feed source/resource type and fill prop table.
-            Persistence.externalFeedSourceProperties
-                .getFiltered(and(eq("feedSourceId", this.id), eq("resourceType", resourceType)))
-                .forEach(prop -> propTable.put(prop.name, prop.value));
-
-            resourceTable.put(resourceType, propTable);
-        }
-        return resourceTable;
+        return new ExternalPropertiesRetriever().retrieveFeedSourceExternalProperties(this.id);
     }
 
     /**

--- a/src/main/java/com/conveyal/datatools/manager/models/FeedSourceSummary.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/FeedSourceSummary.java
@@ -1,7 +1,7 @@
 package com.conveyal.datatools.manager.models;
 
 import com.conveyal.datatools.editor.utils.JacksonSerializers;
-import com.conveyal.datatools.manager.DataManager;
+import com.conveyal.datatools.manager.extensions.ExternalPropertiesRetriever;
 import com.conveyal.datatools.manager.persistence.Persistence;
 import com.conveyal.gtfs.validator.ValidationResult;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -35,9 +35,7 @@ import static com.mongodb.client.model.Aggregates.project;
 import static com.mongodb.client.model.Aggregates.replaceRoot;
 import static com.mongodb.client.model.Aggregates.sort;
 import static com.mongodb.client.model.Aggregates.unwind;
-import static com.mongodb.client.model.Filters.and;
 import static com.mongodb.client.model.Filters.in;
-import static com.mongodb.client.model.Filters.eq;
 
 public class FeedSourceSummary {
     private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd");
@@ -112,7 +110,7 @@ public class FeedSourceSummary {
             hasConfigProperty("modules.gtfsapi.use_extension") &&
             isExtensionEnabled(getConfigPropertyAsText("modules.gtfsapi.use_extension"))
         ) {
-            externalProperties = retrieveExternalProperties();
+            externalProperties = new ExternalPropertiesRetriever().retrieveFeedSourceExternalProperties(this.id);
         }
     }
 
@@ -133,23 +131,6 @@ public class FeedSourceSummary {
                 this.latestValidation = new LatestValidationResult(feedVersionSummary);
             }
         }
-    }
-
-    public Map<String, Map<String, String>> retrieveExternalProperties() {
-
-        Map<String, Map<String, String>> resourceTable = new HashMap<>();
-
-        for(String resourceType : DataManager.feedResources.keySet()) {
-            Map<String, String> propTable = new HashMap<>();
-
-            // Get all external properties for the feed source/resource type and fill prop table.
-            Persistence.externalFeedSourceProperties
-                .getFiltered(and(eq("feedSourceId", this.id), eq("resourceType", resourceType)))
-                .forEach(prop -> propTable.put(prop.name, prop.value));
-
-            resourceTable.put(resourceType, propTable);
-        }
-        return resourceTable;
     }
 
     /**

--- a/src/main/java/com/conveyal/datatools/manager/models/FeedSourceSummary.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/FeedSourceSummary.java
@@ -110,7 +110,7 @@ public class FeedSourceSummary {
             hasConfigProperty("modules.gtfsapi.use_extension") &&
             isExtensionEnabled(getConfigPropertyAsText("modules.gtfsapi.use_extension"))
         ) {
-            externalProperties = new ExternalPropertiesRetriever().retrieveFeedSourceExternalProperties(this.id);
+            externalProperties = ExternalPropertiesRetriever.retrieveFeedSourceExternalProperties(id);
         }
     }
 

--- a/src/main/java/com/conveyal/datatools/manager/models/FeedSourceSummary.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/FeedSourceSummary.java
@@ -1,8 +1,10 @@
 package com.conveyal.datatools.manager.models;
 
 import com.conveyal.datatools.editor.utils.JacksonSerializers;
+import com.conveyal.datatools.manager.DataManager;
 import com.conveyal.datatools.manager.persistence.Persistence;
 import com.conveyal.gtfs.validator.ValidationResult;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.collect.Lists;
@@ -21,6 +23,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static com.conveyal.datatools.manager.DataManager.getConfigPropertyAsText;
+import static com.conveyal.datatools.manager.DataManager.hasConfigProperty;
+import static com.conveyal.datatools.manager.DataManager.isExtensionEnabled;
+import static com.conveyal.datatools.manager.DataManager.isModuleEnabled;
 import static com.mongodb.client.model.Aggregates.group;
 import static com.mongodb.client.model.Aggregates.limit;
 import static com.mongodb.client.model.Aggregates.lookup;
@@ -29,7 +35,9 @@ import static com.mongodb.client.model.Aggregates.project;
 import static com.mongodb.client.model.Aggregates.replaceRoot;
 import static com.mongodb.client.model.Aggregates.sort;
 import static com.mongodb.client.model.Aggregates.unwind;
+import static com.mongodb.client.model.Filters.and;
 import static com.mongodb.client.model.Filters.in;
+import static com.mongodb.client.model.Filters.eq;
 
 public class FeedSourceSummary {
     private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd");
@@ -71,6 +79,9 @@ public class FeedSourceSummary {
 
     public String organizationId;
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public Map<String, Map<String, String>> externalProperties;
+
     public FeedSourceSummary() {
     }
 
@@ -94,6 +105,15 @@ public class FeedSourceSummary {
         this.url = feedSourceDocument.getString("url");
         // Get optional filename.
         this.filename = feedSourceDocument.getString("filename");
+
+        // Optional external properties, if enabled by config.
+        if (
+            isModuleEnabled("gtfsapi") &&
+            hasConfigProperty("modules.gtfsapi.use_extension") &&
+            isExtensionEnabled(getConfigPropertyAsText("modules.gtfsapi.use_extension"))
+        ) {
+            externalProperties = retrieveExternalProperties();
+        }
     }
 
     /**
@@ -113,6 +133,23 @@ public class FeedSourceSummary {
                 this.latestValidation = new LatestValidationResult(feedVersionSummary);
             }
         }
+    }
+
+    public Map<String, Map<String, String>> retrieveExternalProperties() {
+
+        Map<String, Map<String, String>> resourceTable = new HashMap<>();
+
+        for(String resourceType : DataManager.feedResources.keySet()) {
+            Map<String, String> propTable = new HashMap<>();
+
+            // Get all external properties for the feed source/resource type and fill prop table.
+            Persistence.externalFeedSourceProperties
+                .getFiltered(and(eq("feedSourceId", this.id), eq("resourceType", resourceType)))
+                .forEach(prop -> propTable.put(prop.name, prop.value));
+
+            resourceTable.put(resourceType, propTable);
+        }
+        return resourceTable;
     }
 
     /**


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Fix #636.

This PR is a quick fix to add external properties to `FeedSourceSummary` for deployments that use the `gtfsapi` feature, so that alerts that affect a particular feed can be published.

```
gtfsapi:
   enabled: true
   use_extension: abc
```

