### PR TITLE
Add publishedVersionId to FeedSourceSummary

### DIFF
--- a/src/main/java/com/conveyal/datatools/manager/models/FeedSourceSummary.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/FeedSourceSummary.java
@@ -87,6 +87,8 @@ public class FeedSourceSummary {
 
     public FeedValidationResultSummary publishedValidationSummary;
 
+    public String publishedVersionId;
+
     public PublishState publishState;
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -113,6 +115,7 @@ public class FeedSourceSummary {
         // Convert to local date type for consistency.
         lastUpdated = getLocalDateFromDate(feedSourceDocument.getDate("lastUpdated"));
         url = feedSourceDocument.getString("url");
+        publishedVersionId = feedSourceDocument.getString("publishedVersionId");
         // Get optional filename.
         filename = feedSourceDocument.getString("filename");
         // Optional external properties, if enabled by config.
@@ -180,7 +183,8 @@ public class FeedSourceSummary {
                     "labelIds",
                     "url",
                     "filename",
-                    "noteIds"
+                    "noteIds",
+                    "publishedVersionId"
                 )
             ),
             sort(Sorts.ascending("name"))

--- a/src/main/resources/mongo/getFeedSourceSummaries.js
+++ b/src/main/resources/mongo/getFeedSourceSummaries.js
@@ -15,7 +15,8 @@ db.getCollection('FeedSource').aggregate([
             "labelIds": 1,
             "url": 1,
             "filename": 1,
-            "noteIds": 1
+            "noteIds": 1,
+            "publishedVersionId": 1
         }
     },
     {

--- a/src/test/java/com/conveyal/datatools/manager/controllers/api/FeedSourceControllerTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/controllers/api/FeedSourceControllerTest.java
@@ -11,6 +11,7 @@ import com.conveyal.datatools.manager.models.Deployment;
 import com.conveyal.datatools.manager.models.FeedRetrievalMethod;
 import com.conveyal.datatools.manager.models.FeedSource;
 import com.conveyal.datatools.manager.models.FeedSourceSummary;
+import com.conveyal.datatools.manager.models.FeedValidationResultSummary;
 import com.conveyal.datatools.manager.models.FeedVersion;
 import com.conveyal.datatools.manager.models.FeedVersionSummary;
 import com.conveyal.datatools.manager.models.FetchFrequency;
@@ -374,25 +375,28 @@ public class FeedSourceControllerTest extends DatatoolsTest {
             );
 
         assertNotNull(feedSourceSummaries);
-        assertEquals(feedSourceWithLatestDeploymentFeedVersion.id, feedSourceSummaries.get(0).id);
-        assertEquals(feedSourceWithLatestDeploymentFeedVersion.projectId, feedSourceSummaries.get(0).projectId);
-        assertEquals(feedSourceWithLatestDeploymentFeedVersion.labelIds, feedSourceSummaries.get(0).labelIds);
-        assertEquals(feedSourceWithLatestDeploymentFeedVersion.url.toString(), feedSourceSummaries.get(0).url);
-        assertEquals(feedSourceWithLatestDeploymentFeedVersion.noteIds, feedSourceSummaries.get(0).noteIds);
-        assertEquals(feedSourceWithLatestDeploymentFeedVersion.organizationId(), feedSourceSummaries.get(0).organizationId);
-        assertEquals(feedVersionFromLatestDeploymentVersion2.id, feedSourceSummaries.get(0).deployedFeedVersionId);
-        assertEquals(feedVersionFromLatestDeploymentVersion2.validationSummary().startDate, feedSourceSummaries.get(0).deployedFeedVersionStartDate);
-        assertEquals(feedVersionFromLatestDeploymentVersion2.validationSummary().endDate, feedSourceSummaries.get(0).deployedFeedVersionEndDate);
-        assertEquals(feedVersionFromLatestDeploymentVersion2.validationSummary().errorCount, feedSourceSummaries.get(0).deployedFeedVersionIssues);
-        assertEquals(feedVersionFromLatestDeploymentVersion2.id, feedSourceSummaries.get(0).latestValidation.feedVersionId);
-        assertEquals(feedVersionFromLatestDeploymentVersion2.validationSummary().startDate, feedSourceSummaries.get(0).latestValidation.startDate);
-        assertEquals(feedVersionFromLatestDeploymentVersion2.validationSummary().endDate, feedSourceSummaries.get(0).latestValidation.endDate);
-        assertEquals(feedVersionFromLatestDeploymentVersion2.validationSummary().errorCount, feedSourceSummaries.get(0).latestValidation.errorCount);
-        assertEquals(feedVersionFromLatestDeploymentVersion2.sentToExternalPublisher, feedSourceSummaries.get(0).latestSentToExternalPublisher);
-        assertEquals(PublishState.PUBLISH_BLOCKED, feedSourceSummaries.get(0).publishState);
-        assertEquals(feedVersionPublishedFromLatestDeployment.validationResult.errorCount, feedSourceSummaries.get(0).publishedValidationSummary.errorCount);
-        assertEquals(feedVersionPublishedFromLatestDeployment.validationResult.firstCalendarDate, feedSourceSummaries.get(0).publishedValidationSummary.startDate);
-        assertEquals(feedVersionPublishedFromLatestDeployment.validationResult.lastCalendarDate, feedSourceSummaries.get(0).publishedValidationSummary.endDate);
+        FeedSourceSummary firstSummary = feedSourceSummaries.get(0);
+        FeedValidationResultSummary expectedValidationSummary = feedVersionFromLatestDeploymentVersion2.validationSummary();
+        assertEquals(feedSourceWithLatestDeploymentFeedVersion.id, firstSummary.id);
+        assertEquals(feedSourceWithLatestDeploymentFeedVersion.projectId, firstSummary.projectId);
+        assertEquals(feedSourceWithLatestDeploymentFeedVersion.labelIds, firstSummary.labelIds);
+        assertEquals(feedSourceWithLatestDeploymentFeedVersion.url.toString(), firstSummary.url);
+        assertEquals(feedSourceWithLatestDeploymentFeedVersion.noteIds, firstSummary.noteIds);
+        assertEquals(feedSourceWithLatestDeploymentFeedVersion.organizationId(), firstSummary.organizationId);
+        assertEquals(feedVersionFromLatestDeploymentVersion2.id, firstSummary.deployedFeedVersionId);
+        assertEquals(expectedValidationSummary.startDate, firstSummary.deployedFeedVersionStartDate);
+        assertEquals(expectedValidationSummary.endDate, firstSummary.deployedFeedVersionEndDate);
+        assertEquals(expectedValidationSummary.errorCount, firstSummary.deployedFeedVersionIssues);
+        assertEquals(feedVersionFromLatestDeploymentVersion2.id, firstSummary.latestValidation.feedVersionId);
+        assertEquals(expectedValidationSummary.startDate, firstSummary.latestValidation.startDate);
+        assertEquals(expectedValidationSummary.endDate, firstSummary.latestValidation.endDate);
+        assertEquals(expectedValidationSummary.errorCount, firstSummary.latestValidation.errorCount);
+        assertEquals(feedVersionFromLatestDeploymentVersion2.sentToExternalPublisher, firstSummary.latestSentToExternalPublisher);
+        assertEquals(PublishState.PUBLISH_BLOCKED, firstSummary.publishState);
+        assertEquals(feedSourceWithLatestDeploymentFeedVersion.publishedVersionId, firstSummary.publishedVersionId);
+        assertEquals(feedVersionPublishedFromLatestDeployment.validationResult.errorCount, firstSummary.publishedValidationSummary.errorCount);
+        assertEquals(feedVersionPublishedFromLatestDeployment.validationResult.firstCalendarDate, firstSummary.publishedValidationSummary.startDate);
+        assertEquals(feedVersionPublishedFromLatestDeployment.validationResult.lastCalendarDate, firstSummary.publishedValidationSummary.endDate);
     }
 
     @Test
@@ -413,22 +417,26 @@ public class FeedSourceControllerTest extends DatatoolsTest {
                 FeedSourceSummary.class
             );
         assertNotNull(feedSourceSummaries);
-        assertEquals(feedSourceWithPinnedDeploymentFeedVersion.id, feedSourceSummaries.get(0).id);
-        assertEquals(feedSourceWithPinnedDeploymentFeedVersion.projectId, feedSourceSummaries.get(0).projectId);
-        assertEquals(feedSourceWithPinnedDeploymentFeedVersion.labelIds, feedSourceSummaries.get(0).labelIds);
-        assertEquals(feedSourceWithPinnedDeploymentFeedVersion.url.toString(), feedSourceSummaries.get(0).url);
-        assertEquals(feedSourceWithPinnedDeploymentFeedVersion.noteIds, feedSourceSummaries.get(0).noteIds);
-        assertEquals(feedSourceWithPinnedDeploymentFeedVersion.organizationId(), feedSourceSummaries.get(0).organizationId);
-        assertEquals(feedVersionFromPinnedDeployment.id, feedSourceSummaries.get(0).deployedFeedVersionId);
-        assertEquals(feedVersionFromPinnedDeployment.validationSummary().startDate, feedSourceSummaries.get(0).deployedFeedVersionStartDate);
-        assertEquals(feedVersionFromPinnedDeployment.validationSummary().endDate, feedSourceSummaries.get(0).deployedFeedVersionEndDate);
-        assertEquals(feedVersionFromPinnedDeployment.validationSummary().errorCount, feedSourceSummaries.get(0).deployedFeedVersionIssues);
-        assertEquals(feedVersionFromPinnedDeployment.id, feedSourceSummaries.get(0).latestValidation.feedVersionId);
-        assertEquals(feedVersionFromPinnedDeployment.validationSummary().startDate, feedSourceSummaries.get(0).latestValidation.startDate);
-        assertEquals(feedVersionFromPinnedDeployment.validationSummary().endDate, feedSourceSummaries.get(0).latestValidation.endDate);
-        assertEquals(feedVersionFromPinnedDeployment.validationSummary().errorCount, feedSourceSummaries.get(0).latestValidation.errorCount);
-        assertEquals(feedVersionFromPinnedDeployment.sentToExternalPublisher, feedSourceSummaries.get(0).latestSentToExternalPublisher);
-        assertEquals(PublishState.PUBLISH_BLOCKED, feedSourceSummaries.get(0).publishState);
+        FeedSourceSummary firstSummary = feedSourceSummaries.get(0);
+        FeedValidationResultSummary expectedValidationSummary = feedVersionFromPinnedDeployment.validationSummary();
+
+        assertEquals(feedSourceWithPinnedDeploymentFeedVersion.id, firstSummary.id);
+        assertEquals(feedSourceWithPinnedDeploymentFeedVersion.projectId, firstSummary.projectId);
+        assertEquals(feedSourceWithPinnedDeploymentFeedVersion.labelIds, firstSummary.labelIds);
+        assertEquals(feedSourceWithPinnedDeploymentFeedVersion.url.toString(), firstSummary.url);
+        assertEquals(feedSourceWithPinnedDeploymentFeedVersion.noteIds, firstSummary.noteIds);
+        assertEquals(feedSourceWithPinnedDeploymentFeedVersion.organizationId(), firstSummary.organizationId);
+        assertEquals(feedVersionFromPinnedDeployment.id, firstSummary.deployedFeedVersionId);
+        assertEquals(expectedValidationSummary.startDate, firstSummary.deployedFeedVersionStartDate);
+        assertEquals(expectedValidationSummary.endDate, firstSummary.deployedFeedVersionEndDate);
+        assertEquals(expectedValidationSummary.errorCount, firstSummary.deployedFeedVersionIssues);
+        assertEquals(feedVersionFromPinnedDeployment.id, firstSummary.latestValidation.feedVersionId);
+        assertEquals(expectedValidationSummary.startDate, firstSummary.latestValidation.startDate);
+        assertEquals(expectedValidationSummary.endDate, firstSummary.latestValidation.endDate);
+        assertEquals(expectedValidationSummary.errorCount, firstSummary.latestValidation.errorCount);
+        assertEquals(feedVersionFromPinnedDeployment.sentToExternalPublisher, firstSummary.latestSentToExternalPublisher);
+        assertEquals(PublishState.PUBLISH_BLOCKED, firstSummary.publishState);
+        assertEquals(feedSourceWithPinnedDeploymentFeedVersion.publishedVersionId, firstSummary.publishedVersionId);
     }
 
     @ParameterizedTest


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR adds `publishedVersionId` to FeedSourceSummary so that the published feed status/content can be used when creating alerts.
