### PR TITLE
tweak java args to run out of memory more elegantly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,5 +16,5 @@ RUN mkdir -p /var/gtfs/manager/gtfs/gtfsplus
 # Launch server
 # This relies on a configuration volume and aws volume being present. See `docker-compose.yml`, or the example below
 # Try: docker run --publish 4000:4000 -v ~/config/:/config datatools-latest
-CMD ["java", "-XX:MaxRAMPercentage=95", "-jar", "datatools-server.jar", "/config/env.yml", "/config/server.yml"]
+CMD ["java", "-XX:MaxRAMPercentage=85", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:+CrashOnOutOfMemoryError", "-jar", "datatools-server.jar", "/config/env.yml", "/config/server.yml"]
 EXPOSE 4000


### PR DESCRIPTION
Adds new java flags to better handle OOM issues. Lowers the cap to make more room for the heap, and ensures that the app will crash instead of freezing. Finally, makes sure we get a dump we can analyze when it does crash