### PR TITLE
Fix GTFS+ handling

### DIFF
--- a/src/main/java/com/conveyal/datatools/manager/controllers/api/GtfsPlusController.java
+++ b/src/main/java/com/conveyal/datatools/manager/controllers/api/GtfsPlusController.java
@@ -178,46 +178,50 @@ public class GtfsPlusController {
 
         File newFeed = null;
 
-        try (ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(newFeed))) {
+        try {
             // First, create a new zip file to only contain the GTFS+ tables
             newFeed = File.createTempFile(feedVersionId + "_new", ".zip");
+            try (
+                ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(newFeed));
+                ZipFile gtfsFile = new ZipFile(feedVersion.retrieveGtfsFile())
+            ) {
+                // Next, iterate through the existing GTFS file, copying all non-GTFS+ tables.
+                final Enumeration<? extends ZipEntry> entries = gtfsFile.entries();
+                byte[] buffer = new byte[512];
+                while (entries.hasMoreElements()) {
+                    final ZipEntry entry = entries.nextElement();
+                    // skip GTFS+ and non-standard tables
+                    if (gtfsPlusTables.contains(entry.getName()) || entry.getName().startsWith("_")) continue;
 
-            // Next, iterate through the existing GTFS file, copying all non-GTFS+ tables.
-            ZipFile gtfsFile = new ZipFile(feedVersion.retrieveGtfsFile());
-            final Enumeration<? extends ZipEntry> entries = gtfsFile.entries();
-            byte[] buffer = new byte[512];
-            while (entries.hasMoreElements()) {
-                final ZipEntry entry = entries.nextElement();
-                // skip GTFS+ and non-standard tables
-                if (gtfsPlusTables.contains(entry.getName()) || entry.getName().startsWith("_")) continue;
+                    // create a new empty ZipEntry and copy the contents
+                    ZipEntry newEntry = new ZipEntry(entry.getName());
+                    zos.putNextEntry(newEntry);
+                    try (InputStream in = gtfsFile.getInputStream(entry)) {
+                        while (0 < in.available()) {
+                            int read = in.read(buffer);
+                            zos.write(buffer, 0, read);
+                        }
+                    }
+                    zos.closeEntry();
+                }
 
-                // create a new empty ZipEntry and copy the contents
-                ZipEntry newEntry = new ZipEntry(entry.getName());
-                zos.putNextEntry(newEntry);
-                try (InputStream in = gtfsFile.getInputStream(entry)) {
-                    while (0 < in.available()) {
-                        int read = in.read(buffer);
-                        zos.write(buffer, 0, read);
+                // iterate through the GTFS+ file, copying all entries
+                try (ZipFile plusZipFile = new ZipFile(plusFile)) {
+                    final Enumeration<? extends ZipEntry> plusEntries = plusZipFile.entries();
+                    while (plusEntries.hasMoreElements()) {
+                        final ZipEntry entry = plusEntries.nextElement();
+
+                        ZipEntry newEntry = new ZipEntry(entry.getName());
+                        zos.putNextEntry(newEntry);
+                        try (InputStream in = plusZipFile.getInputStream(entry)) {
+                            while (0 < in.available()) {
+                                int read = in.read(buffer);
+                                zos.write(buffer, 0, read);
+                            }
+                        }
+                        zos.closeEntry();
                     }
                 }
-                zos.closeEntry();
-            }
-
-            // iterate through the GTFS+ file, copying all entries
-            ZipFile plusZipFile = new ZipFile(plusFile);
-            final Enumeration<? extends ZipEntry> plusEntries = plusZipFile.entries();
-            while (plusEntries.hasMoreElements()) {
-                final ZipEntry entry = plusEntries.nextElement();
-
-                ZipEntry newEntry = new ZipEntry(entry.getName());
-                zos.putNextEntry(newEntry);
-                try (InputStream in = plusZipFile.getInputStream(entry)) {
-                    while (0 < in.available()) {
-                        int read = in.read(buffer);
-                        zos.write(buffer, 0, read);
-                    }
-                }
-                zos.closeEntry();
             }
         } catch (IOException e) {
             logMessageAndHalt(req, 500, "Error creating combined GTFS/GTFS+ file", e);

--- a/src/main/java/com/conveyal/datatools/manager/controllers/api/GtfsPlusController.java
+++ b/src/main/java/com/conveyal/datatools/manager/controllers/api/GtfsPlusController.java
@@ -100,28 +100,31 @@ public class GtfsPlusController {
             gtfsPlusTables.add(tableNode.get("name").asText());
         }
 
-        try (ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(gtfsPlusFile))) {
+        try {
             // create a new zip file to only contain the GTFS+ tables
             gtfsPlusFile = File.createTempFile(version.id + "_gtfsplus", ".zip");
+            try (
+                ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(gtfsPlusFile));
+                ZipFile gtfsFile = new ZipFile(version.retrieveGtfsFile())
+            ) {
+                // iterate through the existing GTFS file, copying any GTFS+ tables
+                final Enumeration<? extends ZipEntry> entries = gtfsFile.entries();
+                byte[] buffer = new byte[512];
+                while (entries.hasMoreElements()) {
+                    final ZipEntry entry = entries.nextElement();
+                    if (!gtfsPlusTables.contains(entry.getName())) continue;
 
-            // iterate through the existing GTFS file, copying any GTFS+ tables
-            ZipFile gtfsFile = new ZipFile(version.retrieveGtfsFile());
-            final Enumeration<? extends ZipEntry> entries = gtfsFile.entries();
-            byte[] buffer = new byte[512];
-            while (entries.hasMoreElements()) {
-                final ZipEntry entry = entries.nextElement();
-                if (!gtfsPlusTables.contains(entry.getName())) continue;
-
-                // create a new empty ZipEntry and copy the contents
-                ZipEntry newEntry = new ZipEntry(entry.getName());
-                zos.putNextEntry(newEntry);
-                try (InputStream in = gtfsFile.getInputStream(entry)) {
-                    while (0 < in.available()) {
-                        int read = in.read(buffer);
-                        zos.write(buffer, 0, read);
+                    // create a new empty ZipEntry and copy the contents
+                    ZipEntry newEntry = new ZipEntry(entry.getName());
+                    zos.putNextEntry(newEntry);
+                    try (InputStream in = gtfsFile.getInputStream(entry)) {
+                        while (0 < in.available()) {
+                            int read = in.read(buffer);
+                            zos.write(buffer, 0, read);
+                        }
                     }
+                    zos.closeEntry();
                 }
-                zos.closeEntry();
             }
         } catch (IOException e) {
             logMessageAndHalt(req, 500, "An error occurred while trying to create a gtfs file", e);

--- a/src/main/java/com/conveyal/datatools/manager/controllers/api/GtfsPlusController.java
+++ b/src/main/java/com/conveyal/datatools/manager/controllers/api/GtfsPlusController.java
@@ -73,7 +73,7 @@ public class GtfsPlusController {
      */
     private static HttpServletResponse getGtfsPlusFile(Request req, Response res) {
         String feedVersionId = req.params("versionid");
-        LOG.info("Downloading GTFS+ file for FeedVersion " + feedVersionId);
+        LOG.info("Downloading GTFS+ file for FeedVersion {}", feedVersionId);
 
         // check for saved
         File file = gtfsPlusStore.getFeed(feedVersionId);
@@ -161,7 +161,7 @@ public class GtfsPlusController {
     private static String publishGtfsPlusFile(Request req, Response res) {
         Auth0UserProfile profile = req.attribute("user");
         String feedVersionId = req.params("versionid");
-        LOG.info("Publishing GTFS+ for " + feedVersionId);
+        LOG.info("Publishing GTFS+ for {}", feedVersionId);
         File plusFile = gtfsPlusStore.getFeed(feedVersionId);
         if (plusFile == null || !plusFile.exists()) {
             logMessageAndHalt(req, 400, "No saved GTFS+ data for version");

--- a/src/test/java/com/conveyal/datatools/manager/controllers/api/GtfsPlusControllerTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/controllers/api/GtfsPlusControllerTest.java
@@ -62,12 +62,21 @@ class GtfsPlusControllerTest extends UnitTest {
      * Make sure the gtfsplus endpoint can retrieve files.
      */
     @Test
-    void canRetrieveExistingGtfsPlusFile() {
-        LOG.info("Making gtfsplus file request");
+    void canRetrieveAndPublishGtfsPlusFile() {
         feedVersion.persistFeedVersionAfterValidation(true);
-        Response response = gtfsPlusFileRequest(feedVersion.id);
-        // Assert that the call succeeded.
-        assertEquals(200, response.getStatusCode());
+        LOG.info("Making gtfsplus file request");
+        Response downloadResponse = gtfsPlusFileRequest(feedVersion.id);
+        assertEquals(200, downloadResponse.getStatusCode());
+
+        // Upload (same file should be ok)
+        LOG.info("Making gtfsplus upload request");
+        Response uploadResponse = uploadGtfsPlusFile(feedVersion.id, downloadResponse.asByteArray());
+        assertEquals(200, uploadResponse.getStatusCode());
+
+        // Attempt to publish file
+        LOG.info("Making gtfsplus publish request");
+        Response publishResponse = gtfsPlusPublishRequest(feedVersion.id);
+        assertEquals(200, publishResponse.getStatusCode());
     }
 
     /**
@@ -78,6 +87,33 @@ class GtfsPlusControllerTest extends UnitTest {
         return given()
             .port(DataManager.PORT)
             .get(path)
+            .then()
+            .extract()
+            .response();
+    }
+
+    /**
+     * Perform retrieval of an existing GTFS+ file on the feed source ID.
+     */
+    private static Response uploadGtfsPlusFile(String versionId, byte[] bytes) {
+        String path = String.format("/api/manager/secure/gtfsplus/%s", versionId);
+        return given()
+            .port(DataManager.PORT)
+            .body(bytes)
+            .post(path)
+            .then()
+            .extract()
+            .response();
+    }
+
+    /**
+     * Perform retrieval of an existing GTFS+ file on the feed source ID.
+     */
+    private static Response gtfsPlusPublishRequest(String versionId) {
+        String path = String.format("/api/manager/secure/gtfsplus/%s/publish", versionId);
+        return given()
+            .port(DataManager.PORT)
+            .post(path)
             .then()
             .extract()
             .response();

--- a/src/test/java/com/conveyal/datatools/manager/controllers/api/GtfsPlusControllerTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/controllers/api/GtfsPlusControllerTest.java
@@ -1,0 +1,85 @@
+package com.conveyal.datatools.manager.controllers.api;
+
+import com.conveyal.datatools.DatatoolsTest;
+import com.conveyal.datatools.UnitTest;
+import com.conveyal.datatools.manager.DataManager;
+import com.conveyal.datatools.manager.models.FeedSource;
+import com.conveyal.datatools.manager.models.FeedVersion;
+import com.conveyal.datatools.manager.models.Project;
+import com.conveyal.datatools.manager.persistence.Persistence;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Date;
+
+import static com.conveyal.datatools.TestUtils.createFeedVersionFromGtfsZip;
+import static com.conveyal.datatools.manager.auth.Auth0Users.USERS_API_PATH;
+import static com.conveyal.datatools.manager.controllers.api.UserController.TEST_AUTH0_DOMAIN;
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class GtfsPlusControllerTest extends UnitTest {
+    private static final Logger LOG = LoggerFactory.getLogger(GtfsPlusControllerTest.class);
+    private static Project project;
+    private static FeedSource feedSource;
+    private static FeedVersion feedVersion;
+
+    /**
+     * Prepare and start a testing-specific web server
+     */
+    @BeforeAll
+    static void setUp() throws Exception {
+        long startTime = System.currentTimeMillis();
+        // start server if it isn't already running
+        DatatoolsTest.setUp();
+        // Set users URL to test domain used by wiremock.
+        UserController.setBaseUsersUrl("http://" + TEST_AUTH0_DOMAIN + USERS_API_PATH);
+        // Create a project, feed sources, and feed versions to merge.
+        project = new Project();
+        project.name = String.format("Test %s", new Date());
+        Persistence.projects.create(project);
+
+        feedSource = new FeedSource("BART");
+        feedSource.projectId = project.id;
+        Persistence.feedSources.create(feedSource);
+
+        feedVersion = createFeedVersionFromGtfsZip(feedSource, "bart_old.zip");
+
+        LOG.info("{} setup completed in {} ms", GtfsPlusControllerTest.class.getSimpleName(), System.currentTimeMillis() - startTime);
+    }
+
+    @AfterAll
+    static void tearDown() {
+        project.delete();
+        feedSource.delete();
+    }
+
+    /**
+     * Make sure the gtfsplus endpoint can retrieve files.
+     */
+    @Test
+    void canRetrieveExistingGtfsPlusFile() {
+        LOG.info("Making gtfsplus file request");
+        feedVersion.persistFeedVersionAfterValidation(true);
+        Response response = gtfsPlusFileRequest(feedVersion.id);
+        // Assert that the call succeeded.
+        assertEquals(200, response.getStatusCode());
+    }
+
+    /**
+     * Perform retrieval of an existing GTFS+ file on the feed source ID.
+     */
+    private static Response gtfsPlusFileRequest(String versionId) {
+        String path = String.format("/api/manager/secure/gtfsplus/%s", versionId);
+        return given()
+            .port(DataManager.PORT)
+            .get(path)
+            .then()
+            .extract()
+            .response();
+    }
+}


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [na] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Fix #640 Blame #633

This PR addresses incorrect variable initialization in the GtfsPlusController class that prevents GTFS+ editing/publishing. It also adds missing try-with-resources blocks.
