### PR TITLE
S3 for Public Feed Downloads

### DIFF
--- a/configurations/test/server.yml.tmp
+++ b/configurations/test/server.yml.tmp
@@ -33,7 +33,7 @@ modules:
   gtfsapi:
     enabled: true
     load_on_fetch: false
-    # use_extension: mtc
+    use_extension: mtc
     # update_frequency: 30 # in seconds
   manager:
     normalizeFieldTransformation:

--- a/configurations/test/server.yml.tmp
+++ b/configurations/test/server.yml.tmp
@@ -74,8 +74,12 @@ extensions:
     enabled: true
     rtd_api: http://localhost:9876/
     s3_bucket: bucket-name
+    ### Uncomment and edit if the S3 region of the bucket above is different than application.data.s3_region.
+    # s3_region: us-west-2
     s3_prefix: waiting/
     s3_download_prefix: waiting/
+    ### Uncomment and edit if separate credentials are needed to access the bucket above.
+    # s3_credentials_file: ~/.aws/credentials
   transitland:
     enabled: true
     api: https://transit.land/api/v1/feeds

--- a/configurations/test/server.yml.tmp
+++ b/configurations/test/server.yml.tmp
@@ -33,7 +33,7 @@ modules:
   gtfsapi:
     enabled: true
     load_on_fetch: false
-    use_extension: mtc
+    # use_extension: mtc
     # update_frequency: 30 # in seconds
   manager:
     normalizeFieldTransformation:

--- a/src/main/java/com/conveyal/datatools/common/utils/aws/S3Utils.java
+++ b/src/main/java/com/conveyal/datatools/common/utils/aws/S3Utils.java
@@ -41,6 +41,8 @@ public class S3Utils {
     public static final String DEFAULT_BUCKET;
     public static final String DEFAULT_BUCKET_GTFS_FOLDER = "gtfs/";
 
+    public static final String APP_DATA_S3_REGION = "application.data.s3_region";
+
     static {
         // Placeholder variables need to be used before setting the final variable to make sure initialization occurs
         AmazonS3 tempS3Client = null;
@@ -51,8 +53,7 @@ public class S3Utils {
         // Only configure s3 if the config requires doing so
         if (DataManager.useS3 || hasConfigProperty("modules.gtfsapi.use_extension")) {
             final String credsFile = "application.data.s3_credentials_file";
-            final String configRegion = "application.data.s3_region";
-            S3ClientBuild build = buildS3Client(credsFile, List.of(configRegion));
+            S3ClientBuild build = buildS3Client(credsFile, List.of(APP_DATA_S3_REGION));
             tempS3Client = build.s3Client;
             tempS3CredentialsProvider = build.credentials;
 

--- a/src/main/java/com/conveyal/datatools/common/utils/aws/S3Utils.java
+++ b/src/main/java/com/conveyal/datatools/common/utils/aws/S3Utils.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.util.Date;
+import java.util.List;
 import java.util.UUID;
 
 import static com.conveyal.datatools.common.utils.SparkUtils.logMessageAndHalt;
@@ -49,31 +50,12 @@ public class S3Utils {
 
         // Only configure s3 if the config requires doing so
         if (DataManager.useS3 || hasConfigProperty("modules.gtfsapi.use_extension")) {
-            try {
-                AmazonS3ClientBuilder builder = AmazonS3ClientBuilder.standard();
-                String credentialsFile = DataManager.getConfigPropertyAsText("application.data.s3_credentials_file");
-                tempS3CredentialsProvider = credentialsFile != null ?
-                    new ProfileCredentialsProvider(credentialsFile, "default") :
-                    new DefaultAWSCredentialsProviderChain(); // default credentials providers, e.g. IAM role
-                builder.withCredentials(tempS3CredentialsProvider);
+            final String credsFile = "application.data.s3_credentials_file";
+            final String configRegion = "application.data.s3_region";
+            S3ClientBuild build = buildS3Client(credsFile, List.of(configRegion));
+            tempS3Client = build.s3Client;
+            tempS3CredentialsProvider = build.credentials;
 
-                // If region configuration string is provided, use that.
-                // Otherwise defaults to value provided in ~/.aws/config
-                String region = DataManager.getConfigPropertyAsText("application.data.s3_region");
-                if (region != null) {
-                    builder.withRegion(region);
-                }
-                tempS3Client = builder.build();
-            } catch (Exception e) {
-                LOG.error(
-                    "S3 client not initialized correctly.  Must provide config property application.data.s3_region or specify region in ~/.aws/config",
-                    e
-                );
-            }
-
-            if (tempS3Client == null) {
-                throw new IllegalArgumentException("Fatal error initializing the default s3Client");
-            }
             tempS3ClientManager = new S3ClientManagerImpl(tempS3Client);
 
             // s3 storage
@@ -87,6 +69,60 @@ public class S3Utils {
         DEFAULT_S3_CREDENTIALS = tempS3CredentialsProvider;
         S3ClientManager = tempS3ClientManager;
         DEFAULT_BUCKET = tempGtfsS3Bucket;
+    }
+
+    public static class S3ClientBuild {
+        public final AWSCredentialsProvider credentials;
+        public final AmazonS3 s3Client;
+
+        public S3ClientBuild(AWSCredentialsProvider credentials, AmazonS3 s3Client) {
+            this.credentials = credentials;
+            this.s3Client = s3Client;
+        }
+    }
+
+    /**
+     * Builds an S3 client from the specified credentials and region, or fallback to defaults
+     * using the ambient IAM role.
+     * @param configCredentials The credentials file to use for the client.
+     * @param configRegions The configuration entries in the order to try to get the AWS region to apply.
+     * @return An S3 client for the provided credentials and region.
+     */
+    public static S3ClientBuild buildS3Client(String configCredentials, List<String> configRegions) throws IllegalArgumentException {
+        AmazonS3 s3client = null;
+        AWSCredentialsProvider credentialsProvider = null;
+        try {
+            AmazonS3ClientBuilder builder = AmazonS3ClientBuilder.standard();
+            String credentialsFile = DataManager.getConfigPropertyAsText(configCredentials);
+            credentialsProvider = credentialsFile != null ?
+                new ProfileCredentialsProvider(credentialsFile, "default") :
+                new DefaultAWSCredentialsProviderChain(); // default credentials providers, e.g. IAM role
+            builder.withCredentials(credentialsProvider);
+
+            // Iterate through the regions and stop at the first non-null returned.
+            // Otherwise defaults to value (typically provided in ~/.aws/config)
+            for (String configRegion : configRegions) {
+                String region = DataManager.getConfigPropertyAsText(configRegion);
+                if (region != null) {
+                    builder.withRegion(region);
+                    break;
+                }
+            }
+
+            s3client = builder.build();
+        } catch (Exception e) {
+            LOG.error(
+                "S3 client not initialized correctly.  Must provide config property {} or specify region in ~/.aws/config",
+                configRegions,
+                e
+            );
+        }
+
+        if (s3client == null) {
+            throw new IllegalArgumentException("Fatal error initializing the default s3Client");
+        }
+
+        return new S3ClientBuild(credentialsProvider, s3client);
     }
 
     /**

--- a/src/main/java/com/conveyal/datatools/common/utils/aws/S3Utils.java
+++ b/src/main/java/com/conveyal/datatools/common/utils/aws/S3Utils.java
@@ -105,7 +105,7 @@ public class S3Utils {
     }
 
     public static String getDefaultBucketUrlForKey(String key) {
-        return String.format("https://s3.amazonaws.com/%s/%s", DEFAULT_BUCKET, key);
+        return String.format("https://%s.s3.amazonaws.com/%s", DEFAULT_BUCKET, key);
     }
 
     /**

--- a/src/main/java/com/conveyal/datatools/common/utils/aws/S3Utils.java
+++ b/src/main/java/com/conveyal/datatools/common/utils/aws/S3Utils.java
@@ -43,6 +43,8 @@ public class S3Utils {
 
     public static final String APP_DATA_S3_REGION = "application.data.s3_region";
 
+    public static final String APP_DATA_CREDS_FILE = "application.data.s3_credentials_file";
+
     static {
         // Placeholder variables need to be used before setting the final variable to make sure initialization occurs
         AmazonS3 tempS3Client = null;
@@ -52,8 +54,7 @@ public class S3Utils {
 
         // Only configure s3 if the config requires doing so
         if (DataManager.useS3 || hasConfigProperty("modules.gtfsapi.use_extension")) {
-            final String credsFile = "application.data.s3_credentials_file";
-            S3ClientBuild build = buildS3Client(credsFile, List.of(APP_DATA_S3_REGION));
+            S3ClientBuild build = buildS3Client(List.of(APP_DATA_CREDS_FILE), List.of(APP_DATA_S3_REGION));
             tempS3Client = build.s3Client;
             tempS3CredentialsProvider = build.credentials;
 
@@ -89,15 +90,31 @@ public class S3Utils {
      * @param configRegions The configuration entries in the order to try to get the AWS region to apply.
      * @return An S3 client for the provided credentials and region.
      */
-    public static S3ClientBuild buildS3Client(String configCredentials, List<String> configRegions) throws IllegalArgumentException {
+    public static S3ClientBuild buildS3Client(
+        List<String> configCredentials,
+        List<String> configRegions
+    ) throws IllegalArgumentException {
         AmazonS3 s3client = null;
         AWSCredentialsProvider credentialsProvider = null;
         try {
             AmazonS3ClientBuilder builder = AmazonS3ClientBuilder.standard();
-            String credentialsFile = DataManager.getConfigPropertyAsText(configCredentials);
-            credentialsProvider = credentialsFile != null ?
-                new ProfileCredentialsProvider(credentialsFile, "default") :
-                new DefaultAWSCredentialsProviderChain(); // default credentials providers, e.g. IAM role
+            // Iterate through the credentials and stop at the first non-null returned.
+            // Default to the ambient IAM credentials, if any.
+            for (String configCred : configCredentials) {
+                String credentialsFile = DataManager.getConfigPropertyAsText(configCred);
+                if (credentialsFile != null) {
+                    try {
+                        credentialsProvider = new ProfileCredentialsProvider(credentialsFile, "default");
+                    } catch (IllegalArgumentException e) {
+                        LOG.error("Invalid credentials from {}. Trying the next one.", configCred, e);
+                    }
+                    if (credentialsProvider != null) break;
+                }
+            }
+            if (credentialsProvider == null) {
+                // default credentials providers, e.g. IAM role
+                credentialsProvider = new DefaultAWSCredentialsProviderChain();
+            }
             builder.withCredentials(credentialsProvider);
 
             // Iterate through the regions and stop at the first non-null returned.

--- a/src/main/java/com/conveyal/datatools/common/utils/aws/S3Utils.java
+++ b/src/main/java/com/conveyal/datatools/common/utils/aws/S3Utils.java
@@ -127,7 +127,7 @@ public class S3Utils {
             s3client = builder.build();
         } catch (Exception e) {
             LOG.error(
-                "S3 client not initialized correctly.  Must provide config property {} or specify region in ~/.aws/config",
+                "S3 client not initialized correctly. Must provide config property {} or specify region in ~/.aws/config",
                 configRegions,
                 e
             );

--- a/src/main/java/com/conveyal/datatools/common/utils/aws/S3Utils.java
+++ b/src/main/java/com/conveyal/datatools/common/utils/aws/S3Utils.java
@@ -47,18 +47,15 @@ public class S3Utils {
 
     static {
         // Placeholder variables need to be used before setting the final variable to make sure initialization occurs
-        AmazonS3 tempS3Client = null;
         AWSCredentialsProvider tempS3CredentialsProvider = null;
         String tempGtfsS3Bucket = null;
         S3ClientManagerImpl tempS3ClientManager = null;
 
         // Only configure s3 if the config requires doing so
         if (DataManager.useS3 || hasConfigProperty("modules.gtfsapi.use_extension")) {
-            S3ClientBuild build = buildS3Client(List.of(APP_DATA_CREDS_FILE), List.of(APP_DATA_S3_REGION));
-            tempS3Client = build.s3Client;
+            S3Wrapper build = buildS3Wrapper(List.of(APP_DATA_CREDS_FILE), List.of(APP_DATA_S3_REGION));
             tempS3CredentialsProvider = build.credentials;
-
-            tempS3ClientManager = new S3ClientManagerImpl(tempS3Client);
+            tempS3ClientManager = new S3ClientManagerImpl(build.s3Client);
 
             // s3 storage
             tempGtfsS3Bucket = DataManager.getConfigPropertyAsText("application.data.gtfs_s3_bucket");
@@ -73,11 +70,11 @@ public class S3Utils {
         DEFAULT_BUCKET = tempGtfsS3Bucket;
     }
 
-    public static class S3ClientBuild {
+    public static class S3Wrapper {
         public final AWSCredentialsProvider credentials;
         public final AmazonS3 s3Client;
 
-        public S3ClientBuild(AWSCredentialsProvider credentials, AmazonS3 s3Client) {
+        public S3Wrapper(AWSCredentialsProvider credentials, AmazonS3 s3Client) {
             this.credentials = credentials;
             this.s3Client = s3Client;
         }
@@ -90,7 +87,7 @@ public class S3Utils {
      * @param configRegions The configuration entries in the order to try to get the AWS region to apply.
      * @return An S3 client for the provided credentials and region.
      */
-    public static S3ClientBuild buildS3Client(
+    public static S3Wrapper buildS3Wrapper(
         List<String> configCredentials,
         List<String> configRegions
     ) throws IllegalArgumentException {
@@ -140,7 +137,7 @@ public class S3Utils {
             throw new IllegalArgumentException("Fatal error initializing the default s3Client");
         }
 
-        return new S3ClientBuild(credentialsProvider, s3client);
+        return new S3Wrapper(credentialsProvider, s3client);
     }
 
     /**

--- a/src/main/java/com/conveyal/datatools/manager/DataManager.java
+++ b/src/main/java/com/conveyal/datatools/manager/DataManager.java
@@ -252,7 +252,7 @@ public class DataManager {
                 String extensionFeedBucket = getExtensionPropertyAsText(extensionType, "s3_bucket");
                 String extensionBucketFolder = getExtensionPropertyAsText(extensionType, "s3_download_prefix");
                 int updateFrequency = getConfigProperty("modules.gtfsapi.update_frequency").asInt();
-                if (S3Utils.DEFAULT_BUCKET != null && extensionBucketFolder != null) {
+                if (extensionFeedBucket != null && extensionBucketFolder != null) {
                     FeedUpdater.schedule(updateFrequency, extensionFeedBucket, extensionBucketFolder);
                 }
                 else LOG.warn("FeedUpdater not initialized. S3 bucket and folder not provided.");

--- a/src/main/java/com/conveyal/datatools/manager/extensions/mtc/MtcFeedResource.java
+++ b/src/main/java/com/conveyal/datatools/manager/extensions/mtc/MtcFeedResource.java
@@ -215,7 +215,7 @@ public class MtcFeedResource implements ExternalFeedResource {
         LOG.info("Pushing to MTC S3 Bucket: s3://{}/{}", s3Bucket, keyName);
         File file = feedVersion.retrieveGtfsFile();
         try {
-            S3Utils.getDefaultS3Client().putObject(new PutObjectRequest(s3Bucket, keyName, file));
+            getMTCS3Client().s3Client.putObject(new PutObjectRequest(s3Bucket, keyName, file));
         } catch (Exception e) {
             LOG.error("Could not upload feed version to s3.");
             e.printStackTrace();

--- a/src/main/java/com/conveyal/datatools/manager/extensions/mtc/MtcFeedResource.java
+++ b/src/main/java/com/conveyal/datatools/manager/extensions/mtc/MtcFeedResource.java
@@ -1,6 +1,7 @@
 package com.conveyal.datatools.manager.extensions.mtc;
 
 import com.amazonaws.AmazonServiceException;
+import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.conveyal.datatools.common.utils.CloseableHttpURLConnection;
 import com.conveyal.datatools.common.utils.aws.CheckedAWSException;
@@ -58,6 +59,7 @@ public class MtcFeedResource implements ExternalFeedResource {
     public static final String STOP_CODE_SECONDARY_PREFIXES_FIELD_NAME = "SecondaryPrefixes";
     public static final String CONFIG_MTC_CREDENTIALS = "extensions.mtc.s3_credentials_file";
     public static final String CONFIG_MTC_REGION = "extensions.mtc.s3_region";
+    private static S3Utils.S3Wrapper s3Wrapper;
 
     private String rtdApi, s3Bucket, s3Prefix;
 
@@ -216,7 +218,7 @@ public class MtcFeedResource implements ExternalFeedResource {
         LOG.info("Pushing to MTC S3 Bucket: s3://{}/{}", s3Bucket, keyName);
         File file = feedVersion.retrieveGtfsFile();
         try {
-            getMTCS3Client().s3Client.putObject(new PutObjectRequest(s3Bucket, keyName, file));
+            getMTCS3Client().putObject(new PutObjectRequest(s3Bucket, keyName, file));
         } catch (Exception e) {
             LOG.error("Could not upload feed version to s3.");
             e.printStackTrace();
@@ -360,11 +362,23 @@ public class MtcFeedResource implements ExternalFeedResource {
     }
 
     /**
-     * Get the S3 client to access the MTC RTD bucket, which needs separate credentials from the rest of datatools.
+     * Builds the S3 wrapper to access the MTC RTD bucket, which needs separate credentials from the rest of datatools.
      */
-    public static S3Utils.S3ClientBuild getMTCS3Client() {
+    public static S3Utils.S3Wrapper getMTCS3Wrapper() {
         List<String> configRegions = List.of(CONFIG_MTC_REGION, APP_DATA_S3_REGION);
         List<String> configCredentials = List.of(CONFIG_MTC_CREDENTIALS, APP_DATA_CREDS_FILE);
-        return S3Utils.buildS3Client(configCredentials, configRegions);
+        return S3Utils.buildS3Wrapper(configCredentials, configRegions);
+    }
+
+    /**
+     * Get the S3 client from a cached wrapper to access the MTC RTD bucket.
+     * Note: In S3Utils, an AWSClientManager is used, however in practice, only the default client is invoked
+     * (i.e. with role=null, region=null), so the logical path returns the original s3Client, which we are doing here.
+     */
+    public static AmazonS3 getMTCS3Client() {
+        if (s3Wrapper == null) {
+            s3Wrapper = getMTCS3Wrapper();
+        }
+        return s3Wrapper.s3Client;
     }
 }

--- a/src/main/java/com/conveyal/datatools/manager/extensions/mtc/MtcFeedResource.java
+++ b/src/main/java/com/conveyal/datatools/manager/extensions/mtc/MtcFeedResource.java
@@ -218,7 +218,7 @@ public class MtcFeedResource implements ExternalFeedResource {
         LOG.info("Pushing to MTC S3 Bucket: s3://{}/{}", s3Bucket, keyName);
         File file = feedVersion.retrieveGtfsFile();
         try {
-            getMTCS3Client().putObject(new PutObjectRequest(s3Bucket, keyName, file));
+            getS3Client().putObject(new PutObjectRequest(s3Bucket, keyName, file));
         } catch (Exception e) {
             LOG.error("Could not upload feed version to s3.");
             e.printStackTrace();
@@ -362,22 +362,23 @@ public class MtcFeedResource implements ExternalFeedResource {
     }
 
     /**
-     * Builds the S3 wrapper to access the MTC RTD bucket, which needs separate credentials from the rest of datatools.
+     * Builds the S3 wrapper to access the MTC feed processing bucket,
+     * which needs separate credentials from the rest of datatools.
      */
-    public static S3Utils.S3Wrapper getMTCS3Wrapper() {
+    static S3Utils.S3Wrapper getS3Wrapper() {
         List<String> configRegions = List.of(CONFIG_MTC_REGION, APP_DATA_S3_REGION);
         List<String> configCredentials = List.of(CONFIG_MTC_CREDENTIALS, APP_DATA_CREDS_FILE);
         return S3Utils.buildS3Wrapper(configCredentials, configRegions);
     }
 
     /**
-     * Get the S3 client from a cached wrapper to access the MTC RTD bucket.
+     * Get the S3 client from a cached wrapper to access the MTC feed processing bucket.
      * Note: In S3Utils, an AWSClientManager is used, however in practice, only the default client is invoked
      * (i.e. with role=null, region=null), so the logical path returns the original s3Client, which we are doing here.
      */
-    public static AmazonS3 getMTCS3Client() {
+    public static AmazonS3 getS3Client() {
         if (s3Wrapper == null) {
-            s3Wrapper = getMTCS3Wrapper();
+            s3Wrapper = getS3Wrapper();
         }
         return s3Wrapper.s3Client;
     }

--- a/src/main/java/com/conveyal/datatools/manager/extensions/mtc/MtcFeedResource.java
+++ b/src/main/java/com/conveyal/datatools/manager/extensions/mtc/MtcFeedResource.java
@@ -365,15 +365,6 @@ public class MtcFeedResource implements ExternalFeedResource {
     public static S3Utils.S3ClientBuild getMTCS3Client() {
         List<String> configRegions = List.of(CONFIG_MTC_REGION, APP_DATA_S3_REGION);
         List<String> configCredentials = List.of(CONFIG_MTC_CREDENTIALS, APP_DATA_CREDS_FILE);
-        try {
-            return S3Utils.buildS3Client(configCredentials, configRegions);
-        } catch (IllegalArgumentException e) {
-            try {
-                return new S3Utils.S3ClientBuild(null, S3Utils.getDefaultS3Client());
-            } catch (CheckedAWSException ex) {
-                LOG.error("Failed to fallback to default S3 provider", e);
-                return null;
-            }
-        }
+        return S3Utils.buildS3Client(configCredentials, configRegions);
     }
 }

--- a/src/main/java/com/conveyal/datatools/manager/extensions/mtc/MtcFeedResource.java
+++ b/src/main/java/com/conveyal/datatools/manager/extensions/mtc/MtcFeedResource.java
@@ -31,6 +31,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import static com.conveyal.datatools.common.utils.aws.S3Utils.APP_DATA_CREDS_FILE;
 import static com.conveyal.datatools.common.utils.aws.S3Utils.APP_DATA_S3_REGION;
 import static com.conveyal.datatools.manager.models.ExternalFeedSourceProperty.constructId;
 import static com.mongodb.client.model.Filters.eq;
@@ -363,6 +364,16 @@ public class MtcFeedResource implements ExternalFeedResource {
      */
     public static S3Utils.S3ClientBuild getMTCS3Client() {
         List<String> configRegions = List.of(CONFIG_MTC_REGION, APP_DATA_S3_REGION);
-        return S3Utils.buildS3Client(CONFIG_MTC_CREDENTIALS, configRegions);
+        List<String> configCredentials = List.of(CONFIG_MTC_CREDENTIALS, APP_DATA_CREDS_FILE);
+        try {
+            return S3Utils.buildS3Client(configCredentials, configRegions);
+        } catch (IllegalArgumentException e) {
+            try {
+                return new S3Utils.S3ClientBuild(null, S3Utils.getDefaultS3Client());
+            } catch (CheckedAWSException ex) {
+                LOG.error("Failed to fallback to default S3 provider", e);
+                return null;
+            }
+        }
     }
 }

--- a/src/main/java/com/conveyal/datatools/manager/extensions/mtc/MtcFeedResource.java
+++ b/src/main/java/com/conveyal/datatools/manager/extensions/mtc/MtcFeedResource.java
@@ -31,6 +31,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import static com.conveyal.datatools.common.utils.aws.S3Utils.APP_DATA_S3_REGION;
 import static com.conveyal.datatools.manager.models.ExternalFeedSourceProperty.constructId;
 import static com.mongodb.client.model.Filters.eq;
 
@@ -54,6 +55,8 @@ public class MtcFeedResource implements ExternalFeedResource {
     public static final String RESOURCE_TYPE = "MTC";
     public static final String STOP_CODE_PRIMARY_PREFIX_FIELD_NAME = "PrimaryPrefix";
     public static final String STOP_CODE_SECONDARY_PREFIXES_FIELD_NAME = "SecondaryPrefixes";
+    public static final String CONFIG_MTC_CREDENTIALS = "extensions.mtc.s3_credentials_file";
+    public static final String CONFIG_MTC_REGION = "extensions.mtc.s3_region";
 
     private String rtdApi, s3Bucket, s3Prefix;
 
@@ -353,5 +356,13 @@ public class MtcFeedResource implements ExternalFeedResource {
     public static List<String> getSecondaryStopCodePrefixes(Map<String, Map<String, String>> properties) {
         String secondaryStopPrefixValue = MtcFeedResource.getFieldValue(properties, MtcFeedResource.STOP_CODE_SECONDARY_PREFIXES_FIELD_NAME);
         return (secondaryStopPrefixValue == null) ? null : List.of(secondaryStopPrefixValue.split(","));
+    }
+
+    /**
+     * Get the S3 client to access the MTC RTD bucket, which needs separate credentials from the rest of datatools.
+     */
+    public static S3Utils.S3ClientBuild getMTCS3Client() {
+        List<String> configRegions = List.of(CONFIG_MTC_REGION, APP_DATA_S3_REGION);
+        return S3Utils.buildS3Client(CONFIG_MTC_CREDENTIALS, configRegions);
     }
 }

--- a/src/main/java/com/conveyal/datatools/manager/jobs/FeedUpdater.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/FeedUpdater.java
@@ -407,7 +407,7 @@ public class FeedUpdater {
     ) throws AmazonServiceException, IOException, CheckedAWSException {
         String filename = keyName.split("/")[1];
         String feedId = filename.replace(".zip", "");
-        S3Object object = MtcFeedResource.getMTCS3Client().s3Client.getObject(feedBucket, keyName);
+        S3Object object = MtcFeedResource.getMTCS3Client().getObject(feedBucket, keyName);
         File file = new File(FeedStore.basePath, filename);
         try (
             InputStream in = object.getObjectContent();
@@ -453,7 +453,7 @@ public class FeedUpdater {
     public class DefaultCompletedFeedRetriever implements CompletedFeedRetriever {
         @Override
         public List<S3ObjectSummary> retrieveCompletedFeeds() {
-            AmazonS3 s3Client = MtcFeedResource.getMTCS3Client().s3Client;
+            AmazonS3 s3Client = MtcFeedResource.getMTCS3Client();
             ObjectListing gtfsList = s3Client.listObjects(feedBucket, bucketFolder);
             return gtfsList.getObjectSummaries();
         }

--- a/src/main/java/com/conveyal/datatools/manager/jobs/FeedUpdater.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/FeedUpdater.java
@@ -1,6 +1,7 @@
 package com.conveyal.datatools.manager.jobs;
 
 import com.amazonaws.AmazonServiceException;
+import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.ObjectListing;
 import com.amazonaws.services.s3.model.S3Object;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
@@ -37,6 +38,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static com.conveyal.datatools.common.utils.Scheduler.schedulerService;
+import static com.conveyal.datatools.manager.DataManager.isExtensionEnabled;
 import static com.conveyal.datatools.manager.extensions.mtc.MtcFeedResource.AGENCY_ID_FIELDNAME;
 import static com.mongodb.client.model.Aggregates.group;
 import static com.mongodb.client.model.Aggregates.match;
@@ -447,12 +449,20 @@ public class FeedUpdater {
 
     /**
      * Implements the default behavior for above interface.
+     * This method uses extensions.mtc.s3_credentials_file and s3_region is populated, use that file first, and fallback on the default S3 client.
      */
     public class DefaultCompletedFeedRetriever implements CompletedFeedRetriever {
         @Override
         public List<S3ObjectSummary> retrieveCompletedFeeds() {
             try {
-                ObjectListing gtfsList = S3Utils.getDefaultS3Client().listObjects(feedBucket, bucketFolder);
+                AmazonS3 s3Client = S3Utils.getDefaultS3Client();
+                if (isExtensionEnabled("mtc")) {
+                    String credentialsFile = "extensions.mtc.s3_credentials_file";
+                    List<String> configRegions = List.of("extensions.mtc.s3_region", "application.data.s3_region");
+                    AmazonS3 alternateClient = S3Utils.buildS3Client(credentialsFile, configRegions).s3Client;
+                    if (alternateClient != null) s3Client = alternateClient;
+                }
+                ObjectListing gtfsList = s3Client.listObjects(feedBucket, bucketFolder);
                 return gtfsList.getObjectSummaries();
             } catch (CheckedAWSException e) {
                 LOG.error("Failed to list S3 Objects", e);

--- a/src/main/java/com/conveyal/datatools/manager/jobs/FeedUpdater.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/FeedUpdater.java
@@ -1,7 +1,6 @@
 package com.conveyal.datatools.manager.jobs;
 
 import com.amazonaws.AmazonServiceException;
-import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.ObjectListing;
 import com.amazonaws.services.s3.model.S3Object;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
@@ -407,7 +406,7 @@ public class FeedUpdater {
     ) throws AmazonServiceException, IOException, CheckedAWSException {
         String filename = keyName.split("/")[1];
         String feedId = filename.replace(".zip", "");
-        S3Object object = MtcFeedResource.getMTCS3Client().getObject(feedBucket, keyName);
+        S3Object object = MtcFeedResource.getS3Client().getObject(feedBucket, keyName);
         File file = new File(FeedStore.basePath, filename);
         try (
             InputStream in = object.getObjectContent();
@@ -448,13 +447,13 @@ public class FeedUpdater {
 
     /**
      * Implements the default behavior for above interface.
-     * This method uses extensions.mtc.s3_credentials_file and s3_region is populated, use that file first, and fallback on the default S3 client.
+     * This method uses extensions.mtc.s3_credentials_file and s3_region, if populated,
+     * and falls back to .
      */
     public class DefaultCompletedFeedRetriever implements CompletedFeedRetriever {
         @Override
         public List<S3ObjectSummary> retrieveCompletedFeeds() {
-            AmazonS3 s3Client = MtcFeedResource.getMTCS3Client();
-            ObjectListing gtfsList = s3Client.listObjects(feedBucket, bucketFolder);
+            ObjectListing gtfsList = MtcFeedResource.getS3Client().listObjects(feedBucket, bucketFolder);
             return gtfsList.getObjectSummaries();
         }
     }

--- a/src/main/java/com/conveyal/datatools/manager/jobs/FeedUpdater.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/FeedUpdater.java
@@ -448,7 +448,7 @@ public class FeedUpdater {
     /**
      * Implements the default behavior for above interface.
      * This method uses extensions.mtc.s3_credentials_file and s3_region, if populated,
-     * and falls back to .
+     * and falls back to the application's S3 credentials and region otherwise.
      */
     public class DefaultCompletedFeedRetriever implements CompletedFeedRetriever {
         @Override

--- a/src/main/java/com/conveyal/datatools/manager/jobs/FeedUpdater.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/FeedUpdater.java
@@ -7,6 +7,7 @@ import com.amazonaws.services.s3.model.S3Object;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 import com.conveyal.datatools.common.utils.aws.CheckedAWSException;
 import com.conveyal.datatools.common.utils.aws.S3Utils;
+import com.conveyal.datatools.manager.extensions.mtc.MtcFeedResource;
 import com.conveyal.datatools.manager.models.ExternalFeedSourceProperty;
 import com.conveyal.datatools.manager.models.FeedSource;
 import com.conveyal.datatools.manager.models.FeedVersion;
@@ -454,20 +455,9 @@ public class FeedUpdater {
     public class DefaultCompletedFeedRetriever implements CompletedFeedRetriever {
         @Override
         public List<S3ObjectSummary> retrieveCompletedFeeds() {
-            try {
-                AmazonS3 s3Client = S3Utils.getDefaultS3Client();
-                if (isExtensionEnabled("mtc")) {
-                    String credentialsFile = "extensions.mtc.s3_credentials_file";
-                    List<String> configRegions = List.of("extensions.mtc.s3_region", "application.data.s3_region");
-                    AmazonS3 alternateClient = S3Utils.buildS3Client(credentialsFile, configRegions).s3Client;
-                    if (alternateClient != null) s3Client = alternateClient;
-                }
-                ObjectListing gtfsList = s3Client.listObjects(feedBucket, bucketFolder);
-                return gtfsList.getObjectSummaries();
-            } catch (CheckedAWSException e) {
-                LOG.error("Failed to list S3 Objects", e);
-                return null;
-            }
+            AmazonS3 s3Client = MtcFeedResource.getMTCS3Client().s3Client;
+            ObjectListing gtfsList = s3Client.listObjects(feedBucket, bucketFolder);
+            return gtfsList.getObjectSummaries();
         }
     }
 }

--- a/src/main/java/com/conveyal/datatools/manager/jobs/FeedUpdater.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/FeedUpdater.java
@@ -6,7 +6,6 @@ import com.amazonaws.services.s3.model.ObjectListing;
 import com.amazonaws.services.s3.model.S3Object;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 import com.conveyal.datatools.common.utils.aws.CheckedAWSException;
-import com.conveyal.datatools.common.utils.aws.S3Utils;
 import com.conveyal.datatools.manager.extensions.mtc.MtcFeedResource;
 import com.conveyal.datatools.manager.models.ExternalFeedSourceProperty;
 import com.conveyal.datatools.manager.models.FeedSource;
@@ -39,7 +38,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static com.conveyal.datatools.common.utils.Scheduler.schedulerService;
-import static com.conveyal.datatools.manager.DataManager.isExtensionEnabled;
 import static com.conveyal.datatools.manager.extensions.mtc.MtcFeedResource.AGENCY_ID_FIELDNAME;
 import static com.mongodb.client.model.Aggregates.group;
 import static com.mongodb.client.model.Aggregates.match;
@@ -409,7 +407,7 @@ public class FeedUpdater {
     ) throws AmazonServiceException, IOException, CheckedAWSException {
         String filename = keyName.split("/")[1];
         String feedId = filename.replace(".zip", "");
-        S3Object object = S3Utils.getDefaultS3Client().getObject(feedBucket, keyName);
+        S3Object object = MtcFeedResource.getMTCS3Client().s3Client.getObject(feedBucket, keyName);
         File file = new File(FeedStore.basePath, filename);
         try (
             InputStream in = object.getObjectContent();

--- a/src/main/java/com/conveyal/datatools/manager/jobs/PublishProjectFeedsJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/PublishProjectFeedsJob.java
@@ -1,11 +1,8 @@
 package com.conveyal.datatools.manager.jobs;
 
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.conveyal.datatools.common.status.MonitorableJob;
 import com.conveyal.datatools.common.utils.aws.S3Utils;
 import com.conveyal.datatools.manager.auth.Auth0UserProfile;
-import com.conveyal.datatools.manager.models.FeedVersion;
 import com.conveyal.datatools.manager.models.Project;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.commons.io.FileUtils;
@@ -81,7 +78,6 @@ public class PublishProjectFeedsJob extends MonitorableJob {
                         }
                         url = S3Utils.getDefaultBucketUrlForKey(fs.toPublicKey());
                     }
-                    FeedVersion latest = fs.retrieveLatest();
                     r.append("<li>");
                     r.append("<a href=\"" + url + "\">");
                     r.append(fs.name);
@@ -111,12 +107,9 @@ public class PublishProjectFeedsJob extends MonitorableJob {
             e.printStackTrace();
         }
         try {
-            AmazonS3 defaultS3Client = S3Utils.getDefaultS3Client();
-            defaultS3Client.putObject(S3Utils.DEFAULT_BUCKET, folder + fileName, file);
-            defaultS3Client.setObjectAcl(S3Utils.DEFAULT_BUCKET, folder + fileName, CannedAccessControlList.PublicRead);
+            S3Utils.uploadObject(folder + fileName, file);
         } catch (Exception e) {
             status.fail("Failed to perform S3 actions", e);
-            return;
         }
     }
 

--- a/src/main/java/com/conveyal/datatools/manager/jobs/PublishProjectFeedsJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/PublishProjectFeedsJob.java
@@ -47,21 +47,23 @@ public class PublishProjectFeedsJob extends MonitorableJob {
         r.append("<!DOCTYPE html>\n");
         r.append("<html>\n");
         r.append("<head>\n");
-        r.append("<title>" + title + "</title>\n");
-        r.append("<style type=\"text/css\">\n" +
-                "        body { font-family: arial,helvetica,clean,sans-serif; font-size: 12px }\n" +
-                "        h1 { font-size: 18px }\n" +
-                "    </style>");
+        r.append("<title>").append(title).append("</title>\n");
+        r.append("<style type=\"text/css\">\n");
+        r.append("        body { font-family: arial,helvetica,clean,sans-serif; font-size: 12px }\n");
+        r.append("        h1 { font-size: 18px }\n");
+        r.append("    </style>");
 
         r.append("</head>\n");
         r.append("<body>\n");
-        r.append("<h1>" + title + "</h1>\n");
+        r.append("<h1>").append(title).append("</h1>\n");
         r.append("The following feeds, in GTFS format, are available for download and use.\n");
         if (dataSupportEmail != null) {
             r.append(String.format("If you have inquiries, please contact us at: <a href=\"mailto:%1$s\">%1$s</a>", dataSupportEmail));
         }
         r.append("<ul>\n");
         status.update("Ensuring public GTFS files are up-to-date.", 50);
+
+        SimpleDateFormat dateFormat = new SimpleDateFormat("dd MMM yyyy");
         project.retrieveProjectFeedSources().stream()
             .filter(fs -> fs.isPublic)
             // Store latest version id, so we don't have to fetch it again in the forEach stage.
@@ -86,15 +88,15 @@ public class PublishProjectFeedsJob extends MonitorableJob {
                     url = S3Utils.getDefaultBucketUrlForKey(fs.toPublicKey());
                 }
                 r.append("<li>");
-                r.append("<a href=\"" + url + "\">");
+                r.append("<a href=\"").append(url).append("\">");
                 r.append(fs.name);
                 r.append("</a>");
                 r.append(" (");
                 if (fs.url != null && fs.lastFetched != null) {
-                    r.append("last checked: " + new SimpleDateFormat("dd MMM yyyy").format(fs.lastFetched) + ", ");
+                    r.append("last checked: ").append(dateFormat.format(fs.lastFetched)).append(", ");
                 }
                 if (fs.lastUpdated() != null) {
-                    r.append("last updated: " + new SimpleDateFormat("dd MMM yyyy").format(fs.lastUpdated()) + ")");
+                    r.append("last updated: ").append(dateFormat.format(fs.lastUpdated())).append(")");
                 }
                 r.append("</li>");
             });

--- a/src/main/java/com/conveyal/datatools/manager/jobs/PublishProjectFeedsJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/PublishProjectFeedsJob.java
@@ -3,9 +3,11 @@ package com.conveyal.datatools.manager.jobs;
 import com.conveyal.datatools.common.status.MonitorableJob;
 import com.conveyal.datatools.common.utils.aws.S3Utils;
 import com.conveyal.datatools.manager.auth.Auth0UserProfile;
+import com.conveyal.datatools.manager.models.FeedSource;
 import com.conveyal.datatools.manager.models.Project;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.math3.util.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -61,36 +63,41 @@ public class PublishProjectFeedsJob extends MonitorableJob {
         r.append("<ul>\n");
         status.update("Ensuring public GTFS files are up-to-date.", 50);
         project.retrieveProjectFeedSources().stream()
-                .filter(fs -> fs.isPublic && fs.retrieveLatest() != null)
-                .forEach(fs -> {
-                    // generate list item for feed source
-                    String url;
-                    if (fs.url != null && !hasConfigProperty("modules.enterprise.prefer_s3_links")) {
-                        url = fs.url.toString();
+            .filter(fs -> fs.isPublic)
+            // Store latest version id, so we don't have to fetch it again in the forEach stage.
+            .map(fs -> new Pair<FeedSource, String>(fs, fs.latestVersionId()) {})
+            .filter(p -> p.getValue() != null)
+            .forEach(p -> {
+                // generate list item for feed source
+                FeedSource fs = p.getKey();
+                String latestVersionId = p.getValue();
+                String url;
+                if (fs.url != null && !hasConfigProperty("modules.enterprise.prefer_s3_links")) {
+                    url = fs.url.toString();
+                }
+                else {
+                    // ensure latest feed is written to the s3 public folder
+                    try {
+                        fs.makePublic(latestVersionId);
+                    } catch (Exception e) {
+                        status.fail("Failed to make GTFS files public on S3", e);
+                        return;
                     }
-                    else {
-                        // ensure latest feed is written to the s3 public folder
-                        try {
-                            fs.makePublic();
-                        } catch (Exception e) {
-                            status.fail("Failed to make GTFS files public on S3", e);
-                            return;
-                        }
-                        url = S3Utils.getDefaultBucketUrlForKey(fs.toPublicKey());
-                    }
-                    r.append("<li>");
-                    r.append("<a href=\"" + url + "\">");
-                    r.append(fs.name);
-                    r.append("</a>");
-                    r.append(" (");
-                    if (fs.url != null && fs.lastFetched != null) {
-                        r.append("last checked: " + new SimpleDateFormat("dd MMM yyyy").format(fs.lastFetched) + ", ");
-                    }
-                    if (fs.lastUpdated() != null) {
-                        r.append("last updated: " + new SimpleDateFormat("dd MMM yyyy").format(fs.lastUpdated()) + ")");
-                    }
-                    r.append("</li>");
-        });
+                    url = S3Utils.getDefaultBucketUrlForKey(fs.toPublicKey());
+                }
+                r.append("<li>");
+                r.append("<a href=\"" + url + "\">");
+                r.append(fs.name);
+                r.append("</a>");
+                r.append(" (");
+                if (fs.url != null && fs.lastFetched != null) {
+                    r.append("last checked: " + new SimpleDateFormat("dd MMM yyyy").format(fs.lastFetched) + ", ");
+                }
+                if (fs.lastUpdated() != null) {
+                    r.append("last updated: " + new SimpleDateFormat("dd MMM yyyy").format(fs.lastUpdated()) + ")");
+                }
+                r.append("</li>");
+            });
         r.append("</ul>");
         r.append("</body>");
         r.append("</html>");

--- a/src/main/java/com/conveyal/datatools/manager/models/FeedSource.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/FeedSource.java
@@ -585,8 +585,11 @@ public class FeedSource extends Model implements Cloneable {
         String versionId = this.latestVersionId();
         String latestVersionKey = S3Utils.DEFAULT_BUCKET_GTFS_FOLDER + versionId;
 
-        // only deploy to public if storing feeds on s3 (no mechanism for downloading/publishing
-        // them otherwise)
+        // Copy, forever, the latest stored version to the public folder, regardless of
+        // whether S3 is used to store individual feed versions (useS3 = true) or not.
+        //
+        // Note: If modules.enterprise.prefer_s3_links is not set and the feed source has a fetch URL,
+        // this method will not be called, and the feed download link will point to the fetch URL instead.
         if (DataManager.useS3) {
             AmazonS3 defaultS3Client = S3Utils.getDefaultS3Client();
             boolean sourceExists = defaultS3Client.doesObjectExist(S3Utils.DEFAULT_BUCKET, sourceKey);
@@ -617,6 +620,9 @@ public class FeedSource extends Model implements Cloneable {
                     defaultS3Client.copyObject(S3Utils.DEFAULT_BUCKET, latestVersionKey, S3Utils.DEFAULT_BUCKET, sourceKey);
                 }
             }
+        } else {
+            LOG.info("copying latest local feed {} to s3 public folder", this);
+            S3Utils.uploadObject(publicKey, retrieveLatest().retrieveGtfsFile());
         }
     }
 

--- a/src/main/java/com/conveyal/datatools/manager/models/FeedSource.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/FeedSource.java
@@ -580,9 +580,15 @@ public class FeedSource extends Model implements Cloneable {
      * Makes the feed source's latest version have public access on AWS S3.
      */
     public void makePublic() throws CheckedAWSException {
+        makePublic(this.latestVersionId());
+    }
+
+    /**
+     * Makes the feed source's specified version have public access on AWS S3.
+     */
+    public void makePublic(String versionId) throws CheckedAWSException {
         String sourceKey = S3Utils.DEFAULT_BUCKET_GTFS_FOLDER + this.id + ".zip";
         String publicKey = toPublicKey();
-        String versionId = this.latestVersionId();
         String latestVersionKey = S3Utils.DEFAULT_BUCKET_GTFS_FOLDER + versionId;
 
         // Copy, forever, the latest stored version to the public folder, regardless of

--- a/src/test/java/com/conveyal/datatools/common/utils/aws/S3UtilsTest.java
+++ b/src/test/java/com/conveyal/datatools/common/utils/aws/S3UtilsTest.java
@@ -1,0 +1,31 @@
+package com.conveyal.datatools.common.utils.aws;
+
+import com.conveyal.datatools.DatatoolsTest;
+import com.conveyal.datatools.UnitTest;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class S3UtilsTest extends UnitTest {
+    /**
+     * Create feed version for GTFS+ validation test.
+     */
+    @BeforeAll
+    public static void setUp() throws IOException {
+        // Start server if it isn't already running.
+        DatatoolsTest.setUp();
+    }
+
+    @Test
+    void canGetDefaultBucketUrlForKey() {
+        final String FILENAME = "public/index.html";
+
+        assertEquals(
+            "https://bucket-name.s3.amazonaws.com/public/index.html",
+            S3Utils.getDefaultBucketUrlForKey(FILENAME)
+        );
+    }
+}

--- a/src/test/java/com/conveyal/datatools/common/utils/aws/S3UtilsTest.java
+++ b/src/test/java/com/conveyal/datatools/common/utils/aws/S3UtilsTest.java
@@ -1,15 +1,32 @@
 package com.conveyal.datatools.common.utils.aws;
 
+import com.amazonaws.auth.AWSCredentials;
 import com.conveyal.datatools.DatatoolsTest;
+import com.conveyal.datatools.TestUtils;
 import com.conveyal.datatools.UnitTest;
+import com.conveyal.datatools.manager.DataManager;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.IOException;
+import java.util.List;
 
+import static com.conveyal.datatools.manager.DataManager.getConfigPropertyAsText;
+import static com.conveyal.datatools.manager.DataManager.isExtensionEnabled;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class S3UtilsTest extends UnitTest {
+    // TODO: Move these constants
+    public static final String CONFIG_MTC_ENABLED = "extensions.mtc.enabled";
+    public static final String CONFIG_MTC_CREDENTIALS = "extensions.mtc.s3_credentials_file";
+    public static final String CONFIG_MTC_REGION = "extensions.mtc.s3_region";
+    private static boolean defaultMtcEnabled;
+    private static String defaultMtcAwsCredentials;
+    private static String defaultMtcAwsRegion;
+
     /**
      * Create feed version for GTFS+ validation test.
      */
@@ -17,6 +34,16 @@ class S3UtilsTest extends UnitTest {
     public static void setUp() throws IOException {
         // Start server if it isn't already running.
         DatatoolsTest.setUp();
+        defaultMtcEnabled = isExtensionEnabled("mtc");
+        defaultMtcAwsCredentials = getConfigPropertyAsText(CONFIG_MTC_CREDENTIALS);
+        defaultMtcAwsRegion = getConfigPropertyAsText(CONFIG_MTC_REGION);
+    }
+
+    @AfterEach
+    void resetState() {
+        DataManager.overrideConfigProperty(CONFIG_MTC_ENABLED, Boolean.toString(defaultMtcEnabled));
+        DataManager.overrideConfigProperty(CONFIG_MTC_CREDENTIALS, defaultMtcAwsCredentials);
+        DataManager.overrideConfigProperty(CONFIG_MTC_REGION, defaultMtcAwsRegion);
     }
 
     @Test
@@ -27,5 +54,27 @@ class S3UtilsTest extends UnitTest {
             "https://bucket-name.s3.amazonaws.com/public/index.html",
             S3Utils.getDefaultBucketUrlForKey(FILENAME)
         );
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { false, true })
+    void canUseCorrectMtcCredentials(boolean overwriteRegion) {
+        DataManager.overrideConfigProperty(CONFIG_MTC_ENABLED, "true");
+        if (overwriteRegion) {
+            DataManager.overrideConfigProperty(CONFIG_MTC_REGION, "us-west-2");
+        }
+        String credentialsFile = TestUtils.class.getResource("mock-aws-credentials").getFile();
+        DataManager.overrideConfigProperty(CONFIG_MTC_CREDENTIALS, credentialsFile);
+        List<String> configRegions = List.of("extensions.mtc.s3_region", "application.data.s3_region");
+        S3Utils.S3ClientBuild build = S3Utils.buildS3Client(CONFIG_MTC_CREDENTIALS, configRegions);
+
+        // Either application.data.s3_region or extensions.mtc.s3_region from server.yml.tmp.
+        // null denotes the us-east-1 region.
+        assertEquals(overwriteRegion ? "us-west-2" : null, build.s3Client.getRegion().getFirstRegionId());
+
+        // The credentials should reflect the content in the mock-aws-credentials file referenced above.
+        AWSCredentials credentials = build.credentials.getCredentials();
+        assertEquals("mock-id-123", credentials.getAWSAccessKeyId());
+        assertEquals("mock-secret-123", credentials.getAWSSecretKey());
     }
 }

--- a/src/test/java/com/conveyal/datatools/common/utils/aws/S3UtilsTest.java
+++ b/src/test/java/com/conveyal/datatools/common/utils/aws/S3UtilsTest.java
@@ -1,49 +1,22 @@
 package com.conveyal.datatools.common.utils.aws;
 
-import com.amazonaws.auth.AWSCredentials;
 import com.conveyal.datatools.DatatoolsTest;
-import com.conveyal.datatools.TestUtils;
 import com.conveyal.datatools.UnitTest;
-import com.conveyal.datatools.manager.DataManager;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.IOException;
-import java.util.List;
 
-import static com.conveyal.datatools.manager.DataManager.getConfigPropertyAsText;
-import static com.conveyal.datatools.manager.DataManager.isExtensionEnabled;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class S3UtilsTest extends UnitTest {
-    // TODO: Move these constants
-    public static final String CONFIG_MTC_ENABLED = "extensions.mtc.enabled";
-    public static final String CONFIG_MTC_CREDENTIALS = "extensions.mtc.s3_credentials_file";
-    public static final String CONFIG_MTC_REGION = "extensions.mtc.s3_region";
-    private static boolean defaultMtcEnabled;
-    private static String defaultMtcAwsCredentials;
-    private static String defaultMtcAwsRegion;
-
     /**
      * Create feed version for GTFS+ validation test.
      */
     @BeforeAll
-    public static void setUp() throws IOException {
+    static void setUp() throws IOException {
         // Start server if it isn't already running.
         DatatoolsTest.setUp();
-        defaultMtcEnabled = isExtensionEnabled("mtc");
-        defaultMtcAwsCredentials = getConfigPropertyAsText(CONFIG_MTC_CREDENTIALS);
-        defaultMtcAwsRegion = getConfigPropertyAsText(CONFIG_MTC_REGION);
-    }
-
-    @AfterEach
-    void resetState() {
-        DataManager.overrideConfigProperty(CONFIG_MTC_ENABLED, Boolean.toString(defaultMtcEnabled));
-        DataManager.overrideConfigProperty(CONFIG_MTC_CREDENTIALS, defaultMtcAwsCredentials);
-        DataManager.overrideConfigProperty(CONFIG_MTC_REGION, defaultMtcAwsRegion);
     }
 
     @Test
@@ -54,27 +27,5 @@ class S3UtilsTest extends UnitTest {
             "https://bucket-name.s3.amazonaws.com/public/index.html",
             S3Utils.getDefaultBucketUrlForKey(FILENAME)
         );
-    }
-
-    @ParameterizedTest
-    @ValueSource(booleans = { false, true })
-    void canUseCorrectMtcCredentials(boolean overwriteRegion) {
-        DataManager.overrideConfigProperty(CONFIG_MTC_ENABLED, "true");
-        if (overwriteRegion) {
-            DataManager.overrideConfigProperty(CONFIG_MTC_REGION, "us-west-2");
-        }
-        String credentialsFile = TestUtils.class.getResource("mock-aws-credentials").getFile();
-        DataManager.overrideConfigProperty(CONFIG_MTC_CREDENTIALS, credentialsFile);
-        List<String> configRegions = List.of("extensions.mtc.s3_region", "application.data.s3_region");
-        S3Utils.S3ClientBuild build = S3Utils.buildS3Client(CONFIG_MTC_CREDENTIALS, configRegions);
-
-        // Either application.data.s3_region or extensions.mtc.s3_region from server.yml.tmp.
-        // null denotes the us-east-1 region.
-        assertEquals(overwriteRegion ? "us-west-2" : null, build.s3Client.getRegion().getFirstRegionId());
-
-        // The credentials should reflect the content in the mock-aws-credentials file referenced above.
-        AWSCredentials credentials = build.credentials.getCredentials();
-        assertEquals("mock-id-123", credentials.getAWSAccessKeyId());
-        assertEquals("mock-secret-123", credentials.getAWSSecretKey());
     }
 }

--- a/src/test/java/com/conveyal/datatools/manager/extensions/mtc/MtcFeedResourceTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/extensions/mtc/MtcFeedResourceTest.java
@@ -1,6 +1,7 @@
 package com.conveyal.datatools.manager.extensions.mtc;
 
 import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.conveyal.datatools.DatatoolsTest;
 import com.conveyal.datatools.TestUtils;
 import com.conveyal.datatools.UnitTest;
@@ -50,6 +51,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class MtcFeedResourceTest extends UnitTest {
@@ -261,21 +263,26 @@ class MtcFeedResourceTest extends UnitTest {
 
     @ParameterizedTest
     @ValueSource(booleans = { false, true })
-    void canUseCorrectMtcCredentials(boolean overwriteRegion) {
-        if (overwriteRegion) {
+    void canUseCorrectMtcCredentials(boolean overwriteDefaults) {
+        if (overwriteDefaults) {
             DataManager.overrideConfigProperty(CONFIG_MTC_REGION, "us-west-2");
+            String credentialsFile = TestUtils.class.getResource("mock-aws-credentials").getFile();
+            DataManager.overrideConfigProperty(CONFIG_MTC_CREDENTIALS, credentialsFile);
         }
-        String credentialsFile = TestUtils.class.getResource("mock-aws-credentials").getFile();
-        DataManager.overrideConfigProperty(CONFIG_MTC_CREDENTIALS, credentialsFile);
 
         S3Utils.S3ClientBuild build = MtcFeedResource.getMTCS3Client();
+        assertNotNull(build);
 
         // Either application.data.s3_region or extensions.mtc.s3_region from server.yml.tmp.
-        assertEquals(overwriteRegion ? "us-west-2" : "us-east-1", build.s3Client.getRegion().toAWSRegion().getName());
+        assertEquals(overwriteDefaults ? "us-west-2" : "us-east-1", build.s3Client.getRegion().toAWSRegion().getName());
 
         // The credentials should reflect the content in the mock-aws-credentials file referenced above.
-        AWSCredentials credentials = build.credentials.getCredentials();
-        assertEquals("mock-id-123", credentials.getAWSAccessKeyId());
-        assertEquals("mock-secret-123", credentials.getAWSSecretKey());
+        if (overwriteDefaults) {
+            AWSCredentials credentials = build.credentials.getCredentials();
+            assertEquals("mock-id-123", credentials.getAWSAccessKeyId());
+            assertEquals("mock-secret-123", credentials.getAWSSecretKey());
+        } else {
+            assertEquals(DefaultAWSCredentialsProviderChain.class, build.credentials.getClass());
+        }
     }
 }

--- a/src/test/java/com/conveyal/datatools/manager/extensions/mtc/MtcFeedResourceTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/extensions/mtc/MtcFeedResourceTest.java
@@ -270,7 +270,7 @@ class MtcFeedResourceTest extends UnitTest {
             DataManager.overrideConfigProperty(CONFIG_MTC_CREDENTIALS, credentialsFile);
         }
 
-        S3Utils.S3Wrapper s3wrapper = MtcFeedResource.getMTCS3Wrapper();
+        S3Utils.S3Wrapper s3wrapper = MtcFeedResource.getS3Wrapper();
         assertNotNull(s3wrapper);
 
         // Either application.data.s3_region or extensions.mtc.s3_region from server.yml.tmp.

--- a/src/test/java/com/conveyal/datatools/manager/extensions/mtc/MtcFeedResourceTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/extensions/mtc/MtcFeedResourceTest.java
@@ -270,19 +270,19 @@ class MtcFeedResourceTest extends UnitTest {
             DataManager.overrideConfigProperty(CONFIG_MTC_CREDENTIALS, credentialsFile);
         }
 
-        S3Utils.S3ClientBuild build = MtcFeedResource.getMTCS3Client();
-        assertNotNull(build);
+        S3Utils.S3Wrapper s3wrapper = MtcFeedResource.getMTCS3Wrapper();
+        assertNotNull(s3wrapper);
 
         // Either application.data.s3_region or extensions.mtc.s3_region from server.yml.tmp.
-        assertEquals(overwriteDefaults ? "us-west-2" : "us-east-1", build.s3Client.getRegion().toAWSRegion().getName());
+        assertEquals(overwriteDefaults ? "us-west-2" : "us-east-1", s3wrapper.s3Client.getRegion().toAWSRegion().getName());
 
         // The credentials should reflect the content in the mock-aws-credentials file referenced above.
         if (overwriteDefaults) {
-            AWSCredentials credentials = build.credentials.getCredentials();
+            AWSCredentials credentials = s3wrapper.credentials.getCredentials();
             assertEquals("mock-id-123", credentials.getAWSAccessKeyId());
             assertEquals("mock-secret-123", credentials.getAWSSecretKey());
         } else {
-            assertEquals(DefaultAWSCredentialsProviderChain.class, build.credentials.getClass());
+            assertEquals(DefaultAWSCredentialsProviderChain.class, s3wrapper.credentials.getClass());
         }
     }
 }

--- a/src/test/java/com/conveyal/datatools/manager/extensions/mtc/MtcFeedResourceTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/extensions/mtc/MtcFeedResourceTest.java
@@ -1,7 +1,11 @@
 package com.conveyal.datatools.manager.extensions.mtc;
 
+import com.amazonaws.auth.AWSCredentials;
 import com.conveyal.datatools.DatatoolsTest;
+import com.conveyal.datatools.TestUtils;
 import com.conveyal.datatools.UnitTest;
+import com.conveyal.datatools.common.utils.aws.S3Utils;
+import com.conveyal.datatools.manager.DataManager;
 import com.conveyal.datatools.manager.auth.Auth0Connection;
 import com.conveyal.datatools.manager.jobs.ProcessSingleFeedJob;
 import com.conveyal.datatools.manager.models.ExternalFeedSourceProperty;
@@ -14,6 +18,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -26,6 +31,9 @@ import java.util.Date;
 import static com.conveyal.datatools.TestUtils.createFeedVersion;
 import static com.conveyal.datatools.TestUtils.parseJson;
 import static com.conveyal.datatools.TestUtils.zipFolderFiles;
+import static com.conveyal.datatools.manager.DataManager.getConfigPropertyAsText;
+import static com.conveyal.datatools.manager.extensions.mtc.MtcFeedResource.CONFIG_MTC_CREDENTIALS;
+import static com.conveyal.datatools.manager.extensions.mtc.MtcFeedResource.CONFIG_MTC_REGION;
 import static com.conveyal.datatools.manager.extensions.mtc.MtcFeedResource.STOP_CODE_PRIMARY_PREFIX_FIELD_NAME;
 import static com.conveyal.datatools.manager.extensions.mtc.MtcFeedResource.STOP_CODE_SECONDARY_PREFIXES_FIELD_NAME;
 import static com.conveyal.gtfs.error.NewGTFSErrorType.MISSING_STOP_CODE_PREFIX;
@@ -41,12 +49,15 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class MtcFeedResourceTest extends UnitTest {
     private static Project project;
     private static FeedSource feedSource;
     private static WireMockServer wireMockServer;
+    private static String defaultMtcAwsCredentials;
+    private static String defaultMtcAwsRegion;
 
     private static final String AGENCY_CODE = "DE";
 
@@ -61,6 +72,8 @@ class MtcFeedResourceTest extends UnitTest {
         // Enable MTC extension, but disable the transformations.
         ProcessSingleFeedJob.ENABLE_MTC_TRANSFORMATIONS = false;
         DatatoolsTest.enableMTCExtension();
+        defaultMtcAwsCredentials = getConfigPropertyAsText(CONFIG_MTC_CREDENTIALS);
+        defaultMtcAwsRegion = getConfigPropertyAsText(CONFIG_MTC_REGION);
 
         Auth0Connection.setAuthDisabled(true);
         // Create a project, feed sources.
@@ -89,6 +102,16 @@ class MtcFeedResourceTest extends UnitTest {
         }
         DatatoolsTest.resetMTCExtension();
         ProcessSingleFeedJob.ENABLE_MTC_TRANSFORMATIONS = true;
+    }
+
+    @AfterEach
+    void resetState() {
+        DataManager.overrideConfigProperty(CONFIG_MTC_CREDENTIALS, defaultMtcAwsCredentials);
+
+        String currentMtcRegion = getConfigPropertyAsText(CONFIG_MTC_REGION);
+        if (currentMtcRegion != null && !currentMtcRegion.equals(defaultMtcAwsRegion)) {
+            DataManager.overrideConfigProperty(CONFIG_MTC_REGION, defaultMtcAwsRegion);
+        }
     }
 
     @Test
@@ -234,5 +257,25 @@ class MtcFeedResourceTest extends UnitTest {
         assertTrue(
             carrier.toJson().contains(String.format(",\"AgencyAddress\":%s,", jsonAddress))
         );
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { false, true })
+    void canUseCorrectMtcCredentials(boolean overwriteRegion) {
+        if (overwriteRegion) {
+            DataManager.overrideConfigProperty(CONFIG_MTC_REGION, "us-west-2");
+        }
+        String credentialsFile = TestUtils.class.getResource("mock-aws-credentials").getFile();
+        DataManager.overrideConfigProperty(CONFIG_MTC_CREDENTIALS, credentialsFile);
+
+        S3Utils.S3ClientBuild build = MtcFeedResource.getMTCS3Client();
+
+        // Either application.data.s3_region or extensions.mtc.s3_region from server.yml.tmp.
+        assertEquals(overwriteRegion ? "us-west-2" : "us-east-1", build.s3Client.getRegion().toAWSRegion().getName());
+
+        // The credentials should reflect the content in the mock-aws-credentials file referenced above.
+        AWSCredentials credentials = build.credentials.getCredentials();
+        assertEquals("mock-id-123", credentials.getAWSAccessKeyId());
+        assertEquals("mock-secret-123", credentials.getAWSSecretKey());
     }
 }

--- a/src/test/resources/com/conveyal/datatools/mock-aws-credentials
+++ b/src/test/resources/com/conveyal/datatools/mock-aws-credentials
@@ -1,0 +1,3 @@
+[default]
+aws_access_key_id = mock-id-123
+aws_secret_access_key = mock-secret-123


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR adds support for the use of S3 bucket for public feed hosting, even if S3 is not used for storing feed versions for internal DataTools use.

Behind the scenes, support is added for alternate S3 credentials, region, and bucket for the MTCFeedResource and FeedUpdater that, if specified, override the application's ones:
```
extensions
  mtc
    s3_region
    s3_bucket
    s3_credentials_file
```

