### PR TITLE
Deployment zip filenames

### DIFF
--- a/src/main/java/com/conveyal/datatools/manager/jobs/DeployJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/DeployJob.java
@@ -359,9 +359,7 @@ public class DeployJob extends MonitorableJob {
                         // add GTFS data
                         for (String feedVersionId : deployment.feedVersionIds) {
                             CustomFile gtfsFile = new CustomFile();
-                            // OTP 2.x must have the string `gtfs` somewhere inside the filename, so prepend the filename
-                            // with the string `gtfs-`.
-                            gtfsFile.filename = String.format("gtfs-%s", feedVersionId);
+                            gtfsFile.filename = getGraphBuildFeedFilename(feedVersionId);
                             gtfsFile.uri = S3Utils.getS3FeedUri(feedVersionId);
                             addCustomFileAsBaseFolderDownload(manifest, gtfsFile);
                         }
@@ -1217,9 +1215,7 @@ public class DeployJob extends MonitorableJob {
                     // add GTFS data
                     for (String feedVersionId : deployment.feedVersionIds) {
                         CustomFile gtfsFile = new CustomFile();
-                        // OTP 2.x must have the string `gtfs` somewhere inside the filename, so prepend the filename
-                        // with the string `gtfs-`.
-                        gtfsFile.filename = String.format("gtfs-%s", feedVersionId);
+                        gtfsFile.filename = getGraphBuildFeedFilename(feedVersionId);
                         gtfsFile.uri = S3Utils.getS3FeedUri(feedVersionId);
                         addCustomFileAsBaseFolderDownload(manifest, gtfsFile);
                     }
@@ -1308,6 +1304,18 @@ public class DeployJob extends MonitorableJob {
             return null;
         }
         return manifest;
+    }
+
+    /**
+     * Determine the name used when otp-runner downloads a feed for graph building.
+     * Preserve the existing feed-version fallback while honoring the FeedSource filename exactly when configured.
+     */
+    private String getGraphBuildFeedFilename(String feedVersionId) {
+        FeedVersion feedVersion = Persistence.feedVersions.getById(feedVersionId);
+        return deployment.getFeedSourceBundleFilename(
+            feedVersion,
+            String.format("gtfs-%s", feedVersionId)
+        );
     }
 
     /**

--- a/src/main/java/com/conveyal/datatools/manager/models/Deployment.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/Deployment.java
@@ -403,6 +403,29 @@ public class Deployment extends Model implements Serializable {
     }
 
     /**
+     * Determine the entry name for a GTFS file within a deployment.
+     * This prioritizes the FeedSource filename if available and valid, otherwise it falls back
+     * to the provided filename.
+     *
+     * @param feedVersion    The FeedVersion being processed.
+     * @param fallbackName   The filename to use when the FeedSource has no configured filename.
+     * @return The calculated filename for the GTFS file.
+     */
+    public String getFeedSourceBundleFilename(FeedVersion feedVersion, String fallbackName) {
+        FeedSource fs = feedVersion == null ? null : feedVersion.parentFeedSource();
+
+        if (fs != null && !Strings.isBlank(fs.filename)) {
+            // Use FeedSource filename if available, ensuring it ends with .zip
+            LOG.info("Using FeedSource filename for zip entry: {}", fs.filename);
+            return fs.filename.endsWith(".zip") ? fs.filename : fs.filename + ".zip";
+        }
+
+        // Fall back to the filename associated with the FeedVersion.
+        LOG.info("Using fallback filename for zip entry: {}", fallbackName);
+        return fallbackName;
+    }
+
+    /**
      * Determine the entry name for a GTFS file within the deployment bundle.
      * This prioritizes the FeedSource filename if available and valid, otherwise falls back
      * to the original GTFS filename derived from the FeedVersion.
@@ -412,17 +435,7 @@ public class Deployment extends Model implements Serializable {
      * @return The calculated entry name for the zip file.
      */
     public String getFeedSourceBundleFilename(FeedVersion feedVersion, File gtfsFile) {
-        String gtfsFileName = gtfsFile.getName();
-        FeedSource fs = feedVersion.parentFeedSource();
-
-        if (fs != null && !Strings.isBlank(fs.filename)) {
-            // Use FeedSource filename if available, ensuring it ends with .zip
-            LOG.info("Using FeedSource filename for zip entry: {}", gtfsFileName);
-            return fs.filename.endsWith(".zip") ? fs.filename : fs.filename + ".zip";
-        } 
-        // Fallback to the original GTFS filename derived from FeedVersion
-        LOG.info("Using FeedVersion filename for zip entry: {}", gtfsFileName);
-        return gtfsFileName;
+        return getFeedSourceBundleFilename(feedVersion, gtfsFile.getName());
     }
 
     /** Download config from provided URL. */

--- a/src/main/java/com/conveyal/datatools/manager/models/Deployment.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/Deployment.java
@@ -343,7 +343,7 @@ public class Deployment extends Model implements Serializable {
                 File gtfsFile = v.retrieveGtfsFile();
                 try (FileInputStream in = new FileInputStream(gtfsFile)) {
                     // Determine the entry name for the zip file.
-                    String entryName = getFeedSourceBundleFilename(v, gtfsFile);
+                    String entryName = getFeedSourceBundleFilename(v, gtfsFile.getName());
                     ZipEntry e = new ZipEntry(entryName);
                     out.putNextEntry(e);
                     ByteStreams.copy(in, out);
@@ -423,19 +423,6 @@ public class Deployment extends Model implements Serializable {
         // Fall back to the filename associated with the FeedVersion.
         LOG.info("Using fallback filename for zip entry: {}", fallbackName);
         return fallbackName;
-    }
-
-    /**
-     * Determine the entry name for a GTFS file within the deployment bundle.
-     * This prioritizes the FeedSource filename if available and valid, otherwise falls back
-     * to the original GTFS filename derived from the FeedVersion.
-     *
-     * @param feedVersion The FeedVersion being processed.
-     * @param gtfsFile    The GTFS file associated with the FeedVersion.
-     * @return The calculated entry name for the zip file.
-     */
-    public String getFeedSourceBundleFilename(FeedVersion feedVersion, File gtfsFile) {
-        return getFeedSourceBundleFilename(feedVersion, gtfsFile.getName());
     }
 
     /** Download config from provided URL. */

--- a/src/test/java/com/conveyal/datatools/manager/jobs/DeployJobTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/jobs/DeployJobTest.java
@@ -108,77 +108,19 @@ public class DeployJobTest extends UnitTest {
 
         feedSource.filename = "gtfs_from_source.zip";
         Persistence.feedSources.create(feedSource);
-        assertEquals("gtfs_from_source.zip", deployment.getFeedSourceBundleFilename(feedVersion, gtfsFile));
-
-        feedSource.filename = "gtfs_from_source";
-        Persistence.feedSources.replace(feedSource.id, feedSource);
-        assertEquals("gtfs_from_source.zip", deployment.getFeedSourceBundleFilename(feedVersion, gtfsFile));
+        assertEquals("gtfs_from_source.zip", deployment.getFeedSourceBundleFilename(feedVersion, gtfsFile.getName()));
 
         feedSource.filename = " ";
         Persistence.feedSources.replace(feedSource.id, feedSource);
-        assertEquals(gtfsFileName, deployment.getFeedSourceBundleFilename(feedVersion, gtfsFile));
+        assertEquals(gtfsFileName, deployment.getFeedSourceBundleFilename(feedVersion, gtfsFile.getName()));
 
         feedSource.filename = null;
         Persistence.feedSources.replace(feedSource.id, feedSource);
-        assertEquals(gtfsFileName, deployment.getFeedSourceBundleFilename(feedVersion, gtfsFile));
-
-        FeedVersion versionWithNullSource = new FeedVersion();
-        assertEquals(gtfsFileName, deployment.getFeedSourceBundleFilename(versionWithNullSource, gtfsFile));
+        assertEquals(gtfsFileName, deployment.getFeedSourceBundleFilename(feedVersion, gtfsFile.getName() ));
 
         Persistence.feedVersions.removeById(feedVersion.id);
         Persistence.feedSources.removeById(feedSource.id);
     }
-    /**
-     * Graph-build manifests should use the feed source's configured filename rather than the feed version ID.
-     */
-    @Test
-    public void canUseFeedSourceFilenameInGraphBuildManifest () {
-        FeedSource feedSource = new FeedSource("Manifest FeedSource");
-        feedSource.projectId = project.id;
-        feedSource.filename = "foo.zip";
-        Persistence.feedSources.create(feedSource);
-
-        FeedVersion feedVersion = new FeedVersion(feedSource);
-        Persistence.feedVersions.create(feedVersion);
-
-        deployment.feedVersionIds = new ArrayList<>();
-        deployment.feedVersionIds.add(feedVersion.id);
-        deployment.skipOsmExtract = true;
-
-        DeployJob deployJob = new DeployJob(
-            "Test deploy with feed source filename",
-            deployment,
-            Auth0UserProfile.createTestAdminUser(),
-            server,
-            "test-deploy",
-            DeployJob.DeployType.REPLACE,
-            true
-        );
-        OtpRunnerManifest manifest = deployJob.createAndUploadManifestAndConfigs(false);
-
-        assertEquals("foo.zip", manifest.baseFolderDownloads.get(0).name);
-        deployment.tripPlannerVersion = Deployment.TripPlannerVersion.OTP_2;
-        DeployJob otp2DeployJob = new DeployJob(
-            "Test OTP 2 deploy with feed source filename",
-            deployment,
-            Auth0UserProfile.createTestAdminUser(),
-            server,
-            "test-deploy",
-            DeployJob.DeployType.REPLACE,
-            true
-        );
-        OtpRunnerManifest otp2Manifest = otp2DeployJob.createAndUploadManifestAndConfigs(false);
-
-        assertEquals("foo.zip", otp2Manifest.baseFolderDownloads.get(0).name);
-
-        deployment.tripPlannerVersion = Deployment.TripPlannerVersion.OTP_1;
-
-        Persistence.feedVersions.removeById(feedVersion.id);
-        Persistence.feedSources.removeById(feedSource.id);
-        deployment.feedVersionIds = new ArrayList<>();
-        deployment.skipOsmExtract = false;
-    }
-
 
     /**
      * Tests that the otp-runner manifest and user data for a graph build + run server instance can be generated

--- a/src/test/java/com/conveyal/datatools/manager/jobs/DeployJobTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/jobs/DeployJobTest.java
@@ -128,6 +128,57 @@ public class DeployJobTest extends UnitTest {
         Persistence.feedVersions.removeById(feedVersion.id);
         Persistence.feedSources.removeById(feedSource.id);
     }
+    /**
+     * Graph-build manifests should use the feed source's configured filename rather than the feed version ID.
+     */
+    @Test
+    public void canUseFeedSourceFilenameInGraphBuildManifest () {
+        FeedSource feedSource = new FeedSource("Manifest FeedSource");
+        feedSource.projectId = project.id;
+        feedSource.filename = "foo.zip";
+        Persistence.feedSources.create(feedSource);
+
+        FeedVersion feedVersion = new FeedVersion(feedSource);
+        Persistence.feedVersions.create(feedVersion);
+
+        deployment.feedVersionIds = new ArrayList<>();
+        deployment.feedVersionIds.add(feedVersion.id);
+        deployment.skipOsmExtract = true;
+
+        DeployJob deployJob = new DeployJob(
+            "Test deploy with feed source filename",
+            deployment,
+            Auth0UserProfile.createTestAdminUser(),
+            server,
+            "test-deploy",
+            DeployJob.DeployType.REPLACE,
+            true
+        );
+        OtpRunnerManifest manifest = deployJob.createAndUploadManifestAndConfigs(false);
+
+        assertEquals("foo.zip", manifest.baseFolderDownloads.get(0).name);
+        deployment.tripPlannerVersion = Deployment.TripPlannerVersion.OTP_2;
+        DeployJob otp2DeployJob = new DeployJob(
+            "Test OTP 2 deploy with feed source filename",
+            deployment,
+            Auth0UserProfile.createTestAdminUser(),
+            server,
+            "test-deploy",
+            DeployJob.DeployType.REPLACE,
+            true
+        );
+        OtpRunnerManifest otp2Manifest = otp2DeployJob.createAndUploadManifestAndConfigs(false);
+
+        assertEquals("foo.zip", otp2Manifest.baseFolderDownloads.get(0).name);
+
+        deployment.tripPlannerVersion = Deployment.TripPlannerVersion.OTP_1;
+
+        Persistence.feedVersions.removeById(feedVersion.id);
+        Persistence.feedSources.removeById(feedSource.id);
+        deployment.feedVersionIds = new ArrayList<>();
+        deployment.skipOsmExtract = false;
+    }
+
 
     /**
      * Tests that the otp-runner manifest and user data for a graph build + run server instance can be generated


### PR DESCRIPTION
### Checklist

- [ ] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [ ] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [ ] The description lists all applicable issues this PR seeks to resolve
- [ ] The description lists any configuration setting(s) that differ from the default settings
- [ ] All tests and CI builds passing
- [ ] The description lists all relevant PRs included in this release _(remove this if not merging to master)_
- [ ] e2e tests are all passing _(remove this if not merging to master)_

### Description

Datatools was not correctly using the configured GTFS feed source filename in the otp-runner manifest/bundle download, even though it was using the correct filenames in the web ui download. This fixes that