### PR TITLE
Fix criterion for non-rev trips

### DIFF
--- a/src/main/java/com/conveyal/datatools/manager/models/transform/RemoveNonRevenueTripsTransformation.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/transform/RemoveNonRevenueTripsTransformation.java
@@ -95,21 +95,27 @@ public class RemoveNonRevenueTripsTransformation extends ZipTransformation {
                 LOG.warn("No revenue trips! All trips and related stop times will be removed.");
             }
 
-            writeToFile(
-                zipTarget,
-                "stop_times.txt",
-                revenueStopTimes.getStopTimeRows().values().stream().flatMap(List::stream).collect(Collectors.toList()),
-                headersForStopTime,
-                revenueStopTimes.getDeletedRowCount()
-            );
+            // Only update tables and report change if rows are removed.
 
-            writeToFile(
-                zipTarget,
-                "trips.txt",
-                revenueTrips.tripRows,
-                headersForTrips,
-                revenueTrips.getDeletedRowCount()
-            );
+            if (revenueStopTimes.getDeletedRowCount() != 0) {
+                writeToFile(
+                    zipTarget,
+                    "stop_times.txt",
+                    revenueStopTimes.getStopTimeRows().values().stream().flatMap(List::stream).collect(Collectors.toList()),
+                    headersForStopTime,
+                    revenueStopTimes.getDeletedRowCount()
+                );
+            }
+
+            if (revenueTrips.getDeletedRowCount() != 0) {
+                writeToFile(
+                    zipTarget,
+                    "trips.txt",
+                    revenueTrips.tripRows,
+                    headersForTrips,
+                    revenueTrips.getDeletedRowCount()
+                );
+            }
         } catch (Exception e) {
             LOG.error("Unknown error encountered while attempting to remove non revenue trip from zip file.", e);
         }

--- a/src/main/java/com/conveyal/datatools/manager/models/transform/RemoveNonRevenueTripsTransformation.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/transform/RemoveNonRevenueTripsTransformation.java
@@ -231,7 +231,7 @@ public class RemoveNonRevenueTripsTransformation extends ZipTransformation {
     private boolean isRevenuePickupDropOff(CsvReader csvReader, Map<String, Integer> fieldIndexes) throws IOException {
         String pickup = csvReader.get(fieldIndexes.get(PICKUP_FIELD_NAME));
         String dropOff = csvReader.get(fieldIndexes.get(DROP_OFF_FIELD_NAME));
-        return !"1".equals(pickup) && !"1".equals(dropOff);
+        return !"1".equals(pickup) || !"1".equals(dropOff);
     }
 
     /**

--- a/src/test/java/com/conveyal/datatools/manager/models/transform/RemoveNonRevenueTripsTransformationTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/models/transform/RemoveNonRevenueTripsTransformationTest.java
@@ -107,15 +107,16 @@ class RemoveNonRevenueTripsTransformationTest extends UnitTest {
         return Stream.of(
             Arguments.of(
                 List.of(
-                    "non-revenue-trip1,1,",
                     "non-revenue-trip1,1,1",
                     "non-revenue-trip1,1,1",
-                    "non-revenue-trip1,1,"
+                    "non-revenue-trip1,1,1",
+                    "non-revenue-trip1,1,1"
                 ),
                 List.of(
                     "revenue-trip,0,0",
                     "revenue-trip,1,1",
-                    "revenue-trip,1,1",
+                    "revenue-trip,2,1",
+                    "revenue-trip,1,2",
                     "revenue-trip,0,0"
                 ),
                 fieldIndexes
@@ -131,8 +132,8 @@ class RemoveNonRevenueTripsTransformationTest extends UnitTest {
                 List.of(
                     "revenue-trip,0,0,2,2",
                     "revenue-trip,0,0,1,1",
-                    "revenue-trip,0,0,2,2",
-                    "revenue-trip,0,0,2,2"
+                    "revenue-trip,0,0,2,1",
+                    "revenue-trip,0,0,1,2"
                 ),
                 allFieldIndexes
             )


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [na] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR fixes the criterion for a revenue trip, where the pickup and drop off types were incorrectly required to be both-not-unavailable for a stop time to be considered a revenue stop.
