### PR TITLE
Upgrade AWS SDK

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -220,6 +220,13 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents.client5</groupId>
+                <artifactId>httpclient5</artifactId>
+                <version>5.6.2</version>
+                <type>jar</type>
+                <scope>runtime</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <dependencies>
@@ -284,7 +291,6 @@
         </dependency>
         <!-- Used for loading/fetching/validating/writing GTFS entities. gtfs-lib also provides access to:
          - commons-io - generic utilities
-         - AWS S3 SDK - putting/getting objects into/out of S3.
          -->
         <dependency>
             <groupId>com.github.ibi-group</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <!-- Using the latest version of geotools (e.g, 20) seems to cause issues with the shapefile
         plugin where the_geom for each feature is null. -->
         <geotools.version>20.1</geotools.version>
-        <awsjavasdk.version>1.12.720</awsjavasdk.version>
+        <awsjavasdk.version>2.51.3</awsjavasdk.version>
     </properties>
     <build>
         <resources>
@@ -436,6 +436,11 @@
             <artifactId>snakeyaml</artifactId>
             <version>2.4</version>
         </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3-transfer-manager</artifactId>
+            <version>2.51.3</version>
+        </dependency>
         <!-- Used for writing csv for merged feeds. Note: this appears to be one of the only
           CSV libraries that will only quote values when necessary (e.g., there is a comma character
           contained within the value) and that will work with an output stream writer when writing
@@ -448,29 +453,29 @@
         </dependency>
         <!-- AWS individual module imports -->
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-s3</artifactId>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
             <version>${awsjavasdk.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-ec2</artifactId>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>ec2</artifactId>
             <version>${awsjavasdk.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-iam</artifactId>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>iam</artifactId>
             <version>${awsjavasdk.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-elasticloadbalancingv2</artifactId>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>elasticloadbalancingv2</artifactId>
             <version>${awsjavasdk.version}</version>
         </dependency>
         <!-- AWS STS allows Data Tools to assume other roles in order to deploy OTP to other AWS accounts. -->
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-sts</artifactId>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sts</artifactId>
             <version>${awsjavasdk.version}</version>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -442,11 +442,6 @@
             <artifactId>snakeyaml</artifactId>
             <version>2.4</version>
         </dependency>
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>s3-transfer-manager</artifactId>
-            <version>2.51.3</version>
-        </dependency>
         <!-- Used for writing csv for merged feeds. Note: this appears to be one of the only
           CSV libraries that will only quote values when necessary (e.g., there is a comma character
           contained within the value) and that will work with an output stream writer when writing
@@ -458,6 +453,27 @@
             <version>2.4.0</version>
         </dependency>
         <!-- AWS individual module imports -->
+        <!-- AWS signin, sso, and ssooidc enable local development using federated access (aws sso login). -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>signin</artifactId>
+            <version>${awsjavasdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sso</artifactId>
+            <version>${awsjavasdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>ssooidc</artifactId>
+            <version>${awsjavasdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3-transfer-manager</artifactId>
+            <version>${awsjavasdk.version}</version>
+        </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>s3</artifactId>

--- a/src/main/java/com/conveyal/datatools/common/utils/SparkUtils.java
+++ b/src/main/java/com/conveyal/datatools/common/utils/SparkUtils.java
@@ -1,6 +1,5 @@
 package com.conveyal.datatools.common.utils;
 
-import com.amazonaws.AmazonServiceException;
 import com.conveyal.datatools.common.utils.aws.CheckedAWSException;
 import com.conveyal.datatools.common.utils.aws.S3Utils;
 import com.conveyal.datatools.manager.auth.Auth0UserProfile;
@@ -15,6 +14,7 @@ import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.eclipse.jetty.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import spark.HaltException;
 import spark.Request;
 import spark.Response;
@@ -311,7 +311,7 @@ public class SparkUtils {
         }
         try {
             return S3Utils.uploadObject(uploadType + "/" + key + "_" + uploadedFileName, tempFile);
-        } catch (AmazonServiceException | CheckedAWSException e) {
+        } catch (AwsServiceException | CheckedAWSException e) {
             logMessageAndHalt(req, 500, "Error uploading file to S3", e);
             return null;
         } finally {

--- a/src/main/java/com/conveyal/datatools/common/utils/aws/AWSClientManager.java
+++ b/src/main/java/com/conveyal/datatools/common/utils/aws/AWSClientManager.java
@@ -1,14 +1,13 @@
 package com.conveyal.datatools.common.utils.aws;
 
-import com.amazonaws.AmazonServiceException;
-import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.auth.AWSSessionCredentials;
-import com.amazonaws.auth.AWSStaticCredentialsProvider;
-import com.amazonaws.auth.BasicSessionCredentials;
-import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider;
 import com.conveyal.datatools.common.utils.ExpiringAsset;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
 
 import java.util.HashMap;
 
@@ -26,7 +25,7 @@ public abstract class AWSClientManager<T> {
     private static final Logger LOG = LoggerFactory.getLogger(AWSClientManager.class);
 
     private static final long DEFAULT_EXPIRING_AWS_ASSET_VALID_DURATION_MILLIS = 800 * 1000;
-    private static final HashMap<String, ExpiringAsset<AWSStaticCredentialsProvider>> crendentialsProvidersByRole =
+    private static final HashMap<String, ExpiringAsset<StaticCredentialsProvider>> crendentialsProvidersByRole =
         new HashMap<>();
 
     protected final T defaultClient;
@@ -43,37 +42,32 @@ public abstract class AWSClientManager<T> {
      * https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html). The credentials can be
      * then used for creating a temporary client.
      */
-    private static ExpiringAsset<AWSStaticCredentialsProvider> getCredentialsForRole(
+    private static ExpiringAsset<StaticCredentialsProvider> getCredentialsForRole(
         String role
     ) throws CheckedAWSException {
         String roleSessionName = "data-tools-session";
         // check if an active credentials provider exists for this role
-        ExpiringAsset<AWSStaticCredentialsProvider> session = crendentialsProvidersByRole.get(role);
+        ExpiringAsset<StaticCredentialsProvider> session = crendentialsProvidersByRole.get(role);
         if (session != null && session.isActive()) {
             LOG.debug("Returning active role-based session credentials");
             return session;
         }
         // either a session hasn't been created or an existing one has expired. Create a new session.
-        STSAssumeRoleSessionCredentialsProvider sessionProvider = new STSAssumeRoleSessionCredentialsProvider
-            .Builder(
-                role,
-                roleSessionName
+        StsAssumeRoleCredentialsProvider sessionProvider = StsAssumeRoleCredentialsProvider
+            .builder()
+            .refreshRequest(r ->
+                    r.roleSessionName(roleSessionName)
+                    .roleArn(role)
             )
             .build();
-        AWSSessionCredentials credentials;
-        try {
-            credentials = sessionProvider.getCredentials();
-        } catch (AmazonServiceException e) {
+        AwsSessionCredentials credentials;
+        try (sessionProvider) {
+            credentials = (AwsSessionCredentials) sessionProvider.resolveCredentials();
+        } catch (AwsServiceException e) {
             throw new CheckedAWSException("Failed to obtain AWS credentials");
         }
         LOG.info("Successfully created role-based session credentials");
-        AWSStaticCredentialsProvider credentialsProvider = new AWSStaticCredentialsProvider(
-            new BasicSessionCredentials(
-                credentials.getAWSAccessKeyId(),
-                credentials.getAWSSecretKey(),
-                credentials.getSessionToken()
-            )
-        );
+        StaticCredentialsProvider credentialsProvider = StaticCredentialsProvider.create(AwsSessionCredentials.create(credentials.accessKeyId(), credentials.secretAccessKey(), credentials.sessionToken()));
         session = new ExpiringAsset<>(credentialsProvider, DEFAULT_EXPIRING_AWS_ASSET_VALID_DURATION_MILLIS);
         // store the credentials provider in a lookup by role for future use
         crendentialsProvidersByRole.put(role, session);
@@ -89,7 +83,7 @@ public abstract class AWSClientManager<T> {
      * An abstract method where the implementation will create a client with the specified role and region.
      */
     protected abstract T buildCredentialedClientForRoleAndRegion(
-        AWSCredentialsProvider credentials, String region, String role
+        AwsCredentialsProvider credentials, String region, String role
     ) throws CheckedAWSException;
 
     /**
@@ -127,7 +121,7 @@ public abstract class AWSClientManager<T> {
         }
 
         // Either a new client hasn't been created or it has expired. Create a new client and cache it.
-        ExpiringAsset<AWSStaticCredentialsProvider> session = getCredentialsForRole(role);
+        ExpiringAsset<StaticCredentialsProvider> session = getCredentialsForRole(role);
         T credentialedClientForRoleAndRegion = buildCredentialedClientForRoleAndRegion(session.asset, region, role);
         LOG.info("Successfully created role-based {} client", getClientClassName());
         clientsByRoleAndRegion.put(

--- a/src/main/java/com/conveyal/datatools/common/utils/aws/AWSClientManager.java
+++ b/src/main/java/com/conveyal/datatools/common/utils/aws/AWSClientManager.java
@@ -67,7 +67,13 @@ public abstract class AWSClientManager<T> {
             throw new CheckedAWSException("Failed to obtain AWS credentials");
         }
         LOG.info("Successfully created role-based session credentials");
-        StaticCredentialsProvider credentialsProvider = StaticCredentialsProvider.create(AwsSessionCredentials.create(credentials.accessKeyId(), credentials.secretAccessKey(), credentials.sessionToken()));
+        StaticCredentialsProvider credentialsProvider = StaticCredentialsProvider.create(
+            AwsSessionCredentials.create(
+                credentials.accessKeyId(),
+                credentials.secretAccessKey(),
+                credentials.sessionToken()
+            )
+        );
         session = new ExpiringAsset<>(credentialsProvider, DEFAULT_EXPIRING_AWS_ASSET_VALID_DURATION_MILLIS);
         // store the credentials provider in a lookup by role for future use
         crendentialsProvidersByRole.put(role, session);

--- a/src/main/java/com/conveyal/datatools/common/utils/aws/CheckedAWSException.java
+++ b/src/main/java/com/conveyal/datatools/common/utils/aws/CheckedAWSException.java
@@ -1,6 +1,6 @@
 package com.conveyal.datatools.common.utils.aws;
 
-import com.amazonaws.AmazonServiceException;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
 
 /**
  * A helper exception class that does not extend the RunTimeException class in order to make the compiler properly
@@ -14,7 +14,7 @@ public class CheckedAWSException extends Exception {
         originalException = null;
     }
 
-    public CheckedAWSException(AmazonServiceException e) {
+    public CheckedAWSException(AwsServiceException e) {
         super(e.getMessage());
         originalException = e;
     }

--- a/src/main/java/com/conveyal/datatools/common/utils/aws/EC2Utils.java
+++ b/src/main/java/com/conveyal/datatools/common/utils/aws/EC2Utils.java
@@ -1,44 +1,21 @@
 package com.conveyal.datatools.common.utils.aws;
 
-import com.amazonaws.AmazonServiceException;
-import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.services.ec2.AmazonEC2;
-import com.amazonaws.services.ec2.AmazonEC2Client;
-import com.amazonaws.services.ec2.AmazonEC2ClientBuilder;
-import com.amazonaws.services.ec2.model.AmazonEC2Exception;
-import com.amazonaws.services.ec2.model.DescribeImagesRequest;
-import com.amazonaws.services.ec2.model.DescribeImagesResult;
-import com.amazonaws.services.ec2.model.DescribeInstancesRequest;
-import com.amazonaws.services.ec2.model.DescribeInstancesResult;
-import com.amazonaws.services.ec2.model.DescribeKeyPairsResult;
-import com.amazonaws.services.ec2.model.DescribeSubnetsRequest;
-import com.amazonaws.services.ec2.model.DescribeSubnetsResult;
-import com.amazonaws.services.ec2.model.Filter;
-import com.amazonaws.services.ec2.model.Image;
-import com.amazonaws.services.ec2.model.Instance;
-import com.amazonaws.services.ec2.model.InstanceType;
-import com.amazonaws.services.ec2.model.KeyPairInfo;
-import com.amazonaws.services.ec2.model.Reservation;
-import com.amazonaws.services.ec2.model.Subnet;
-import com.amazonaws.services.ec2.model.TerminateInstancesRequest;
-import com.amazonaws.services.ec2.model.TerminateInstancesResult;
-import com.amazonaws.services.elasticloadbalancingv2.AmazonElasticLoadBalancing;
-import com.amazonaws.services.elasticloadbalancingv2.AmazonElasticLoadBalancingClient;
-import com.amazonaws.services.elasticloadbalancingv2.AmazonElasticLoadBalancingClientBuilder;
-import com.amazonaws.services.elasticloadbalancingv2.model.AmazonElasticLoadBalancingException;
-import com.amazonaws.services.elasticloadbalancingv2.model.DeregisterTargetsRequest;
-import com.amazonaws.services.elasticloadbalancingv2.model.DescribeLoadBalancersRequest;
-import com.amazonaws.services.elasticloadbalancingv2.model.DescribeLoadBalancersResult;
-import com.amazonaws.services.elasticloadbalancingv2.model.DescribeTargetGroupsRequest;
-import com.amazonaws.services.elasticloadbalancingv2.model.LoadBalancer;
-import com.amazonaws.services.elasticloadbalancingv2.model.TargetDescription;
-import com.amazonaws.services.elasticloadbalancingv2.model.TargetGroup;
 import com.conveyal.datatools.manager.DataManager;
 import com.conveyal.datatools.manager.models.EC2InstanceSummary;
 import com.conveyal.datatools.manager.models.OtpServer;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.ec2.Ec2Client;
+import software.amazon.awssdk.services.ec2.Ec2ClientBuilder;
+import software.amazon.awssdk.services.ec2.model.*;
+import software.amazon.awssdk.services.elasticloadbalancingv2.ElasticLoadBalancingV2Client;
+import software.amazon.awssdk.services.elasticloadbalancingv2.ElasticLoadBalancingV2ClientBuilder;
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.*;
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.TargetGroup;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -59,8 +36,8 @@ public class EC2Utils {
     public static final String DEFAULT_AMI_ID = DataManager.getConfigPropertyAsText(AMI_CONFIG_PATH);
     public static final String DEFAULT_INSTANCE_TYPE = "t2.medium";
 
-    private static final AmazonEC2 DEFAULT_EC2_CLIENT = AmazonEC2Client.builder().build();
-    private static final AmazonElasticLoadBalancing DEFAULT_ELB_CLIENT = AmazonElasticLoadBalancingClient
+    private static final Ec2Client DEFAULT_EC2_CLIENT = Ec2Client.builder().build();
+    private static final ElasticLoadBalancingV2Client DEFAULT_ELB_CLIENT = ElasticLoadBalancingV2Client
         .builder()
         .build();
     private static final EC2ClientManagerImpl EC2ClientManager = new EC2ClientManagerImpl(DEFAULT_EC2_CLIENT);
@@ -69,23 +46,23 @@ public class EC2Utils {
     /**
      * A class that manages the creation of EC2 clients.
      */
-    private static class EC2ClientManagerImpl extends AWSClientManager<AmazonEC2> {
-        public EC2ClientManagerImpl(AmazonEC2 defaultClient) {
+    private static class EC2ClientManagerImpl extends AWSClientManager<Ec2Client> {
+        public EC2ClientManagerImpl(Ec2Client defaultClient) {
             super(defaultClient);
         }
 
         @Override
-        public AmazonEC2 buildDefaultClientWithRegion(String region) {
-            return AmazonEC2Client.builder().withRegion(region).build();
+        public Ec2Client buildDefaultClientWithRegion(String region) {
+            return Ec2Client.builder().region(Region.of(region)).build();
         }
 
         @Override
-        public AmazonEC2 buildCredentialedClientForRoleAndRegion(
-            AWSCredentialsProvider credentials, String region, String role
+        public Ec2Client buildCredentialedClientForRoleAndRegion(
+            AwsCredentialsProvider credentials, String region, String role
         ) {
-            AmazonEC2ClientBuilder builder = AmazonEC2Client.builder().withCredentials(credentials);
+            Ec2ClientBuilder builder = Ec2Client.builder().credentialsProvider(credentials);
             if (region != null) {
-                builder = builder.withRegion(region);
+                builder = builder.region(Region.of(region));
             }
             return builder.build();
         }
@@ -94,37 +71,38 @@ public class EC2Utils {
     /**
      * A class that manages the creation of ELB clients.
      */
-    private static class ELBClientManagerImpl extends AWSClientManager<AmazonElasticLoadBalancing> {
-        public ELBClientManagerImpl(AmazonElasticLoadBalancing defaultClient) {
+    private static class ELBClientManagerImpl extends AWSClientManager<ElasticLoadBalancingV2Client> {
+        public ELBClientManagerImpl(ElasticLoadBalancingV2Client defaultClient) {
             super(defaultClient);
         }
 
         @Override
-        public AmazonElasticLoadBalancing buildDefaultClientWithRegion(String region) {
-            return AmazonElasticLoadBalancingClient.builder().withRegion(region).build();
+        public ElasticLoadBalancingV2Client buildDefaultClientWithRegion(String region) {
+            return ElasticLoadBalancingV2Client.builder().region(Region.of(region)).build();
         }
 
         @Override
-        public AmazonElasticLoadBalancing buildCredentialedClientForRoleAndRegion(
-            AWSCredentialsProvider credentials, String region, String role
+        public ElasticLoadBalancingV2Client buildCredentialedClientForRoleAndRegion(
+            AwsCredentialsProvider credentials, String region, String role
         ) {
-            AmazonElasticLoadBalancingClientBuilder builder = AmazonElasticLoadBalancingClient
+            ElasticLoadBalancingV2ClientBuilder builder = ElasticLoadBalancingV2Client
                 .builder()
-                .withCredentials(credentials);
+                .credentialsProvider(credentials);
             if (region != null) {
-                builder = builder.withRegion(region);
+                builder = builder.region(Region.of(region));
             }
             return builder.build();
         }
     }
 
     /** Determine if AMI ID exists (and is gettable by the application's AWS credentials). */
-    public static boolean amiExists(AmazonEC2 ec2Client, String amiId) {
-        DescribeImagesRequest request = new DescribeImagesRequest().withImageIds(amiId);
-        DescribeImagesResult result = ec2Client.describeImages(request);
+    public static boolean amiExists(Ec2Client ec2Client, String amiId) {
+        DescribeImagesRequest request = DescribeImagesRequest.builder().imageIds(amiId)
+            .build();
+        DescribeImagesResponse result = ec2Client.describeImages(request);
         // Iterate over AMIs to find a matching ID.
-        for (Image image : result.getImages()) {
-            if (image.getImageId().equals(amiId) && image.getState().toLowerCase().equals("available")) return true;
+        for (Image image : result.images()) {
+            if (image.imageId().equals(amiId) && image.state().name().equalsIgnoreCase("available")) return true;
         }
         return false;
     }
@@ -140,15 +118,17 @@ public class EC2Utils {
     ) {
         LOG.info("De-registering instances from load balancer {}", instanceIds);
         TargetDescription[] targetDescriptions = instanceIds.stream()
-            .map(id -> new TargetDescription().withId(id))
+            .map(id -> TargetDescription.builder().id(id)
+                .build())
             .toArray(TargetDescription[]::new);
         try {
-            DeregisterTargetsRequest request = new DeregisterTargetsRequest()
-                .withTargetGroupArn(targetGroupArn)
-                .withTargets(targetDescriptions);
+            DeregisterTargetsRequest request = DeregisterTargetsRequest.builder()
+                .targetGroupArn(targetGroupArn)
+                .targets(targetDescriptions)
+                .build();
             getELBClient(role, region).deregisterTargets(request);
             terminateInstances(getEC2Client(role, region), instanceIds);
-        } catch (AmazonServiceException | CheckedAWSException e) {
+        } catch (AwsServiceException | CheckedAWSException e) {
             LOG.warn("Could not terminate EC2 instances: {}", String.join(",", instanceIds), e);
             return false;
         }
@@ -158,31 +138,32 @@ public class EC2Utils {
     /**
      * Fetches list of {@link EC2InstanceSummary} for all instances matching the provided filters.
      */
-    public static List<EC2InstanceSummary> fetchEC2InstanceSummaries(AmazonEC2 ec2Client, Filter... filters) {
+    public static List<EC2InstanceSummary> fetchEC2InstanceSummaries(Ec2Client ec2Client, Filter... filters) {
         return fetchEC2Instances(ec2Client, filters).stream().map(EC2InstanceSummary::new).collect(Collectors.toList());
     }
 
     /**
      * Fetch EC2 instances from AWS that match the provided set of filters (e.g., tags, instance ID, or other properties).
      */
-    public static List<Instance> fetchEC2Instances(AmazonEC2 ec2Client, Filter... filters) {
+    public static List<Instance> fetchEC2Instances(Ec2Client ec2Client, Filter... filters) {
         if (ec2Client == null) throw new IllegalArgumentException("Must provide EC2Client");
         List<Instance> instances = new ArrayList<>();
-        DescribeInstancesRequest request = new DescribeInstancesRequest().withFilters(filters);
-        DescribeInstancesResult result = ec2Client.describeInstances(request);
-        for (Reservation reservation : result.getReservations()) {
-            instances.addAll(reservation.getInstances());
+        DescribeInstancesRequest request = DescribeInstancesRequest.builder().filters(filters)
+            .build();
+        DescribeInstancesResponse result = ec2Client.describeInstances(request);
+        for (Reservation reservation : result.reservations()) {
+            instances.addAll(reservation.instances());
         }
         // Sort by launch time (most recent first).
-        instances.sort(Comparator.comparing(Instance::getLaunchTime).reversed());
+        instances.sort(Comparator.comparing(Instance::launchTime).reversed());
         return instances;
     }
 
-    public static AmazonEC2 getEC2Client(String role, String region) throws CheckedAWSException {
+    public static Ec2Client getEC2Client(String role, String region) throws CheckedAWSException {
         return EC2ClientManager.getClient(role, region);
     }
 
-    public static AmazonElasticLoadBalancing getELBClient(String role, String region) throws CheckedAWSException {
+    public static ElasticLoadBalancingV2Client getELBClient(String role, String region) throws CheckedAWSException {
         return ELBClientManager.getClient(role, region);
     }
 
@@ -194,21 +175,23 @@ public class EC2Utils {
      *  - https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-limits.html
      */
     public static LoadBalancer getLoadBalancerForTargetGroup(
-        AmazonElasticLoadBalancing elbClient,
+        ElasticLoadBalancingV2Client elbClient,
         String targetGroupArn
     ) {
         try {
-            DescribeTargetGroupsRequest targetGroupsRequest = new DescribeTargetGroupsRequest()
-                .withTargetGroupArns(targetGroupArn);
-            List<TargetGroup> targetGroups = elbClient.describeTargetGroups(targetGroupsRequest).getTargetGroups();
+            DescribeTargetGroupsRequest targetGroupsRequest = DescribeTargetGroupsRequest.builder()
+                .targetGroupArns(targetGroupArn)
+                .build();
+            List<TargetGroup> targetGroups = elbClient.describeTargetGroups(targetGroupsRequest).targetGroups();
             for (TargetGroup tg : targetGroups) {
-                DescribeLoadBalancersRequest request = new DescribeLoadBalancersRequest()
-                    .withLoadBalancerArns(tg.getLoadBalancerArns());
-                DescribeLoadBalancersResult result = elbClient.describeLoadBalancers(request);
+                DescribeLoadBalancersRequest request = DescribeLoadBalancersRequest.builder()
+                    .loadBalancerArns(tg.loadBalancerArns())
+                    .build();
+                DescribeLoadBalancersResponse result = elbClient.describeLoadBalancers(request);
                 // Return the first load balancer
-                return result.getLoadBalancers().iterator().next();
+                return result.loadBalancers().iterator().next();
             }
-        } catch (AmazonElasticLoadBalancingException e) {
+        } catch (ElasticLoadBalancingV2Exception e) {
             LOG.warn("Invalid value for Target Group ARN: {}", targetGroupArn);
         }
         // If no target group/load balancer found, return null.
@@ -221,8 +204,8 @@ public class EC2Utils {
      * @param ec2Client The client to use when terminating the instances.
      * @param instanceIds A collection of strings of EC2 instance IDs that should be terminated.
      */
-    public static TerminateInstancesResult terminateInstances(
-        AmazonEC2 ec2Client,
+    public static TerminateInstancesResponse terminateInstances(
+        Ec2Client ec2Client,
         Collection<String> instanceIds
     ) throws CheckedAWSException {
         if (instanceIds.size() == 0) {
@@ -230,35 +213,36 @@ public class EC2Utils {
             return null;
         }
         LOG.info("Terminating EC2 instances {}", instanceIds);
-        TerminateInstancesRequest request = new TerminateInstancesRequest().withInstanceIds(instanceIds);
+        TerminateInstancesRequest request = TerminateInstancesRequest.builder().instanceIds(instanceIds)
+            .build();
         try {
             return ec2Client.terminateInstances(request);
-        } catch (AmazonEC2Exception e) {
+        } catch (Ec2Exception e) {
             throw new CheckedAWSException(e);
         }
     }
 
     /**
-     * Convenience method to override {@link EC2Utils#terminateInstances(AmazonEC2, Collection)}.
+     * Convenience method to override {@link EC2Utils#terminateInstances(Ec2Client, Collection)}.
      *
      * @param ec2Client The client to use when terminating the instances.
      * @param instanceIds Each argument should be a string of an instance ID that should be terminated.
      */
-    public static TerminateInstancesResult terminateInstances(
-        AmazonEC2 ec2Client,
+    public static TerminateInstancesResponse terminateInstances(
+        Ec2Client ec2Client,
         String... instanceIds
     ) throws CheckedAWSException {
         return terminateInstances(ec2Client, Arrays.asList(instanceIds));
     }
 
     /**
-     * Convenience method to override {@link EC2Utils#terminateInstances(AmazonEC2, Collection)}.
+     * Convenience method to override {@link EC2Utils#terminateInstances(Ec2Client, Collection)}.
      *
      * @param ec2Client The client to use when terminating the instances.
      * @param instances A list of EC2 Instances that should be terminated.
      */
-    public static TerminateInstancesResult terminateInstances(
-        AmazonEC2 ec2Client,
+    public static TerminateInstancesResponse terminateInstances(
+        Ec2Client ec2Client,
         List<Instance> instances
     ) throws CheckedAWSException {
         return terminateInstances(ec2Client, getIds(instances));
@@ -268,7 +252,7 @@ public class EC2Utils {
      * Shorthand method for getting list of string identifiers from a list of EC2 instances.
      */
     public static List<String> getIds (List<Instance> instances) {
-        return instances.stream().map(Instance::getInstanceId).collect(Collectors.toList());
+        return instances.stream().map(Instance::instanceId).collect(Collectors.toList());
     }
 
     /**
@@ -277,7 +261,7 @@ public class EC2Utils {
      * TODO: Should we warn user if the AMI provided is older than the default AMI registered with this application as
      *   DEFAULT_AMI_ID?
      */
-    public static EC2ValidationResult validateAmiId(AmazonEC2 ec2Client, String amiId) {
+    public static EC2ValidationResult validateAmiId(Ec2Client ec2Client, String amiId) {
         EC2ValidationResult result = new EC2ValidationResult();
         if (StringUtils.isEmpty(amiId))
             return result;
@@ -285,7 +269,7 @@ public class EC2Utils {
             if (!EC2Utils.amiExists(ec2Client, amiId)) {
                 result.setInvalid("Server must have valid AMI ID (or field must be empty)");
             }
-        } catch (AmazonEC2Exception e) {
+        } catch (Ec2Exception e) {
             result.setInvalid("AMI does not exist or some error prevented proper checking of the AMI ID.", e);
         }
         return result;
@@ -301,18 +285,19 @@ public class EC2Utils {
         if (!otpServer.ec2Info.recreateBuildImage) return result;
         String buildImageName = otpServer.ec2Info.buildImageName;
         try {
-            DescribeImagesRequest describeImagesRequest = new DescribeImagesRequest()
+            DescribeImagesRequest describeImagesRequest = DescribeImagesRequest.builder()
                 // limit AMIs to only those owned by the current ec2 user.
-                .withOwners("self");
-            DescribeImagesResult describeImagesResult = otpServer.getEC2Client().describeImages(describeImagesRequest);
+                .owners("self")
+                .build();
+            DescribeImagesResponse describeImagesResult = otpServer.getEC2Client().describeImages(describeImagesRequest);
             // Iterate over AMIs to see if any images have a duplicate name.
-            for (Image image : describeImagesResult.getImages()) {
-                if (image.getName().equals(buildImageName)) {
+            for (Image image : describeImagesResult.images()) {
+                if (image.name().equals(buildImageName)) {
                     result.setInvalid(String.format("An image with the name `%s` already exists!", buildImageName));
                     break;
                 }
             }
-        } catch (AmazonEC2Exception | CheckedAWSException e) {
+        } catch (Ec2Exception | CheckedAWSException e) {
             String message = "Some error prevented proper checking of for duplicate AMI names.";
             LOG.error(message, e);
             result.setInvalid(message, e);
@@ -344,16 +329,16 @@ public class EC2Utils {
     /**
      * Validate that the AWS key name (the first part of a .pem key) exists and is not empty.
      */
-    public static EC2ValidationResult validateKeyName(AmazonEC2 ec2Client, String keyName) {
+    public static EC2ValidationResult validateKeyName(Ec2Client ec2Client, String keyName) {
         String message = "Server must have valid key name";
         EC2ValidationResult result = new EC2ValidationResult();
         if (StringUtils.isEmpty(keyName)) {
             result.setInvalid(message);
             return result;
         }
-        DescribeKeyPairsResult response = ec2Client.describeKeyPairs();
-        for (KeyPairInfo key_pair : response.getKeyPairs()) {
-            if (key_pair.getKeyName().equals(keyName)) return result;
+        DescribeKeyPairsResponse response = ec2Client.describeKeyPairs();
+        for (KeyPairInfo key_pair : response.keyPairs()) {
+            if (key_pair.keyName().equals(keyName)) return result;
         }
         result.setInvalid(message);
         return result;
@@ -369,7 +354,7 @@ public class EC2Utils {
     ) {
         EC2ValidationResult result = new EC2ValidationResult();
         String message = "Server must have valid security group ID";
-        List<String> securityGroups = loadBalancer.getSecurityGroups();
+        List<String> securityGroups = loadBalancer.securityGroups();
         if (StringUtils.isEmpty(otpServer.ec2Info.securityGroupId)) {
             // Attempt to assign security group by deriving the value from target group/ELB.
             String securityGroupId = securityGroups.iterator().next();
@@ -396,16 +381,17 @@ public class EC2Utils {
         EC2ValidationResult result = new EC2ValidationResult();
         String message = "Server must have valid subnet ID";
         // Make request for all subnets associated with load balancer's vpc
-        Filter filter = new Filter("vpc-id").withValues(loadBalancer.getVpcId());
-        DescribeSubnetsRequest describeSubnetsRequest = new DescribeSubnetsRequest().withFilters(filter);
-        DescribeSubnetsResult describeSubnetsResult;
+        Filter filter = Filter.builder().name("vpc-id").values(loadBalancer.vpcId()).build();
+        DescribeSubnetsRequest describeSubnetsRequest = DescribeSubnetsRequest.builder().filters(filter)
+            .build();
+        DescribeSubnetsResponse describeSubnetsResult;
         try {
             describeSubnetsResult = otpServer.getEC2Client().describeSubnets(describeSubnetsRequest);
         } catch (CheckedAWSException e) {
             result.setInvalid(message, e);
             return result;
         }
-        List<Subnet> subnets = describeSubnetsResult.getSubnets();
+        List<Subnet> subnets = describeSubnetsResult.subnets();
         // Attempt to assign subnet by deriving the value from target group/ELB.
         if (StringUtils.isEmpty(otpServer.ec2Info.subnetId)) {
             // Set subnetID to the first value found.
@@ -413,15 +399,15 @@ public class EC2Utils {
             //  the Internet?
             Subnet subnet = subnets.iterator().next();
             if (subnet != null) {
-                otpServer.ec2Info.subnetId = subnet.getSubnetId();
+                otpServer.ec2Info.subnetId = subnet.subnetId();
                 return result;
             }
         } else {
             // Otherwise, verify the value set in the EC2Info.
             try {
                 // Iterate over subnets. If a matching ID is found, silently return.
-                for (Subnet subnet : subnets) if (subnet.getSubnetId().equals(otpServer.ec2Info.subnetId)) return result;
-            } catch (AmazonEC2Exception e) {
+                for (Subnet subnet : subnets) if (subnet.subnetId().equals(otpServer.ec2Info.subnetId)) return result;
+            } catch (Ec2Exception e) {
                 result.setInvalid(message, e);
                 return result;
             }

--- a/src/main/java/com/conveyal/datatools/common/utils/aws/EC2Utils.java
+++ b/src/main/java/com/conveyal/datatools/common/utils/aws/EC2Utils.java
@@ -11,10 +11,24 @@ import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.awssdk.services.ec2.Ec2ClientBuilder;
-import software.amazon.awssdk.services.ec2.model.*;
+import software.amazon.awssdk.services.ec2.model.DescribeImagesResponse;
+import software.amazon.awssdk.services.ec2.model.DescribeInstancesResponse;
+import software.amazon.awssdk.services.ec2.model.DescribeKeyPairsResponse;
+import software.amazon.awssdk.services.ec2.model.DescribeSubnetsResponse;
+import software.amazon.awssdk.services.ec2.model.Ec2Exception;
+import software.amazon.awssdk.services.ec2.model.Filter;
+import software.amazon.awssdk.services.ec2.model.Image;
+import software.amazon.awssdk.services.ec2.model.Instance;
+import software.amazon.awssdk.services.ec2.model.InstanceType;
+import software.amazon.awssdk.services.ec2.model.KeyPairInfo;
+import software.amazon.awssdk.services.ec2.model.Reservation;
+import software.amazon.awssdk.services.ec2.model.Subnet;
+import software.amazon.awssdk.services.ec2.model.TerminateInstancesResponse;
 import software.amazon.awssdk.services.elasticloadbalancingv2.ElasticLoadBalancingV2Client;
 import software.amazon.awssdk.services.elasticloadbalancingv2.ElasticLoadBalancingV2ClientBuilder;
-import software.amazon.awssdk.services.elasticloadbalancingv2.model.*;
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.ElasticLoadBalancingV2Exception;
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.LoadBalancer;
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.TargetDescription;
 import software.amazon.awssdk.services.elasticloadbalancingv2.model.TargetGroup;
 
 import java.util.ArrayList;
@@ -97,9 +111,7 @@ public class EC2Utils {
 
     /** Determine if AMI ID exists (and is gettable by the application's AWS credentials). */
     public static boolean amiExists(Ec2Client ec2Client, String amiId) {
-        DescribeImagesRequest request = DescribeImagesRequest.builder().imageIds(amiId)
-            .build();
-        DescribeImagesResponse result = ec2Client.describeImages(request);
+        DescribeImagesResponse result = ec2Client.describeImages(req -> req.imageIds(amiId));
         // Iterate over AMIs to find a matching ID.
         for (Image image : result.images()) {
             if (image.imageId().equals(amiId) && image.state().name().equalsIgnoreCase("available")) return true;
@@ -118,15 +130,14 @@ public class EC2Utils {
     ) {
         LOG.info("De-registering instances from load balancer {}", instanceIds);
         TargetDescription[] targetDescriptions = instanceIds.stream()
-            .map(id -> TargetDescription.builder().id(id)
-                .build())
+            .map(id -> TargetDescription.builder().id(id).build())
             .toArray(TargetDescription[]::new);
         try {
-            DeregisterTargetsRequest request = DeregisterTargetsRequest.builder()
-                .targetGroupArn(targetGroupArn)
-                .targets(targetDescriptions)
-                .build();
-            getELBClient(role, region).deregisterTargets(request);
+            getELBClient(role, region).deregisterTargets(
+                req -> req
+                    .targetGroupArn(targetGroupArn)
+                    .targets(targetDescriptions)
+            );
             terminateInstances(getEC2Client(role, region), instanceIds);
         } catch (AwsServiceException | CheckedAWSException e) {
             LOG.warn("Could not terminate EC2 instances: {}", String.join(",", instanceIds), e);
@@ -147,10 +158,8 @@ public class EC2Utils {
      */
     public static List<Instance> fetchEC2Instances(Ec2Client ec2Client, Filter... filters) {
         if (ec2Client == null) throw new IllegalArgumentException("Must provide EC2Client");
+        DescribeInstancesResponse result = ec2Client.describeInstances(req -> req.filters(filters));
         List<Instance> instances = new ArrayList<>();
-        DescribeInstancesRequest request = DescribeInstancesRequest.builder().filters(filters)
-            .build();
-        DescribeInstancesResponse result = ec2Client.describeInstances(request);
         for (Reservation reservation : result.reservations()) {
             instances.addAll(reservation.instances());
         }
@@ -179,17 +188,15 @@ public class EC2Utils {
         String targetGroupArn
     ) {
         try {
-            DescribeTargetGroupsRequest targetGroupsRequest = DescribeTargetGroupsRequest.builder()
-                .targetGroupArns(targetGroupArn)
-                .build();
-            List<TargetGroup> targetGroups = elbClient.describeTargetGroups(targetGroupsRequest).targetGroups();
+            List<TargetGroup> targetGroups = elbClient
+                .describeTargetGroups(req -> req.targetGroupArns(targetGroupArn))
+                .targetGroups();
             for (TargetGroup tg : targetGroups) {
-                DescribeLoadBalancersRequest request = DescribeLoadBalancersRequest.builder()
-                    .loadBalancerArns(tg.loadBalancerArns())
-                    .build();
-                DescribeLoadBalancersResponse result = elbClient.describeLoadBalancers(request);
                 // Return the first load balancer
-                return result.loadBalancers().iterator().next();
+                return elbClient
+                    .describeLoadBalancers(req -> req.loadBalancerArns(tg.loadBalancerArns()))
+                    .loadBalancers()
+                    .iterator().next();
             }
         } catch (ElasticLoadBalancingV2Exception e) {
             LOG.warn("Invalid value for Target Group ARN: {}", targetGroupArn);
@@ -208,15 +215,13 @@ public class EC2Utils {
         Ec2Client ec2Client,
         Collection<String> instanceIds
     ) throws CheckedAWSException {
-        if (instanceIds.size() == 0) {
+        if (instanceIds.isEmpty()) {
             LOG.warn("No instance IDs provided in list. Skipping termination request.");
             return null;
         }
         LOG.info("Terminating EC2 instances {}", instanceIds);
-        TerminateInstancesRequest request = TerminateInstancesRequest.builder().instanceIds(instanceIds)
-            .build();
         try {
-            return ec2Client.terminateInstances(request);
+            return ec2Client.terminateInstances(req -> req.instanceIds(instanceIds));
         } catch (Ec2Exception e) {
             throw new CheckedAWSException(e);
         }
@@ -285,11 +290,10 @@ public class EC2Utils {
         if (!otpServer.ec2Info.recreateBuildImage) return result;
         String buildImageName = otpServer.ec2Info.buildImageName;
         try {
-            DescribeImagesRequest describeImagesRequest = DescribeImagesRequest.builder()
+            DescribeImagesResponse describeImagesResult = otpServer.getEC2Client().describeImages(
                 // limit AMIs to only those owned by the current ec2 user.
-                .owners("self")
-                .build();
-            DescribeImagesResponse describeImagesResult = otpServer.getEC2Client().describeImages(describeImagesRequest);
+                req -> req.owners("self")
+            );
             // Iterate over AMIs to see if any images have a duplicate name.
             for (Image image : describeImagesResult.images()) {
                 if (image.name().equals(buildImageName)) {
@@ -382,11 +386,9 @@ public class EC2Utils {
         String message = "Server must have valid subnet ID";
         // Make request for all subnets associated with load balancer's vpc
         Filter filter = Filter.builder().name("vpc-id").values(loadBalancer.vpcId()).build();
-        DescribeSubnetsRequest describeSubnetsRequest = DescribeSubnetsRequest.builder().filters(filter)
-            .build();
         DescribeSubnetsResponse describeSubnetsResult;
         try {
-            describeSubnetsResult = otpServer.getEC2Client().describeSubnets(describeSubnetsRequest);
+            describeSubnetsResult = otpServer.getEC2Client().describeSubnets(req -> req.filters(filter));
         } catch (CheckedAWSException e) {
             result.setInvalid(message, e);
             return result;

--- a/src/main/java/com/conveyal/datatools/common/utils/aws/EC2Utils.java
+++ b/src/main/java/com/conveyal/datatools/common/utils/aws/EC2Utils.java
@@ -341,8 +341,8 @@ public class EC2Utils {
             return result;
         }
         DescribeKeyPairsResponse response = ec2Client.describeKeyPairs();
-        for (KeyPairInfo key_pair : response.keyPairs()) {
-            if (key_pair.keyName().equals(keyName)) return result;
+        for (KeyPairInfo keyPair : response.keyPairs()) {
+            if (keyPair.keyName().equals(keyName)) return result;
         }
         result.setInvalid(message);
         return result;

--- a/src/main/java/com/conveyal/datatools/common/utils/aws/IAMUtils.java
+++ b/src/main/java/com/conveyal/datatools/common/utils/aws/IAMUtils.java
@@ -1,66 +1,65 @@
 package com.conveyal.datatools.common.utils.aws;
 
-import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.services.identitymanagement.AmazonIdentityManagement;
-import com.amazonaws.services.identitymanagement.AmazonIdentityManagementClientBuilder;
-import com.amazonaws.services.identitymanagement.model.InstanceProfile;
-import com.amazonaws.services.identitymanagement.model.ListInstanceProfilesResult;
 import org.apache.commons.lang3.StringUtils;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.iam.IamClient;
+import software.amazon.awssdk.services.iam.IamClientBuilder;
+import software.amazon.awssdk.services.iam.model.InstanceProfile;
+import software.amazon.awssdk.services.iam.model.ListInstanceProfilesResponse;
 
 /**
  * This class contains utilities related to using AWS IAM services.
  */
 public class IAMUtils {
-    private static final AmazonIdentityManagement DEFAULT_IAM_CLIENT = AmazonIdentityManagementClientBuilder
-        .defaultClient();
+    private static final IamClient DEFAULT_IAM_CLIENT = IamClient.builder().build();
     private static final IAMClientManagerImpl IAMClientManager = new IAMClientManagerImpl(DEFAULT_IAM_CLIENT);
 
     /**
      * A class that manages the creation of IAM clients.
      */
-    private static class IAMClientManagerImpl extends AWSClientManager<AmazonIdentityManagement> {
-        public IAMClientManagerImpl(AmazonIdentityManagement defaultClient) {
+    private static class IAMClientManagerImpl extends AWSClientManager<IamClient> {
+        public IAMClientManagerImpl(IamClient defaultClient) {
             super(defaultClient);
         }
 
         @Override
-        public AmazonIdentityManagement buildDefaultClientWithRegion(String region) {
+        public IamClient buildDefaultClientWithRegion(String region) {
             return defaultClient;
         }
 
         @Override
-        public AmazonIdentityManagement buildCredentialedClientForRoleAndRegion(
-            AWSCredentialsProvider credentials, String region, String role
+        public IamClient buildCredentialedClientForRoleAndRegion(
+            AwsCredentialsProvider credentials, String region, String role
         ) {
-            AmazonIdentityManagementClientBuilder builder = AmazonIdentityManagementClientBuilder
-                .standard()
-                .withCredentials(credentials);
+            IamClientBuilder builder = IamClient.builder()
+                .credentialsProvider(credentials);
             if (region != null) {
-                builder = builder.withRegion(region);
+                builder = builder.region(Region.of(region));
             }
             return builder.build();
         }
     }
 
-    public static AmazonIdentityManagement getIAMClient(String role, String region) throws CheckedAWSException {
+    public static IamClient getIAMClient(String role, String region) throws CheckedAWSException {
         return IAMClientManager.getClient(role, region);
     }
 
     /** Get IAM instance profile for the provided role ARN. */
     public static InstanceProfile getIamInstanceProfile(
-        AmazonIdentityManagement iamClient, String iamInstanceProfileArn
+        IamClient iamClient, String iamInstanceProfileArn
     ) {
-        ListInstanceProfilesResult result = iamClient.listInstanceProfiles();
+        ListInstanceProfilesResponse result = iamClient.listInstanceProfiles();
         // Iterate over instance profiles. If a matching ARN is found, silently return.
-        for (InstanceProfile profile: result.getInstanceProfiles()) {
-            if (profile.getArn().equals(iamInstanceProfileArn)) return profile;
+        for (InstanceProfile profile: result.instanceProfiles()) {
+            if (profile.arn().equals(iamInstanceProfileArn)) return profile;
         }
         return null;
     }
 
     /** Validate that IAM instance profile ARN exists and is not empty. */
     public static EC2ValidationResult validateIamInstanceProfileArn(
-        AmazonIdentityManagement client, String iamInstanceProfileArn
+        IamClient client, String iamInstanceProfileArn
     ) {
         EC2ValidationResult result = new EC2ValidationResult();
         String message = "Server must have valid IAM instance profile ARN (e.g., arn:aws:iam::123456789012:instance-profile/otp-ec2-role).";

--- a/src/main/java/com/conveyal/datatools/common/utils/aws/InstanceStateAws1.java
+++ b/src/main/java/com/conveyal/datatools/common/utils/aws/InstanceStateAws1.java
@@ -1,0 +1,100 @@
+package com.conveyal.datatools.common.utils.aws;
+
+import software.amazon.awssdk.services.ec2.model.InstanceStateName;
+
+import java.io.Serializable;
+
+/**
+ * Extracted from AWS SDK1 runtime because the SDK2 version can't be serialized for some reason.
+ */
+public class InstanceStateAws1 implements Serializable, Cloneable {
+    private Integer code;
+    private String name;
+
+    public void setCode(Integer code) {
+        this.code = code;
+    }
+
+    public Integer getCode() {
+        return this.code;
+    }
+
+    public InstanceStateAws1 withCode(Integer code) {
+        this.setCode(code);
+        return this;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public InstanceStateAws1 withName(String name) {
+        this.setName(name);
+        return this;
+    }
+
+    public void setName(InstanceStateName name) {
+        this.withName(name);
+    }
+
+    public InstanceStateAws1 withName(InstanceStateName name) {
+        this.name = name.toString();
+        return this;
+    }
+
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("{");
+        if (this.getCode() != null) {
+            sb.append("Code: ").append(this.getCode()).append(",");
+        }
+
+        if (this.getName() != null) {
+            sb.append("Name: ").append(this.getName());
+        }
+
+        sb.append("}");
+        return sb.toString();
+    }
+
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        } else if (obj == null) {
+            return false;
+        } else if (!(obj instanceof InstanceStateAws1)) {
+            return false;
+        } else {
+            InstanceStateAws1 other = (InstanceStateAws1)obj;
+            if (other.getCode() == null ^ this.getCode() == null) {
+                return false;
+            } else if (other.getCode() != null && !other.getCode().equals(this.getCode())) {
+                return false;
+            } else if (other.getName() == null ^ this.getName() == null) {
+                return false;
+            } else {
+                return other.getName() == null || other.getName().equals(this.getName());
+            }
+        }
+    }
+
+    public int hashCode() {
+        int prime = 31;
+        int hashCode = 1;
+        hashCode = prime * hashCode + (this.getCode() == null ? 0 : this.getCode().hashCode());
+        hashCode = prime * hashCode + (this.getName() == null ? 0 : this.getName().hashCode());
+        return hashCode;
+    }
+
+    public InstanceStateAws1 clone() {
+        try {
+            return (InstanceStateAws1)super.clone();
+        } catch (CloneNotSupportedException e) {
+            throw new IllegalStateException("Got a CloneNotSupportedException from Object.clone() even though we're Cloneable!", e);
+        }
+    }
+}

--- a/src/main/java/com/conveyal/datatools/common/utils/aws/S3Utils.java
+++ b/src/main/java/com/conveyal/datatools/common/utils/aws/S3Utils.java
@@ -62,6 +62,7 @@ public class S3Utils {
     public static final String APP_DATA_S3_REGION = "application.data.s3_region";
 
     public static final String APP_DATA_CREDS_FILE = "application.data.s3_credentials_file";
+    public static final String QUOTES_REGEX = "^\"|\"$";
 
     static {
         // Placeholder variables need to be used before setting the final variable to make sure initialization occurs
@@ -399,5 +400,22 @@ public class S3Utils {
      */
     public static S3Uri makeUri(String uriString) {
         return S3Uri.builder().uri(URI.create(uriString)).build();
+    }
+
+    /**
+     * Whether etags match, accounting for formatting changes moving from AWS SDK v1 to v2.
+     */
+    public static boolean eTagsMatch(String etag1, String etag2) {
+        return cleanETag(etag1).equals(cleanETag(etag2));
+    }
+
+    /**
+     * Returns a cleaned etag without quotes, accounting for formatting changes moving from AWS SDK v1 to v2.
+     * AWS SDK for Java v2 migration: NOTE: V2's eTag() preserves surrounding quotes in the response,
+     * whereas V1's getETag() strips them.
+     * <a href="https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/migration-s3-client.html#V1s-ObjectMetadata-using-V1s-getETag">...</a>
+     */
+    public static String cleanETag(String etag) {
+        return etag.replaceAll(QUOTES_REGEX, "");
     }
 }

--- a/src/main/java/com/conveyal/datatools/common/utils/aws/S3Utils.java
+++ b/src/main/java/com/conveyal/datatools/common/utils/aws/S3Utils.java
@@ -17,6 +17,7 @@ import software.amazon.awssdk.services.s3.S3AsyncClientBuilder;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3ClientBuilder;
 import software.amazon.awssdk.services.s3.S3Uri;
+import software.amazon.awssdk.services.s3.S3Utilities;
 import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
@@ -51,6 +52,7 @@ public class S3Utils {
     private static final AwsCredentialsProvider DEFAULT_S3_CREDENTIALS;
     private static final S3ClientManagerImpl S3ClientManager;
     private static final S3AsyncClientManagerImpl S3AsyncClientManager;
+    private static final S3Utilities S3_GLOBAL_UTILS = S3Utilities.builder().region(Region.AWS_GLOBAL).build();
 
     public static final String DEFAULT_BUCKET;
     public static final String DEFAULT_BUCKET_GTFS_FOLDER = "gtfs/";
@@ -396,10 +398,10 @@ public class S3Utils {
     }
 
     /**
-     * Create a S3Uri from a string after encoding it.
+     * Create a S3Uri from a string from which a bucket or key can be extracted.
      */
     public static S3Uri makeUri(String uriString) {
-        return S3Uri.builder().uri(URI.create(uriString)).build();
+        return S3_GLOBAL_UTILS.parseUri(URI.create(uriString));
     }
 
     /**

--- a/src/main/java/com/conveyal/datatools/common/utils/aws/S3Utils.java
+++ b/src/main/java/com/conveyal/datatools/common/utils/aws/S3Utils.java
@@ -36,8 +36,6 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.Date;
@@ -404,6 +402,6 @@ public class S3Utils {
      * Create a S3Uri from a string after encoding it.
      */
     public static S3Uri makeUri(String uriString) {
-        return S3Uri.builder().uri(URI.create(URLEncoder.encode(uriString, StandardCharsets.UTF_8))).build();
+        return S3Uri.builder().uri(URI.create(uriString)).build();
     }
 }

--- a/src/main/java/com/conveyal/datatools/common/utils/aws/S3Utils.java
+++ b/src/main/java/com/conveyal/datatools/common/utils/aws/S3Utils.java
@@ -18,7 +18,6 @@ import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3ClientBuilder;
 import software.amazon.awssdk.services.s3.S3Uri;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
-import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
@@ -145,8 +144,7 @@ public class S3Utils {
             }
             if (credentialsProvider == null) {
                 // default credentials providers, e.g. IAM role
-                credentialsProvider = DefaultCredentialsProvider.builder()
-                    .build();
+                credentialsProvider = DefaultCredentialsProvider.builder().build();
             }
             builder.credentialsProvider(credentialsProvider);
             asyncBuilder.credentialsProvider(credentialsProvider);
@@ -254,10 +252,7 @@ public class S3Utils {
         try {
             Validate.notEmpty(bucketName, "The bucket name must not be null or an empty string.", "");
             Validate.notEmpty(key, "The object key must not be null or an empty string.", "");
-            return s3Client.headObject(HeadObjectRequest.builder()
-                .bucket(bucketName)
-                .key(key)
-                .build());
+            return s3Client.headObject(req -> req.bucket(bucketName).key(key));
         } catch (NoSuchKeyException e) {
             return null;
         }
@@ -340,13 +335,14 @@ public class S3Utils {
      * @return             A URL where the file is publicly accessible
      */
     public static String uploadObject(String keyName, File fileToUpload) throws AwsServiceException, CheckedAWSException {
-        String url = S3Utils.getDefaultBucketUrlForKey(keyName);
-        // FIXME: This may need to change during feed store refactor
-        getDefaultS3Client().putObject(PutObjectRequest.builder().bucket(S3Utils.DEFAULT_BUCKET).key(keyName)
-            // grant public read
-            .acl(ObjectCannedACL.PUBLIC_READ)
-            .build(), RequestBody.fromFile(fileToUpload));
-        return url;
+        getDefaultS3Client().putObject(
+            req -> req
+                .bucket(S3Utils.DEFAULT_BUCKET)
+                .key(keyName)
+                .acl(ObjectCannedACL.PUBLIC_READ),
+            RequestBody.fromFile(fileToUpload)
+        );
+        return S3Utils.getDefaultBucketUrlForKey(keyName);
     }
 
     public static void uploadAndWaitForCompletion(Consumer<UploadFileRequest.Builder> builderFunc) throws CheckedAWSException {

--- a/src/main/java/com/conveyal/datatools/common/utils/aws/S3Utils.java
+++ b/src/main/java/com/conveyal/datatools/common/utils/aws/S3Utils.java
@@ -17,14 +17,10 @@ import software.amazon.awssdk.services.s3.S3AsyncClientBuilder;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3ClientBuilder;
 import software.amazon.awssdk.services.s3.S3Uri;
-import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
-import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
-import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
-import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
 import software.amazon.awssdk.transfer.s3.S3TransferManager;
 import software.amazon.awssdk.transfer.s3.model.UploadFileRequest;
 import software.amazon.awssdk.utils.Validate;
@@ -307,13 +303,13 @@ public class S3Utils {
 
         URL url;
         try (S3Presigner presigner = S3Presigner.create()) {
-            GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
-                .signatureDuration(Duration.ofMillis(REQUEST_TIMEOUT_MSEC))
-                .getObjectRequest(objReq -> objReq.bucket(bucket).key(key))
-                .build();
-
-            PresignedGetObjectRequest presignedRequest = presigner.presignGetObject(presignRequest);
-            url = presignedRequest.url();
+            url = presigner
+                .presignGetObject(
+                    sign -> sign
+                        .signatureDuration(Duration.ofMillis(REQUEST_TIMEOUT_MSEC))
+                        .getObjectRequest(objReq -> objReq.bucket(bucket).key(key))
+                )
+                .url();
         } catch (AwsServiceException e) {
             logMessageAndHalt(req, 500, "Failed to download file from S3.", e);
             return null;
@@ -389,10 +385,11 @@ public class S3Utils {
      */
     public static void verifyS3WritePermissions(S3Client client, String s3Bucket) throws IOException {
         String key = UUID.randomUUID().toString();
-        client.putObject(PutObjectRequest.builder().bucket(s3Bucket).key(key)
-            .build(), RequestBody.fromFile(File.createTempFile("test", ".zip")));
-        client.deleteObject(DeleteObjectRequest.builder().bucket(s3Bucket).key(key)
-            .build());
+        client.putObject(
+            req -> req.bucket(s3Bucket).key(key),
+            RequestBody.fromFile(File.createTempFile("test", ".zip"))
+        );
+        client.deleteObject(req -> req.bucket(s3Bucket).key(key));
     }
 
     /**

--- a/src/main/java/com/conveyal/datatools/common/utils/aws/S3Utils.java
+++ b/src/main/java/com/conveyal/datatools/common/utils/aws/S3Utils.java
@@ -218,9 +218,8 @@ public class S3Utils {
     }
 
     /**
-     * A class that manages the creation of S3 clients.
+     * A class that manages the creation of S3 Async clients.
      */
-    // TODO: merge these two impl classes
     private static class S3AsyncClientManagerImpl extends AWSClientManager<S3AsyncClient> {
         public S3AsyncClientManagerImpl(S3AsyncClient defaultClient) {
             super(defaultClient);

--- a/src/main/java/com/conveyal/datatools/common/utils/aws/S3Utils.java
+++ b/src/main/java/com/conveyal/datatools/common/utils/aws/S3Utils.java
@@ -1,26 +1,37 @@
 package com.conveyal.datatools.common.utils.aws;
 
-import com.amazonaws.AmazonServiceException;
-import com.amazonaws.HttpMethod;
-import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
-import com.amazonaws.auth.profile.ProfileCredentialsProvider;
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.AmazonS3ClientBuilder;
-import com.amazonaws.services.s3.model.CannedAccessControlList;
-import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
-import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.conveyal.datatools.common.utils.SparkUtils;
 import com.conveyal.datatools.manager.DataManager;
 import com.conveyal.datatools.manager.models.OtpServer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.profiles.ProfileFile;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3ClientBuilder;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
+import software.amazon.awssdk.utils.Validate;
 import spark.Request;
 import spark.Response;
 
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
+import java.nio.file.Paths;
+import java.time.Duration;
 import java.util.Date;
 import java.util.List;
 import java.util.UUID;
@@ -35,7 +46,7 @@ public class S3Utils {
     private static final Logger LOG = LoggerFactory.getLogger(S3Utils.class);
 
     private static final int REQUEST_TIMEOUT_MSEC = 30 * 1000;
-    private static final AWSCredentialsProvider DEFAULT_S3_CREDENTIALS;
+    private static final AwsCredentialsProvider DEFAULT_S3_CREDENTIALS;
     private static final S3ClientManagerImpl S3ClientManager;
 
     public static final String DEFAULT_BUCKET;
@@ -47,7 +58,7 @@ public class S3Utils {
 
     static {
         // Placeholder variables need to be used before setting the final variable to make sure initialization occurs
-        AWSCredentialsProvider tempS3CredentialsProvider = null;
+        AwsCredentialsProvider tempS3CredentialsProvider = null;
         String tempGtfsS3Bucket = null;
         S3ClientManagerImpl tempS3ClientManager = null;
 
@@ -71,12 +82,14 @@ public class S3Utils {
     }
 
     public static class S3Wrapper {
-        public final AWSCredentialsProvider credentials;
-        public final AmazonS3 s3Client;
+        public final AwsCredentialsProvider credentials;
+        public final S3Client s3Client;
+        public final String region;
 
-        public S3Wrapper(AWSCredentialsProvider credentials, AmazonS3 s3Client) {
+        public S3Wrapper(AwsCredentialsProvider credentials, S3Client s3Client, String region) {
             this.credentials = credentials;
             this.s3Client = s3Client;
+            this.region = region;
         }
     }
 
@@ -91,17 +104,24 @@ public class S3Utils {
         List<String> configCredentials,
         List<String> configRegions
     ) throws IllegalArgumentException {
-        AmazonS3 s3client = null;
-        AWSCredentialsProvider credentialsProvider = null;
+        S3Client s3client = null;
+        AwsCredentialsProvider credentialsProvider = null;
+        String finalRegion = null;
         try {
-            AmazonS3ClientBuilder builder = AmazonS3ClientBuilder.standard();
+            S3ClientBuilder builder = S3Client.builder();
             // Iterate through the credentials and stop at the first non-null returned.
             // Default to the ambient IAM credentials, if any.
             for (String configCred : configCredentials) {
                 String credentialsFile = DataManager.getConfigPropertyAsText(configCred);
                 if (credentialsFile != null) {
                     try {
-                        credentialsProvider = new ProfileCredentialsProvider(credentialsFile, "default");
+                        credentialsProvider = ProfileCredentialsProvider.builder()
+                            .profileFile(file -> file
+                                .content(Paths.get(credentialsFile))
+                                .type(ProfileFile.Type.CONFIGURATION) // Expects all non-default profiles to be prefixed with "profile".
+                            )
+                            .profileName("default")
+                            .build();
                     } catch (IllegalArgumentException e) {
                         LOG.error("Invalid credentials from {}. Trying the next one.", configCred, e);
                     }
@@ -110,16 +130,18 @@ public class S3Utils {
             }
             if (credentialsProvider == null) {
                 // default credentials providers, e.g. IAM role
-                credentialsProvider = new DefaultAWSCredentialsProviderChain();
+                credentialsProvider = DefaultCredentialsProvider.builder()
+                    .build();
             }
-            builder.withCredentials(credentialsProvider);
+            builder.credentialsProvider(credentialsProvider);
 
             // Iterate through the regions and stop at the first non-null returned.
             // Otherwise defaults to value (typically provided in ~/.aws/config)
             for (String configRegion : configRegions) {
                 String region = DataManager.getConfigPropertyAsText(configRegion);
                 if (region != null) {
-                    builder.withRegion(region);
+                    builder.region(Region.of(region));
+                    finalRegion = region;
                     break;
                 }
             }
@@ -137,7 +159,7 @@ public class S3Utils {
             throw new IllegalArgumentException("Fatal error initializing the default s3Client");
         }
 
-        return new S3Wrapper(credentialsProvider, s3client);
+        return new S3Wrapper(credentialsProvider, s3client, finalRegion);
     }
 
     /**
@@ -162,24 +184,45 @@ public class S3Utils {
     /**
      * A class that manages the creation of S3 clients.
      */
-    private static class S3ClientManagerImpl extends AWSClientManager<AmazonS3> {
-        public S3ClientManagerImpl(AmazonS3 defaultClient) {
+    private static class S3ClientManagerImpl extends AWSClientManager<S3Client> {
+        public S3ClientManagerImpl(S3Client defaultClient) {
             super(defaultClient);
         }
 
         @Override
-        public AmazonS3 buildDefaultClientWithRegion(String region) {
-            return AmazonS3ClientBuilder.standard().withCredentials(DEFAULT_S3_CREDENTIALS).withRegion(region).build();
+        public S3Client buildDefaultClientWithRegion(String region) {
+            return S3Client.builder().credentialsProvider(DEFAULT_S3_CREDENTIALS).region(Region.of(region)).build();
         }
 
         @Override
-        public AmazonS3 buildCredentialedClientForRoleAndRegion(
-            AWSCredentialsProvider credentials, String region, String role
+        public S3Client buildCredentialedClientForRoleAndRegion(
+            AwsCredentialsProvider credentials, String region, String role
         ) {
-            AmazonS3ClientBuilder builder = AmazonS3ClientBuilder.standard();
-            if (region != null) builder.withRegion(region);
-            return builder.withCredentials(credentials).build();
+            S3ClientBuilder builder = S3Client.builder();
+            if (region != null) builder.region(Region.of(region));
+            return builder.credentialsProvider(credentials).build();
         }
+    }
+
+    /**
+     * Attemps to get the head or metadata for an S3 object.
+     * @return an {@link HeadObjectResponse} if the requested object exists, null otherwise.
+     */
+    public static HeadObjectResponse getHeadObject(S3Client s3Client, String bucketName, String key) {
+        try {
+            Validate.notEmpty(bucketName, "The bucket name must not be null or an empty string.", "");
+            Validate.notEmpty(key, "The object key must not be null or an empty string.", "");
+            return s3Client.headObject(HeadObjectRequest.builder()
+                .bucket(bucketName)
+                .key(key)
+                .build());
+        } catch (NoSuchKeyException e) {
+            return null;
+        }
+    }
+
+    public static boolean objectExists(S3Client s3Client, String bucketName, String key) {
+        return getHeadObject(s3Client, bucketName, key) != null;
     }
 
     /**
@@ -205,14 +248,14 @@ public class S3Utils {
      * @param res The response to write the download info to
      */
     public static String downloadObject(
-        AmazonS3 s3,
+        S3Client s3,
         String bucket,
         String key,
         boolean redirect,
         Request req,
         Response res
     ) {
-        if (!s3.doesObjectExist(bucket, key)) {
+        if (!objectExists(s3, bucket, key)) {
             logMessageAndHalt(
                 req,
                 500,
@@ -224,13 +267,16 @@ public class S3Utils {
         Date expiration = new Date();
         expiration.setTime(expiration.getTime() + REQUEST_TIMEOUT_MSEC);
 
-        GeneratePresignedUrlRequest presigned = new GeneratePresignedUrlRequest(bucket, key);
-        presigned.setExpiration(expiration);
-        presigned.setMethod(HttpMethod.GET);
         URL url;
-        try {
-            url = s3.generatePresignedUrl(presigned);
-        } catch (AmazonServiceException e) {
+        try (S3Presigner presigner = S3Presigner.create()) {
+            GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
+                .signatureDuration(Duration.ofMillis(REQUEST_TIMEOUT_MSEC))
+                .getObjectRequest(objReq -> objReq.bucket(bucket).key(key))
+                .build();
+
+            PresignedGetObjectRequest presignedRequest = presigner.presignGetObject(presignRequest);
+            url = presignedRequest.url();
+        } catch (AwsServiceException e) {
             logMessageAndHalt(req, 500, "Failed to download file from S3.", e);
             return null;
         }
@@ -251,25 +297,25 @@ public class S3Utils {
      * @param fileToUpload The file to upload to S3
      * @return             A URL where the file is publicly accessible
      */
-    public static String uploadObject(String keyName, File fileToUpload) throws AmazonServiceException, CheckedAWSException {
+    public static String uploadObject(String keyName, File fileToUpload) throws AwsServiceException, CheckedAWSException {
         String url = S3Utils.getDefaultBucketUrlForKey(keyName);
         // FIXME: This may need to change during feed store refactor
-        getDefaultS3Client().putObject(new PutObjectRequest(
-                S3Utils.DEFAULT_BUCKET, keyName, fileToUpload)
-                // grant public read
-                .withCannedAcl(CannedAccessControlList.PublicRead));
+        getDefaultS3Client().putObject(PutObjectRequest.builder().bucket(S3Utils.DEFAULT_BUCKET).key(keyName)
+            // grant public read
+            .acl(ObjectCannedACL.PUBLIC_READ)
+            .build(), RequestBody.fromFile(fileToUpload));
         return url;
     }
 
-    public static AmazonS3 getDefaultS3Client() throws CheckedAWSException {
+    public static S3Client getDefaultS3Client() throws CheckedAWSException {
         return getS3Client (null, null);
     }
 
-    public static AmazonS3 getS3Client(String role, String region) throws CheckedAWSException {
+    public static S3Client getS3Client(String role, String region) throws CheckedAWSException {
         return S3ClientManager.getClient(role, region);
     }
 
-    public static AmazonS3 getS3Client(OtpServer server) throws CheckedAWSException {
+    public static S3Client getS3Client(OtpServer server) throws CheckedAWSException {
         return S3Utils.getS3Client(server.role, server.getRegion());
     }
 
@@ -279,9 +325,11 @@ public class S3Utils {
      * there is a way to do this effectively without incurring AWS costs (although writing/deleting an empty file to S3
      * is probably minuscule).
      */
-    public static void verifyS3WritePermissions(AmazonS3 client, String s3Bucket) throws IOException {
+    public static void verifyS3WritePermissions(S3Client client, String s3Bucket) throws IOException {
         String key = UUID.randomUUID().toString();
-        client.putObject(s3Bucket, key, File.createTempFile("test", ".zip"));
-        client.deleteObject(s3Bucket, key);
+        client.putObject(PutObjectRequest.builder().bucket(s3Bucket).key(key)
+            .build(), RequestBody.fromFile(File.createTempFile("test", ".zip")));
+        client.deleteObject(DeleteObjectRequest.builder().bucket(s3Bucket).key(key)
+            .build());
     }
 }

--- a/src/main/java/com/conveyal/datatools/common/utils/aws/S3Utils.java
+++ b/src/main/java/com/conveyal/datatools/common/utils/aws/S3Utils.java
@@ -25,6 +25,8 @@ import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
+import software.amazon.awssdk.transfer.s3.S3TransferManager;
+import software.amazon.awssdk.transfer.s3.model.UploadFileRequest;
 import software.amazon.awssdk.utils.Validate;
 import spark.Request;
 import spark.Response;
@@ -37,6 +39,7 @@ import java.time.Duration;
 import java.util.Date;
 import java.util.List;
 import java.util.UUID;
+import java.util.function.Consumer;
 
 import static com.conveyal.datatools.common.utils.SparkUtils.logMessageAndHalt;
 import static com.conveyal.datatools.manager.DataManager.hasConfigProperty;
@@ -342,6 +345,21 @@ public class S3Utils {
             .acl(ObjectCannedACL.PUBLIC_READ)
             .build(), RequestBody.fromFile(fileToUpload));
         return url;
+    }
+
+    public static void uploadAndWaitForCompletion(Consumer<UploadFileRequest.Builder> builderFunc) throws CheckedAWSException {
+        uploadAndWaitForCompletion(UploadFileRequest.builder().applyMutation(builderFunc).build());
+    }
+
+    public static void uploadAndWaitForCompletion(UploadFileRequest uploadFileRequest) throws CheckedAWSException {
+        try (S3TransferManager transferManager = S3TransferManager
+            .builder()
+            .s3Client(getDefaultS3AsyncClient())
+            .build()
+        ) {
+            // Wait for the upload to finish
+            transferManager.uploadFile(uploadFileRequest).completionFuture().join();
+        }
     }
 
     public static S3Client getDefaultS3Client() throws CheckedAWSException {

--- a/src/main/java/com/conveyal/datatools/common/utils/aws/S3Utils.java
+++ b/src/main/java/com/conveyal/datatools/common/utils/aws/S3Utils.java
@@ -12,6 +12,8 @@ import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.profiles.ProfileFile;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.S3AsyncClientBuilder;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3ClientBuilder;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
@@ -48,6 +50,7 @@ public class S3Utils {
     private static final int REQUEST_TIMEOUT_MSEC = 30 * 1000;
     private static final AwsCredentialsProvider DEFAULT_S3_CREDENTIALS;
     private static final S3ClientManagerImpl S3ClientManager;
+    private static final S3AsyncClientManagerImpl S3AsyncClientManager;
 
     public static final String DEFAULT_BUCKET;
     public static final String DEFAULT_BUCKET_GTFS_FOLDER = "gtfs/";
@@ -61,12 +64,14 @@ public class S3Utils {
         AwsCredentialsProvider tempS3CredentialsProvider = null;
         String tempGtfsS3Bucket = null;
         S3ClientManagerImpl tempS3ClientManager = null;
+        S3AsyncClientManagerImpl tempS3AsyncClientManager = null;
 
         // Only configure s3 if the config requires doing so
         if (DataManager.useS3 || hasConfigProperty("modules.gtfsapi.use_extension")) {
             S3Wrapper build = buildS3Wrapper(List.of(APP_DATA_CREDS_FILE), List.of(APP_DATA_S3_REGION));
             tempS3CredentialsProvider = build.credentials;
             tempS3ClientManager = new S3ClientManagerImpl(build.s3Client);
+            tempS3AsyncClientManager = new S3AsyncClientManagerImpl(build.s3AsyncClient);
 
             // s3 storage
             tempGtfsS3Bucket = DataManager.getConfigPropertyAsText("application.data.gtfs_s3_bucket");
@@ -78,17 +83,20 @@ public class S3Utils {
         // initialize final fields
         DEFAULT_S3_CREDENTIALS = tempS3CredentialsProvider;
         S3ClientManager = tempS3ClientManager;
+        S3AsyncClientManager = tempS3AsyncClientManager;
         DEFAULT_BUCKET = tempGtfsS3Bucket;
     }
 
     public static class S3Wrapper {
         public final AwsCredentialsProvider credentials;
         public final S3Client s3Client;
+        public final S3AsyncClient s3AsyncClient;
         public final String region;
 
-        public S3Wrapper(AwsCredentialsProvider credentials, S3Client s3Client, String region) {
+        public S3Wrapper(AwsCredentialsProvider credentials, S3Client s3Client, S3AsyncClient s3AsyncClient, String region) {
             this.credentials = credentials;
             this.s3Client = s3Client;
+            this.s3AsyncClient = s3AsyncClient;
             this.region = region;
         }
     }
@@ -105,10 +113,12 @@ public class S3Utils {
         List<String> configRegions
     ) throws IllegalArgumentException {
         S3Client s3client = null;
+        S3AsyncClient s3AsyncClient = null;
         AwsCredentialsProvider credentialsProvider = null;
         String finalRegion = null;
         try {
             S3ClientBuilder builder = S3Client.builder();
+            S3AsyncClientBuilder asyncBuilder = S3AsyncClient.builder();
             // Iterate through the credentials and stop at the first non-null returned.
             // Default to the ambient IAM credentials, if any.
             for (String configCred : configCredentials) {
@@ -134,6 +144,7 @@ public class S3Utils {
                     .build();
             }
             builder.credentialsProvider(credentialsProvider);
+            asyncBuilder.credentialsProvider(credentialsProvider);
 
             // Iterate through the regions and stop at the first non-null returned.
             // Otherwise defaults to value (typically provided in ~/.aws/config)
@@ -141,12 +152,14 @@ public class S3Utils {
                 String region = DataManager.getConfigPropertyAsText(configRegion);
                 if (region != null) {
                     builder.region(Region.of(region));
+                    asyncBuilder.region(Region.of(region));
                     finalRegion = region;
                     break;
                 }
             }
 
             s3client = builder.build();
+            s3AsyncClient = asyncBuilder.build();
         } catch (Exception e) {
             LOG.error(
                 "S3 client not initialized correctly. Must provide config property {} or specify region in ~/.aws/config",
@@ -159,7 +172,7 @@ public class S3Utils {
             throw new IllegalArgumentException("Fatal error initializing the default s3Client");
         }
 
-        return new S3Wrapper(credentialsProvider, s3client, finalRegion);
+        return new S3Wrapper(credentialsProvider, s3client, s3AsyncClient, finalRegion);
     }
 
     /**
@@ -199,6 +212,30 @@ public class S3Utils {
             AwsCredentialsProvider credentials, String region, String role
         ) {
             S3ClientBuilder builder = S3Client.builder();
+            if (region != null) builder.region(Region.of(region));
+            return builder.credentialsProvider(credentials).build();
+        }
+    }
+
+    /**
+     * A class that manages the creation of S3 clients.
+     */
+    // TODO: merge these two impl classes
+    private static class S3AsyncClientManagerImpl extends AWSClientManager<S3AsyncClient> {
+        public S3AsyncClientManagerImpl(S3AsyncClient defaultClient) {
+            super(defaultClient);
+        }
+
+        @Override
+        public S3AsyncClient buildDefaultClientWithRegion(String region) {
+            return S3AsyncClient.builder().credentialsProvider(DEFAULT_S3_CREDENTIALS).region(Region.of(region)).build();
+        }
+
+        @Override
+        public S3AsyncClient buildCredentialedClientForRoleAndRegion(
+            AwsCredentialsProvider credentials, String region, String role
+        ) {
+            S3AsyncClientBuilder builder = S3AsyncClient.builder();
             if (region != null) builder.region(Region.of(region));
             return builder.credentialsProvider(credentials).build();
         }
@@ -317,6 +354,14 @@ public class S3Utils {
 
     public static S3Client getS3Client(OtpServer server) throws CheckedAWSException {
         return S3Utils.getS3Client(server.role, server.getRegion());
+    }
+
+    public static S3AsyncClient getDefaultS3AsyncClient() throws CheckedAWSException {
+        return getS3AsyncClient (null, null);
+    }
+
+    public static S3AsyncClient getS3AsyncClient(String role, String region) throws CheckedAWSException {
+        return S3AsyncClientManager.getClient(role, region);
     }
 
     /**

--- a/src/main/java/com/conveyal/datatools/common/utils/aws/S3Utils.java
+++ b/src/main/java/com/conveyal/datatools/common/utils/aws/S3Utils.java
@@ -263,7 +263,8 @@ public class S3Utils {
      */
     public static String downloadObject(String bucket, String key, boolean redirect, Request req, Response res) {
         try {
-            return downloadObject(getDefaultS3Client(), bucket, key, redirect, req, res);
+            // The default client is invoked with a null/unspecified region parameter.
+            return downloadObject(getDefaultS3Client(), null, bucket, key, redirect, req, res);
         } catch (CheckedAWSException e) {
             logMessageAndHalt(req, 500, "Failed to download file from S3.", e);
             return null;
@@ -282,6 +283,7 @@ public class S3Utils {
      */
     public static String downloadObject(
         S3Client s3,
+        String region,
         String bucket,
         String key,
         boolean redirect,
@@ -301,7 +303,9 @@ public class S3Utils {
         expiration.setTime(expiration.getTime() + REQUEST_TIMEOUT_MSEC);
 
         URL url;
-        try (S3Presigner presigner = S3Presigner.create()) {
+
+        Region awsRegion = region != null ? Region.of(region) : Region.AWS_GLOBAL;
+        try (S3Presigner presigner = S3Presigner.builder().region(awsRegion).build()) {
             url = presigner
                 .presignGetObject(
                     sign -> sign

--- a/src/main/java/com/conveyal/datatools/common/utils/aws/S3Utils.java
+++ b/src/main/java/com/conveyal/datatools/common/utils/aws/S3Utils.java
@@ -16,6 +16,7 @@ import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3AsyncClientBuilder;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3ClientBuilder;
+import software.amazon.awssdk.services.s3.S3Uri;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
@@ -33,7 +34,10 @@ import spark.Response;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URI;
 import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.Date;
@@ -394,5 +398,12 @@ public class S3Utils {
             .build(), RequestBody.fromFile(File.createTempFile("test", ".zip")));
         client.deleteObject(DeleteObjectRequest.builder().bucket(s3Bucket).key(key)
             .build());
+    }
+
+    /**
+     * Create a S3Uri from a string after encoding it.
+     */
+    public static S3Uri makeUri(String uriString) {
+        return S3Uri.builder().uri(URI.create(URLEncoder.encode(uriString, StandardCharsets.UTF_8))).build();
     }
 }

--- a/src/main/java/com/conveyal/datatools/editor/jobs/ExportSnapshotToGTFSJob.java
+++ b/src/main/java/com/conveyal/datatools/editor/jobs/ExportSnapshotToGTFSJob.java
@@ -1,6 +1,5 @@
 package com.conveyal.datatools.editor.jobs;
 
-import com.amazonaws.AmazonServiceException;
 import com.conveyal.datatools.common.status.MonitorableJob;
 import com.conveyal.datatools.common.utils.aws.CheckedAWSException;
 import com.conveyal.datatools.common.utils.aws.S3Utils;
@@ -13,6 +12,9 @@ import com.conveyal.gtfs.loader.JdbcGtfsExporter;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -75,8 +77,9 @@ public class ExportSnapshotToGTFSJob extends MonitorableJob {
         if (DataManager.useS3) {
             String s3Key = String.format("%s/%s", bucketPrefix, filename);
             try {
-                S3Utils.getDefaultS3Client().putObject(S3Utils.DEFAULT_BUCKET, s3Key, tempFile);
-            } catch (AmazonServiceException | CheckedAWSException e) {
+                S3Utils.getDefaultS3Client().putObject(PutObjectRequest.builder().bucket(S3Utils.DEFAULT_BUCKET).key(s3Key)
+                    .build(), RequestBody.fromFile(tempFile));
+            } catch (AwsServiceException | CheckedAWSException e) {
                 status.fail("Failed to upload file to S3", e);
                 return;
             }

--- a/src/main/java/com/conveyal/datatools/editor/jobs/ExportSnapshotToGTFSJob.java
+++ b/src/main/java/com/conveyal/datatools/editor/jobs/ExportSnapshotToGTFSJob.java
@@ -14,7 +14,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.core.sync.RequestBody;
-import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -77,8 +76,10 @@ public class ExportSnapshotToGTFSJob extends MonitorableJob {
         if (DataManager.useS3) {
             String s3Key = String.format("%s/%s", bucketPrefix, filename);
             try {
-                S3Utils.getDefaultS3Client().putObject(PutObjectRequest.builder().bucket(S3Utils.DEFAULT_BUCKET).key(s3Key)
-                    .build(), RequestBody.fromFile(tempFile));
+                S3Utils.getDefaultS3Client().putObject(
+                    req -> req.bucket(S3Utils.DEFAULT_BUCKET).key(s3Key),
+                    RequestBody.fromFile(tempFile)
+                );
             } catch (AwsServiceException | CheckedAWSException e) {
                 status.fail("Failed to upload file to S3", e);
                 return;

--- a/src/main/java/com/conveyal/datatools/manager/DataManager.java
+++ b/src/main/java/com/conveyal/datatools/manager/DataManager.java
@@ -3,6 +3,7 @@ package com.conveyal.datatools.manager;
 import com.conveyal.datatools.common.utils.CorsFilter;
 import com.conveyal.datatools.common.utils.RequestSummary;
 import com.conveyal.datatools.common.utils.Scheduler;
+import com.conveyal.datatools.common.utils.SparkUtils;
 import com.conveyal.datatools.editor.controllers.EditorLockController;
 import com.conveyal.datatools.editor.controllers.api.EditorControllerImpl;
 import com.conveyal.datatools.editor.controllers.api.SnapshotController;
@@ -54,7 +55,6 @@ import java.util.Properties;
 
 import static com.conveyal.datatools.common.utils.SparkUtils.logMessageAndHalt;
 import static com.conveyal.datatools.common.utils.SparkUtils.logRequest;
-import static com.conveyal.datatools.common.utils.SparkUtils.logResponse;
 import static spark.Service.SPARK_DEFAULT_PORT;
 import static spark.Spark.after;
 import static spark.Spark.before;
@@ -129,7 +129,7 @@ public class DataManager {
 
         // Optionally set port for server. Otherwise, Spark defaults to 4567.
         if (hasConfigProperty("application.port")) {
-            PORT = Integer.parseInt(getConfigPropertyAsText("application.port"));
+            PORT = getConfigProperty("application.port").asInt();
             port(PORT);
         }
         useS3 = "true".equals(getConfigPropertyAsText("application.data.use_s3_storage"));
@@ -338,9 +338,7 @@ public class DataManager {
         });
 
         // add logger
-        after((request, response) -> {
-            logResponse(request, response);
-        });
+        after(SparkUtils::logResponse);
     }
 
     /**
@@ -362,10 +360,10 @@ public class DataManager {
     }
 
     private static boolean hasConfigProperty(JsonNode config, String name) {
-        String parts[] = name.split("\\.");
+        String[] parts = name.split("\\.");
         JsonNode node = config;
         for (int i = 0; i < parts.length; i++) {
-            if(node == null) return false;
+            if (node == null) return false;
             node = node.get(parts[i]);
         }
         return node != null;
@@ -392,10 +390,10 @@ public class DataManager {
     }
 
     private static JsonNode getConfigProperty(JsonNode config, String name) {
-        String parts[] = name.split("\\.");
+        String[] parts = name.split("\\.");
         JsonNode node = config;
-        for(int i = 0; i < parts.length; i++) {
-            if(node == null) {
+        for (int i = 0; i < parts.length; i++) {
+            if (node == null) {
                 LOG.warn("Config property {} not found", name);
                 return null;
             }
@@ -467,7 +465,7 @@ public class DataManager {
                 node = (ObjectNode) node.get(part);
             } else {
                 // If a value is null, delete the corresponding node instead of put-ting the node value
-                // (After node.put(part, null), calling getConfigPropertyAsText will return "null".
+                // (After node.put(part, null), calling getConfigPropertyAsText will return "null".)
                 if (value == null) {
                     node.remove(part);
                 } else {

--- a/src/main/java/com/conveyal/datatools/manager/DataManager.java
+++ b/src/main/java/com/conveyal/datatools/manager/DataManager.java
@@ -3,7 +3,6 @@ package com.conveyal.datatools.manager;
 import com.conveyal.datatools.common.utils.CorsFilter;
 import com.conveyal.datatools.common.utils.RequestSummary;
 import com.conveyal.datatools.common.utils.Scheduler;
-import com.conveyal.datatools.common.utils.aws.S3Utils;
 import com.conveyal.datatools.editor.controllers.EditorLockController;
 import com.conveyal.datatools.editor.controllers.api.EditorControllerImpl;
 import com.conveyal.datatools.editor.controllers.api.SnapshotController;
@@ -455,18 +454,25 @@ public class DataManager {
      * In a test environment allows for overriding a specific config value on the server config object.
      */
     public static void overrideConfigProperty(String name, String value) {
-        String parts[] = name.split("\\.");
+        String[] parts = name.split("\\.");
         ObjectNode node = (ObjectNode) serverConfig;
 
-        //Loop through the dot separated field names to obtain final node and override that node's value.
+        // Loop through the dot separated field names to obtain final node and override that node's value.
         for (int i = 0; i < parts.length; i++) {
+            String part = parts[i];
             if (i < parts.length - 1) {
-                if (!node.has(parts[i])) {
-                    node.set(parts[i], JsonUtil.objectMapper.createObjectNode());
+                if (!node.has(part)) {
+                    node.set(part, JsonUtil.objectMapper.createObjectNode());
                 }
-                node = (ObjectNode) node.get(parts[i]);
+                node = (ObjectNode) node.get(part);
             } else {
-                node.put(parts[i], value);
+                // If a value is null, delete the corresponding node instead of put-ting the node value
+                // (After node.put(part, null), calling getConfigPropertyAsText will return "null".
+                if (value == null) {
+                    node.remove(part);
+                } else {
+                    node.put(part, value);
+                }
             }
         }
     }

--- a/src/main/java/com/conveyal/datatools/manager/controllers/api/DeploymentController.java
+++ b/src/main/java/com/conveyal/datatools/manager/controllers/api/DeploymentController.java
@@ -26,16 +26,13 @@ import org.bson.Document;
 import org.eclipse.jetty.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Uri;
-import software.amazon.awssdk.services.s3.S3Utilities;
 import spark.Request;
 import spark.Response;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -139,9 +136,7 @@ public class DeploymentController {
             region = summaryToDownload.ec2Info == null ? null : summaryToDownload.ec2Info.region;
         }
 
-        Region awsRegion = region != null ? Region.of(region) : Region.AWS_GLOBAL;
-        S3Uri uri = S3Utilities.builder().region(awsRegion).build().parseUri(URI.create(uriString));
-
+        S3Uri uri = S3Utils.makeUri(uriString);
         // Assume the alternative role if needed to download the deploy artifact.
         return S3Utils.downloadObject(
             S3Utils.getS3Client(role, region),

--- a/src/main/java/com/conveyal/datatools/manager/controllers/api/DeploymentController.java
+++ b/src/main/java/com/conveyal/datatools/manager/controllers/api/DeploymentController.java
@@ -34,7 +34,6 @@ import spark.Response;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -44,7 +43,6 @@ import java.util.stream.Collectors;
 
 import static com.conveyal.datatools.common.utils.SparkUtils.logMessageAndHalt;
 import static com.conveyal.datatools.manager.DataManager.isExtensionEnabled;
-import static com.conveyal.datatools.manager.jobs.DeployJob.S3_URI_UTILS;
 import static com.conveyal.datatools.manager.jobs.DeployJob.bundlePrefix;
 import static com.mongodb.client.model.Filters.and;
 import static com.mongodb.client.model.Filters.eq;
@@ -138,10 +136,7 @@ public class DeploymentController {
             role = summaryToDownload.role;
             region = summaryToDownload.ec2Info == null ? null : summaryToDownload.ec2Info.region;
         }
-        /* AWS SDK for Java v2 migration: v2 S3Uri does not URL-encode a String URI.
-           If you relied on this functionality in v1 you must update your code to manually encode the String. */
-        // Response to above: it looks like we are okay without encoding because uriString is set from raw text above.
-        S3Uri uri = S3_URI_UTILS.parseUri(URI.create(uriString));
+        S3Uri uri = S3Utils.makeUri(uriString);
         // Assume the alternative role if needed to download the deploy artifact.
         return S3Utils.downloadObject(
             S3Utils.getS3Client(role, region),
@@ -406,10 +401,7 @@ public class DeploymentController {
                 // Only delete if the file does not exist in the deployment
                 if (!csvUrls.contains(existingCsvUrl)) {
                     try {
-                        /* AWS SDK for Java v2 migration: v2 S3Uri does not URL-encode a String URI.
-                           If you relied on this functionality in v1 you must update your code to manually encode the String. */
-                        // Upgrade note: it doesn't look we rely on encoding. We are building a URI to reference an entry in an S3 bucket.
-                        S3Uri s3URIToDelete = S3_URI_UTILS.parseUri(URI.create(existingCsvUrl));
+                        S3Uri s3URIToDelete = S3Utils.makeUri(existingCsvUrl);
                         S3Utils.getDefaultS3Client().deleteObject(DeleteObjectRequest.builder().bucket(s3URIToDelete.bucket().orElse(null)).key(s3URIToDelete.key().orElse(null))
                             .build());
                     } catch(Exception e) {

--- a/src/main/java/com/conveyal/datatools/manager/controllers/api/DeploymentController.java
+++ b/src/main/java/com/conveyal/datatools/manager/controllers/api/DeploymentController.java
@@ -26,13 +26,16 @@ import org.bson.Document;
 import org.eclipse.jetty.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Uri;
+import software.amazon.awssdk.services.s3.S3Utilities;
 import spark.Request;
 import spark.Response;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -135,10 +138,14 @@ public class DeploymentController {
             role = summaryToDownload.role;
             region = summaryToDownload.ec2Info == null ? null : summaryToDownload.ec2Info.region;
         }
-        S3Uri uri = S3Utils.makeUri(uriString);
+
+        Region awsRegion = region != null ? Region.of(region) : Region.AWS_GLOBAL;
+        S3Uri uri = S3Utilities.builder().region(awsRegion).build().parseUri(URI.create(uriString));
+
         // Assume the alternative role if needed to download the deploy artifact.
         return S3Utils.downloadObject(
             S3Utils.getS3Client(role, region),
+            region,
             uri.bucket().orElse(null),
             String.join("/", uri.key().orElse(null), filename),
             false,

--- a/src/main/java/com/conveyal/datatools/manager/controllers/api/DeploymentController.java
+++ b/src/main/java/com/conveyal/datatools/manager/controllers/api/DeploymentController.java
@@ -27,7 +27,6 @@ import org.eclipse.jetty.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.s3.S3Uri;
-import software.amazon.awssdk.services.s3.S3Utilities;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import spark.Request;
 import spark.Response;
@@ -45,6 +44,7 @@ import java.util.stream.Collectors;
 
 import static com.conveyal.datatools.common.utils.SparkUtils.logMessageAndHalt;
 import static com.conveyal.datatools.manager.DataManager.isExtensionEnabled;
+import static com.conveyal.datatools.manager.jobs.DeployJob.S3_URI_UTILS;
 import static com.conveyal.datatools.manager.jobs.DeployJob.bundlePrefix;
 import static com.mongodb.client.model.Filters.and;
 import static com.mongodb.client.model.Filters.eq;
@@ -141,7 +141,7 @@ public class DeploymentController {
         /* AWS SDK for Java v2 migration: v2 S3Uri does not URL-encode a String URI.
            If you relied on this functionality in v1 you must update your code to manually encode the String. */
         // Response to above: it looks like we are okay without encoding because uriString is set from raw text above.
-        S3Uri uri = S3Utilities.builder().build().parseUri(URI.create(uriString));
+        S3Uri uri = S3_URI_UTILS.parseUri(URI.create(uriString));
         // Assume the alternative role if needed to download the deploy artifact.
         return S3Utils.downloadObject(
             S3Utils.getS3Client(role, region),
@@ -409,7 +409,7 @@ public class DeploymentController {
                         /* AWS SDK for Java v2 migration: v2 S3Uri does not URL-encode a String URI.
                            If you relied on this functionality in v1 you must update your code to manually encode the String. */
                         // Upgrade note: it doesn't look we rely on encoding. We are building a URI to reference an entry in an S3 bucket.
-                        S3Uri s3URIToDelete = S3Utilities.builder().build().parseUri(URI.create(existingCsvUrl));
+                        S3Uri s3URIToDelete = S3_URI_UTILS.parseUri(URI.create(existingCsvUrl));
                         S3Utils.getDefaultS3Client().deleteObject(DeleteObjectRequest.builder().bucket(s3URIToDelete.bucket().orElse(null)).key(s3URIToDelete.key().orElse(null))
                             .build());
                     } catch(Exception e) {

--- a/src/main/java/com/conveyal/datatools/manager/controllers/api/DeploymentController.java
+++ b/src/main/java/com/conveyal/datatools/manager/controllers/api/DeploymentController.java
@@ -27,7 +27,6 @@ import org.eclipse.jetty.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.s3.S3Uri;
-import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import spark.Request;
 import spark.Response;
 
@@ -402,8 +401,11 @@ public class DeploymentController {
                 if (!csvUrls.contains(existingCsvUrl)) {
                     try {
                         S3Uri s3URIToDelete = S3Utils.makeUri(existingCsvUrl);
-                        S3Utils.getDefaultS3Client().deleteObject(DeleteObjectRequest.builder().bucket(s3URIToDelete.bucket().orElse(null)).key(s3URIToDelete.key().orElse(null))
-                            .build());
+                        S3Utils.getDefaultS3Client().deleteObject(
+                            delete -> delete
+                                .bucket(s3URIToDelete.bucket().orElse(null))
+                                .key(s3URIToDelete.key().orElse(null))
+                        );
                     } catch(Exception e) {
                         logMessageAndHalt(req, 500, "Failed to delete file from S3.", e);
                     }

--- a/src/main/java/com/conveyal/datatools/manager/controllers/api/DeploymentController.java
+++ b/src/main/java/com/conveyal/datatools/manager/controllers/api/DeploymentController.java
@@ -1,7 +1,5 @@
 package com.conveyal.datatools.manager.controllers.api;
 
-import com.amazonaws.services.s3.AmazonS3URI;
-import com.amazonaws.services.s3.model.DeleteObjectRequest;
 import com.conveyal.datatools.common.status.MonitorableJob;
 import com.conveyal.datatools.common.utils.SparkUtils;
 import com.conveyal.datatools.common.utils.aws.CheckedAWSException;
@@ -28,12 +26,16 @@ import org.bson.Document;
 import org.eclipse.jetty.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.s3.S3Uri;
+import software.amazon.awssdk.services.s3.S3Utilities;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import spark.Request;
 import spark.Response;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -136,12 +138,15 @@ public class DeploymentController {
             role = summaryToDownload.role;
             region = summaryToDownload.ec2Info == null ? null : summaryToDownload.ec2Info.region;
         }
-        AmazonS3URI uri = new AmazonS3URI(uriString);
+        /* AWS SDK for Java v2 migration: v2 S3Uri does not URL-encode a String URI.
+           If you relied on this functionality in v1 you must update your code to manually encode the String. */
+        // Response to above: it looks like we are okay without encoding because uriString is set from raw text above.
+        S3Uri uri = S3Utilities.builder().build().parseUri(URI.create(uriString));
         // Assume the alternative role if needed to download the deploy artifact.
         return S3Utils.downloadObject(
             S3Utils.getS3Client(role, region),
-            uri.getBucket(),
-            String.join("/", uri.getKey(), filename),
+            uri.bucket().orElse(null),
+            String.join("/", uri.key().orElse(null), filename),
             false,
             req,
             res
@@ -401,8 +406,12 @@ public class DeploymentController {
                 // Only delete if the file does not exist in the deployment
                 if (!csvUrls.contains(existingCsvUrl)) {
                     try {
-                        AmazonS3URI s3URIToDelete = new AmazonS3URI(existingCsvUrl);
-                        S3Utils.getDefaultS3Client().deleteObject(new DeleteObjectRequest(s3URIToDelete.getBucket(), s3URIToDelete.getKey()));
+                        /* AWS SDK for Java v2 migration: v2 S3Uri does not URL-encode a String URI.
+                           If you relied on this functionality in v1 you must update your code to manually encode the String. */
+                        // Upgrade note: it doesn't look we rely on encoding. We are building a URI to reference an entry in an S3 bucket.
+                        S3Uri s3URIToDelete = S3Utilities.builder().build().parseUri(URI.create(existingCsvUrl));
+                        S3Utils.getDefaultS3Client().deleteObject(DeleteObjectRequest.builder().bucket(s3URIToDelete.bucket().orElse(null)).key(s3URIToDelete.key().orElse(null))
+                            .build());
                     } catch(Exception e) {
                         logMessageAndHalt(req, 500, "Failed to delete file from S3.", e);
                     }
@@ -445,7 +454,7 @@ public class DeploymentController {
                 logMessageAndHalt(req, HttpStatus.UNAUTHORIZED_401, "It is not permitted to terminate an instance that is not associated with deployment " + deployment.id);
                 return false;
             }
-            int code = instances.get(instanceIdsForDeployment.indexOf(id)).state.getCode();
+            int code = instances.get(instanceIdsForDeployment.indexOf(id)).state.code();
             // 48 indicates instance is terminated, 32 indicates shutting down. Prohibit terminating an already
             if (code == 48 || code == 32) {
                 logMessageAndHalt(req, 400, "Instance is already terminated/shutting down: " + id);

--- a/src/main/java/com/conveyal/datatools/manager/controllers/api/DeploymentController.java
+++ b/src/main/java/com/conveyal/datatools/manager/controllers/api/DeploymentController.java
@@ -117,7 +117,7 @@ public class DeploymentController {
             // See if there is an ongoing job for the provided jobId.
             MonitorableJob job = JobUtils.getJobByJobId(jobId);
             if (job instanceof DeployJob) {
-                uriString = ((DeployJob) job).getS3FolderURI().toString();
+                uriString = ((DeployJob) job).getRawS3URI();
             } else {
                 // Try to construct the URI string
                 OtpServer server = Persistence.servers.getById(deployment.deployedTo);

--- a/src/main/java/com/conveyal/datatools/manager/controllers/api/DeploymentController.java
+++ b/src/main/java/com/conveyal/datatools/manager/controllers/api/DeploymentController.java
@@ -454,7 +454,7 @@ public class DeploymentController {
                 logMessageAndHalt(req, HttpStatus.UNAUTHORIZED_401, "It is not permitted to terminate an instance that is not associated with deployment " + deployment.id);
                 return false;
             }
-            int code = instances.get(instanceIdsForDeployment.indexOf(id)).state.code();
+            int code = instances.get(instanceIdsForDeployment.indexOf(id)).state.getCode();
             // 48 indicates instance is terminated, 32 indicates shutting down. Prohibit terminating an already
             if (code == 48 || code == 32) {
                 logMessageAndHalt(req, 400, "Instance is already terminated/shutting down: " + id);

--- a/src/main/java/com/conveyal/datatools/manager/controllers/api/FeedSourceController.java
+++ b/src/main/java/com/conveyal/datatools/manager/controllers/api/FeedSourceController.java
@@ -27,6 +27,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.eclipse.jetty.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import spark.Request;
 import spark.Response;
 
@@ -232,7 +233,8 @@ public class FeedSourceController {
         // If feed just changed from public to private, delete feed from public repo if it's present there.
         if (formerFeedSource.isPublic && !updatedFeedSource.isPublic) {
             LOG.info("Deleting {} as feed is being adjusted from public to private.", updatedFeedSource.toPublicKey());
-            S3Utils.getDefaultS3Client().deleteObject(S3Utils.DEFAULT_BUCKET, updatedFeedSource.toPublicKey());
+            S3Utils.getDefaultS3Client().deleteObject(DeleteObjectRequest.builder().bucket(S3Utils.DEFAULT_BUCKET).key(updatedFeedSource.toPublicKey())
+                .build());
         }
 
         if (shouldNotifyUsersOnFeedUpdated(formerFeedSource, updatedFeedSource)) {

--- a/src/main/java/com/conveyal/datatools/manager/controllers/api/FeedSourceController.java
+++ b/src/main/java/com/conveyal/datatools/manager/controllers/api/FeedSourceController.java
@@ -27,7 +27,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.eclipse.jetty.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import spark.Request;
 import spark.Response;
 
@@ -233,8 +232,11 @@ public class FeedSourceController {
         // If feed just changed from public to private, delete feed from public repo if it's present there.
         if (formerFeedSource.isPublic && !updatedFeedSource.isPublic) {
             LOG.info("Deleting {} as feed is being adjusted from public to private.", updatedFeedSource.toPublicKey());
-            S3Utils.getDefaultS3Client().deleteObject(DeleteObjectRequest.builder().bucket(S3Utils.DEFAULT_BUCKET).key(updatedFeedSource.toPublicKey())
-                .build());
+            S3Utils.getDefaultS3Client().deleteObject(
+                delete -> delete
+                    .bucket(S3Utils.DEFAULT_BUCKET)
+                    .key(updatedFeedSource.toPublicKey())
+            );
         }
 
         if (shouldNotifyUsersOnFeedUpdated(formerFeedSource, updatedFeedSource)) {

--- a/src/main/java/com/conveyal/datatools/manager/controllers/api/ServerController.java
+++ b/src/main/java/com/conveyal/datatools/manager/controllers/api/ServerController.java
@@ -1,8 +1,5 @@
 package com.conveyal.datatools.manager.controllers.api;
 
-import com.amazonaws.AmazonServiceException;
-import com.amazonaws.services.ec2.AmazonEC2;
-import com.amazonaws.services.ec2.model.Instance;
 import com.conveyal.datatools.common.utils.aws.CheckedAWSException;
 import com.conveyal.datatools.common.utils.aws.EC2Utils;
 import com.conveyal.datatools.common.utils.aws.EC2ValidationResult;
@@ -18,6 +15,9 @@ import org.apache.commons.lang3.StringUtils;
 import org.eclipse.jetty.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.services.ec2.Ec2Client;
+import software.amazon.awssdk.services.ec2.model.Instance;
 import spark.HaltException;
 import spark.Request;
 import spark.Response;
@@ -25,7 +25,6 @@ import spark.Response;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 
 import static com.conveyal.datatools.common.utils.SparkUtils.getPOJOFromRequestBody;
@@ -68,7 +67,7 @@ public class ServerController {
         OtpServer server = getServerWithPermissions(req);
         // Ensure that there are no active EC2 instances associated with server. Halt deletion if so.
         List<Instance> activeInstances = server.retrieveEC2Instances().stream()
-            .filter(instance -> "running".equals(instance.getState().getName()))
+            .filter(instance -> "running".equals(instance.state().nameAsString()))
             .collect(Collectors.toList());
         if (activeInstances.size() > 0) {
             logMessageAndHalt(
@@ -87,9 +86,9 @@ public class ServerController {
         List<Instance> instances = server.retrieveEC2Instances();
         List<String> ids = EC2Utils.getIds(instances);
         try {
-            AmazonEC2 ec2Client = server.getEC2Client();
+            Ec2Client ec2Client = server.getEC2Client();
             EC2Utils.terminateInstances(ec2Client, ids);
-        } catch (AmazonServiceException | CheckedAWSException e) {
+        } catch (AwsServiceException | CheckedAWSException e) {
             logMessageAndHalt(req, 500, "Failed to terminate instances!", e);
         }
         for (Deployment deployment : Deployment.retrieveDeploymentForServerAndRouterId(server.id, null)) {

--- a/src/main/java/com/conveyal/datatools/manager/extensions/mtc/MtcFeedResource.java
+++ b/src/main/java/com/conveyal/datatools/manager/extensions/mtc/MtcFeedResource.java
@@ -1,8 +1,5 @@
 package com.conveyal.datatools.manager.extensions.mtc;
 
-import com.amazonaws.AmazonServiceException;
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.conveyal.datatools.common.utils.CloseableHttpURLConnection;
 import com.conveyal.datatools.common.utils.aws.CheckedAWSException;
 import com.conveyal.datatools.common.utils.aws.S3Utils;
@@ -17,6 +14,10 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -193,7 +194,7 @@ public class MtcFeedResource implements ExternalFeedResource {
     public void feedVersionCreated(
         FeedVersion feedVersion,
         String authHeader
-    ) throws AmazonServiceException, CheckedAWSException {
+    ) throws AwsServiceException, CheckedAWSException {
 
         if(s3Bucket == null) {
             LOG.error("Cannot push {} to S3 bucket. No bucket name specified.", feedVersion.id);
@@ -218,7 +219,8 @@ public class MtcFeedResource implements ExternalFeedResource {
         LOG.info("Pushing to MTC S3 Bucket: s3://{}/{}", s3Bucket, keyName);
         File file = feedVersion.retrieveGtfsFile();
         try {
-            getS3Client().putObject(new PutObjectRequest(s3Bucket, keyName, file));
+            getS3Client().putObject(PutObjectRequest.builder().bucket(s3Bucket).key(keyName)
+                .build(), RequestBody.fromFile(file));
         } catch (Exception e) {
             LOG.error("Could not upload feed version to s3.");
             e.printStackTrace();
@@ -376,7 +378,7 @@ public class MtcFeedResource implements ExternalFeedResource {
      * Note: In S3Utils, an AWSClientManager is used, however in practice, only the default client is invoked
      * (i.e. with role=null, region=null), so the logical path returns the original s3Client, which we are doing here.
      */
-    public static AmazonS3 getS3Client() {
+    public static S3Client getS3Client() {
         if (s3Wrapper == null) {
             s3Wrapper = getS3Wrapper();
         }

--- a/src/main/java/com/conveyal/datatools/manager/extensions/mtc/MtcFeedResource.java
+++ b/src/main/java/com/conveyal/datatools/manager/extensions/mtc/MtcFeedResource.java
@@ -17,7 +17,6 @@ import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -219,8 +218,7 @@ public class MtcFeedResource implements ExternalFeedResource {
         LOG.info("Pushing to MTC S3 Bucket: s3://{}/{}", s3Bucket, keyName);
         File file = feedVersion.retrieveGtfsFile();
         try {
-            getS3Client().putObject(PutObjectRequest.builder().bucket(s3Bucket).key(keyName)
-                .build(), RequestBody.fromFile(file));
+            getS3Client().putObject(req -> req.bucket(s3Bucket).key(keyName), RequestBody.fromFile(file));
         } catch (Exception e) {
             LOG.error("Could not upload feed version to s3.");
             e.printStackTrace();

--- a/src/main/java/com/conveyal/datatools/manager/jobs/DeployJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/DeployJob.java
@@ -1,28 +1,5 @@
 package com.conveyal.datatools.manager.jobs;
 
-import com.amazonaws.event.ProgressListener;
-import com.amazonaws.services.ec2.AmazonEC2;
-import com.amazonaws.services.ec2.model.CreateTagsRequest;
-import com.amazonaws.services.ec2.model.DescribeInstanceStatusRequest;
-import com.amazonaws.services.ec2.model.Filter;
-import com.amazonaws.services.ec2.model.IamInstanceProfileSpecification;
-import com.amazonaws.services.ec2.model.Instance;
-import com.amazonaws.services.ec2.model.InstanceMetadataOptionsRequest;
-import com.amazonaws.services.ec2.model.InstanceNetworkInterfaceSpecification;
-import com.amazonaws.services.ec2.model.InstanceStateChange;
-import com.amazonaws.services.ec2.model.InstanceType;
-import com.amazonaws.services.ec2.model.RunInstancesRequest;
-import com.amazonaws.services.ec2.model.Tag;
-import com.amazonaws.services.ec2.model.TerminateInstancesResult;
-import com.amazonaws.services.elasticloadbalancingv2.AmazonElasticLoadBalancing;
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.AmazonS3URI;
-import com.amazonaws.services.s3.model.CopyObjectRequest;
-import com.amazonaws.services.s3.transfer.TransferManager;
-import com.amazonaws.services.s3.transfer.TransferManagerBuilder;
-import com.amazonaws.services.s3.transfer.Upload;
-import com.amazonaws.waiters.Waiter;
-import com.amazonaws.waiters.WaiterParameters;
 import com.conveyal.datatools.common.status.MonitorableJob;
 import com.conveyal.datatools.common.utils.CloseableHttpURLConnection;
 import com.conveyal.datatools.common.utils.aws.CheckedAWSException;
@@ -53,6 +30,20 @@ import org.bson.codecs.pojo.annotations.BsonIgnore;
 import org.eclipse.jetty.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.ec2.Ec2Client;
+import software.amazon.awssdk.services.ec2.model.*;
+import software.amazon.awssdk.services.ec2.waiters.Ec2Waiter;
+import software.amazon.awssdk.services.elasticloadbalancingv2.ElasticLoadBalancingV2Client;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Uri;
+import software.amazon.awssdk.services.s3.S3Utilities;
+import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.transfer.s3.S3TransferManager;
+import software.amazon.awssdk.transfer.s3.model.UploadFileRequest;
+import software.amazon.awssdk.transfer.s3.progress.TransferListener;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -63,6 +54,7 @@ import java.io.InputStream;
 import java.io.Serializable;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.nio.channels.Channels;
 import java.nio.channels.FileChannel;
@@ -425,7 +417,7 @@ public class DeployJob extends MonitorableJob {
      * that a client is obtained that has a session that eventually expires.
      */
     @JsonIgnore
-    public AmazonEC2 getEC2ClientForDeployJob() throws CheckedAWSException {
+    public Ec2Client getEC2ClientForDeployJob() throws CheckedAWSException {
         return EC2Utils.getEC2Client(otpServer.role, customRegion);
     }
 
@@ -435,7 +427,7 @@ public class DeployJob extends MonitorableJob {
      * that a client is obtained that has a session that eventually expires.
      */
     @JsonIgnore
-    public AmazonElasticLoadBalancing getELBClientForDeployJob() throws CheckedAWSException {
+    public ElasticLoadBalancingV2Client getELBClientForDeployJob() throws CheckedAWSException {
         return EC2Utils.getELBClient(otpServer.role, customRegion);
     }
 
@@ -445,54 +437,90 @@ public class DeployJob extends MonitorableJob {
      * that a client is obtained that has a session that eventually expires.
      */
     @JsonIgnore
-    public AmazonS3 getS3ClientForDeployJob() throws CheckedAWSException {
+    public S3Client getS3ClientForDeployJob() throws CheckedAWSException {
         return S3Utils.getS3Client(otpServer.role, customRegion);
+    }
+
+    /**
+     * Similar to above, but creating a async client instead.
+     */
+    @JsonIgnore
+    public S3AsyncClient getS3AsyncClientForDeployJob() throws CheckedAWSException {
+        return S3Utils.getS3AsyncClient(otpServer.role, customRegion);
     }
 
     /**
      * Upload to S3 the transit data bundle zip that contains GTFS zip files, OSM data, and config files.
      */
     private void uploadBundleToS3() throws InterruptedException, IOException, CheckedAWSException {
-        AmazonS3URI uri = new AmazonS3URI(getS3BundleURI());
-        String bucket = uri.getBucket();
+        S3Uri uri = /*AWS SDK for Java v2 migration: v2 S3Uri does not URL-encode a String URI. If you relied on this functionality in v1 you must update your code to manually encode the String.*/S3Utilities.builder().build().parseUri(URI.create(getS3BundleURI()));
+        String bucket = uri.bucket().orElse(null);
         status.message = "Uploading bundle to " + getS3BundleURI();
         status.uploadingS3 = true;
-        LOG.info("Uploading deployment {} to {}", deployment.name, uri.toString());
-        // Use Transfer Manager so we can monitor S3 bundle upload progress.
-        TransferManager transferManager = TransferManagerBuilder
-            .standard()
-            .withS3Client(getS3ClientForDeployJob())
-            .build();
-        final Upload uploadBundle = transferManager.upload(bucket, uri.getKey(), deploymentTempFile);
-        uploadBundle.addProgressListener(
-            (ProgressListener) progressEvent -> status.percentUploaded = uploadBundle.getProgress().getPercentTransferred()
-        );
-        uploadBundle.waitForCompletion();
-        // Check if router config exists and upload as separate file using transfer manager. Note: this is because we
-        // need the router-config separately from the bundle for EC2 instances that download the graph only.
-        byte[] routerConfigAsBytes = deployment.generateRouterConfig();
-        if (routerConfigAsBytes != null) {
-            LOG.info("Uploading router-config.json to s3 bucket");
-            // Write router config to temp file.
-            File routerConfigFile = File.createTempFile("router-config", ".json");
-            try (FileOutputStream out = new FileOutputStream(routerConfigFile)) {
-                out.write(routerConfigAsBytes);
+        LOG.info("Uploading deployment {} to {}", deployment.name, uri);
+
+        TransferListener transferListener = new TransferListener() {
+            @Override
+            public void bytesTransferred(Context.BytesTransferred context) {
+                status.percentUploaded = context.progressSnapshot().ratioTransferred().orElse(0);
             }
-            // Upload router config.
-            transferManager
-                .upload(bucket, getS3FolderURI().getKey() + "/" + ROUTER_CONFIG_FILENAME, routerConfigFile)
-                .waitForCompletion();
-            // Delete temp file.
-            routerConfigFile.delete();
+
+            @Override
+            public void transferComplete(Context.TransferComplete context) {
+                // Equivalent to ProgressEventType.TRANSFER_COMPLETED_EVENT
+                System.out.println("Transfer completed");
+            }
+
+            @Override
+            public void transferFailed(Context.TransferFailed context) {
+                // Equivalent to ProgressEventType.TRANSFER_FAILED_EVENT
+                System.out.println("Transfer failed: " + context.exception().getMessage());
+            }
+        };
+
+        UploadFileRequest bundleUploadRequest = UploadFileRequest
+            .builder()
+            .putObjectRequest(req -> req.bucket(bucket).key(uri.key().orElse(null)))
+            .source(deploymentTempFile)
+            .addTransferListener(transferListener)
+            .build();
+
+        // Use Transfer Manager so we can monitor S3 bundle upload progress.
+        S3TransferManager transferManager = S3TransferManager.builder()
+            .s3Client(getS3AsyncClientForDeployJob())
+            .build();
+        try (transferManager) {
+            // Wait for transfer completion.
+            transferManager.uploadFile(bundleUploadRequest).completionFuture().join();
+
+            // Check if router config exists and upload as separate file using transfer manager. Note: this is because we
+            // need the router-config separately from the bundle for EC2 instances that download the graph only.
+            byte[] routerConfigAsBytes = deployment.generateRouterConfig();
+            if (routerConfigAsBytes != null) {
+                LOG.info("Uploading router-config.json to s3 bucket");
+                // Write router config to temp file.
+                File routerConfigFile = File.createTempFile("router-config", ".json");
+                try (FileOutputStream out = new FileOutputStream(routerConfigFile)) {
+                    out.write(routerConfigAsBytes);
+                }
+                UploadFileRequest routerConfigUploadRequest = UploadFileRequest
+                    .builder()
+                    .putObjectRequest(req -> req.bucket(bucket).key(getS3FolderURI().key().orElse(null) + "/" + ROUTER_CONFIG_FILENAME))
+                    .source(routerConfigFile)
+                    // no transfer listener for router config upload, it is a small file.
+                    .build();
+
+                // Upload router config (wait for transfer completion).
+                transferManager.uploadFile(routerConfigUploadRequest).completionFuture().join();
+                // Delete temp file.
+                routerConfigFile.delete();
+            }
         }
-        // Shutdown the Transfer Manager, but don't shut down the underlying S3 client.
-        // The default behavior for shutdownNow shut's down the underlying s3 client
-        // which will cause any following s3 operations to fail.
-        transferManager.shutdownNow(false);
 
         // copy to [name]-latest.zip
         String copyKey = getLatestS3BundleKey();
-        CopyObjectRequest copyObjRequest = new CopyObjectRequest(bucket, uri.getKey(), uri.getBucket(), copyKey);
+        CopyObjectRequest copyObjRequest = CopyObjectRequest.builder().sourceBucket(bucket).sourceKey(uri.key().orElse(null)).destinationBucket(uri.bucket().orElse(null)).destinationKey(copyKey)
+            .build();
         getS3ClientForDeployJob().copyObject(copyObjRequest);
         LOG.info("Copied to s3://{}/{}", bucket, copyKey);
         LOG.info("Uploaded to {}", getS3BundleURI());
@@ -846,7 +874,7 @@ public class DeployJob extends MonitorableJob {
                     numFailedInstances++;
                     String id = job.getInstanceId();
                     LOG.warn("Error encountered while monitoring server {}. Terminating.", id);
-                    remainingInstances.removeIf(instance -> instance.getInstanceId().equals(id));
+                    remainingInstances.removeIf(instance -> instance.instanceId().equals(id));
                     try {
                         // terminate instance without failing overall deploy job. That happens later.
                         EC2Utils.terminateInstances(getEC2ClientForDeployJob(), id);
@@ -867,7 +895,7 @@ public class DeployJob extends MonitorableJob {
             } else {
                 // Deregister and terminate previous EC2 servers running that were associated with this server.
                 if (deployType.equals(DeployType.REPLACE)) {
-                    List<String> previousInstanceIds = previousInstances.stream().filter(instance -> "running".equals(instance.state.getName()))
+                    List<String> previousInstanceIds = previousInstances.stream().filter(instance -> "running".equals(instance.state.name()))
                         .map(instance -> instance.instanceId).collect(Collectors.toList());
                     // If there were previous instances assigned to the server, deregister/terminate them (now that the new
                     // instances are up and running).
@@ -944,11 +972,12 @@ public class DeployJob extends MonitorableJob {
         // The subnet ID should only change if starting up a server in some other AWS account. This is not
         // likely to be a requirement.
         // Define network interface so that a public IP can be associated with server.
-        InstanceNetworkInterfaceSpecification interfaceSpecification = new InstanceNetworkInterfaceSpecification()
-                .withSubnetId(otpServer.ec2Info.subnetId)
-                .withAssociatePublicIpAddress(true)
-                .withGroups(otpServer.ec2Info.securityGroupId)
-                .withDeviceIndex(0);
+        InstanceNetworkInterfaceSpecification interfaceSpecification = InstanceNetworkInterfaceSpecification.builder()
+            .subnetId(otpServer.ec2Info.subnetId)
+            .associatePublicIpAddress(true)
+            .groups(otpServer.ec2Info.securityGroupId)
+            .deviceIndex(0)
+            .build();
         // Pick proper ami depending on whether graph is being built and what is defined.
         String amiId = otpServer.ec2Info.getAmiId(graphAlreadyBuilt);
         // Verify that AMI is correctly defined.
@@ -988,28 +1017,31 @@ public class DeployJob extends MonitorableJob {
         }
         status.message = String.format("Starting up %d new instance(s) to run OTP", count);
 
-        RunInstancesRequest runInstancesRequest = new RunInstancesRequest()
-                .withNetworkInterfaces(interfaceSpecification)
-                .withInstanceType(instanceType)
-                // TODO: Optimize for EBS to support large systems like NYSDOT.
-                //  This may incur additional costs and may need to be replaced with some other setting
-                //  if it is proves too expensive. However, it may be the easiest way to resolve the
-                //  issue where downloading a graph larger than 3GB slows to a halt.
-                .withEbsOptimized(EBS_OPTIMIZED)
-                .withMinCount(count)
-                .withMaxCount(count)
-                .withIamInstanceProfile(new IamInstanceProfileSpecification().withArn(otpServer.ec2Info.iamInstanceProfileArn))
-                .withImageId(amiId)
-                .withKeyName(otpServer.ec2Info.keyName)
-                // This will have the instance terminate when it is shut down.
-                .withInstanceInitiatedShutdownBehavior("terminate")
-                .withMetadataOptions(new InstanceMetadataOptionsRequest().withHttpTokens("optional").withHttpEndpoint("enabled"))
-                .withUserData(Base64.encodeBase64String(userData.getBytes()));
+        RunInstancesRequest runInstancesRequest = RunInstancesRequest.builder()
+            .networkInterfaces(interfaceSpecification)
+            .instanceType(instanceType)
+            // TODO: Optimize for EBS to support large systems like NYSDOT.
+            //  This may incur additional costs and may need to be replaced with some other setting
+            //  if it is proves too expensive. However, it may be the easiest way to resolve the
+            //  issue where downloading a graph larger than 3GB slows to a halt.
+            .ebsOptimized(EBS_OPTIMIZED)
+            .minCount(count)
+            .maxCount(count)
+            .iamInstanceProfile(IamInstanceProfileSpecification.builder().arn(otpServer.ec2Info.iamInstanceProfileArn)
+                .build())
+            .imageId(amiId)
+            .keyName(otpServer.ec2Info.keyName)
+            // This will have the instance terminate when it is shut down.
+            .instanceInitiatedShutdownBehavior("terminate")
+            .metadataOptions(InstanceMetadataOptionsRequest.builder().httpTokens("optional").httpEndpoint("enabled")
+                .build())
+            .userData(Base64.encodeBase64String(userData.getBytes()))
+            .build();
         List<Instance> instances;
         try {
             // attempt to start the instances. Sometimes, AWS does not have enough availability of the desired instance
             // type and can throw an error at this point.
-            instances = getEC2ClientForDeployJob().runInstances(runInstancesRequest).getReservation().getInstances();
+            instances = getEC2ClientForDeployJob().runInstances(runInstancesRequest).instances();
         } catch (Exception e) {
             status.fail(String.format("DeployJob failed due to a problem with AWS: %s", e.getMessage()), e);
             return Collections.EMPTY_LIST;
@@ -1019,39 +1051,37 @@ public class DeployJob extends MonitorableJob {
         List<String> instanceIds = EC2Utils.getIds(instances);
         Set<String> instanceIpAddresses = new HashSet<>();
         // Wait so that create tags request does not fail because instances not found.
-        try {
-            Waiter<DescribeInstanceStatusRequest> waiter = getEC2ClientForDeployJob().waiters().instanceStatusOk();
+        try (Ec2Waiter waiter = getEC2ClientForDeployJob().waiter()) {
             long beginWaiting = System.currentTimeMillis();
-            waiter.run(new WaiterParameters<>(new DescribeInstanceStatusRequest().withInstanceIds(instanceIds)));
+            waiter.waitUntilInstanceStatusOk(req -> req.instanceIds(instanceIds));
             LOG.info("Instance status is OK after {} ms", (System.currentTimeMillis() - beginWaiting));
         } catch (Exception e) {
             status.fail("Waiter for instance status check failed. You may need to terminate the failed instances.", e);
             return Collections.EMPTY_LIST;
         }
+
+        String tagKey = DataManager.getConfigPropertyAsText("modules.deployment.ec2.tag_key");
+        String tagValue = DataManager.getConfigPropertyAsText("modules.deployment.ec2.tag_value");
         for (Instance instance : instances) {
             // Note: The public IP addresses will likely be null at this point because they take a few seconds to
             // initialize.
             String serverName = String.format("%s %s (%s) %d %s", deployment.tripPlannerVersion, deployment.name, dateString, serverCounter++, graphAlreadyBuilt ? "clone" : "builder");
             LOG.info("Creating tags for new EC2 instance {}", serverName);
             try {
-                CreateTagsRequest createTagsRequest = new CreateTagsRequest()
-                        .withTags(new Tag("Name", serverName))
-                        .withTags(new Tag("projectId", deployment.projectId))
-                        .withTags(new Tag("deploymentId", deployment.id))
-                        .withTags(new Tag("jobId", this.jobId))
-                        .withTags(new Tag("serverId", otpServer.id))
-                        .withTags(new Tag("routerId", getRouterId()))
-                        .withTags(new Tag("user", retrieveEmail()))
-                        .withResources(instance.getInstanceId());
+                CreateTagsRequest createTagsRequest = CreateTagsRequest.builder()
+                    .tags(
+                        Tag.builder().key("Name").value(serverName).build(),
+                        Tag.builder().key("projectId").value(deployment.projectId).build(),
+                        Tag.builder().key("deploymentId").value(deployment.id).build(),
+                        Tag.builder().key("jobId").value(this.jobId).build(),
+                        Tag.builder().key("serverId").value(otpServer.id).build(),
+                        Tag.builder().key("routerId").value(getRouterId()).build(),
+                        Tag.builder().key("user").value(retrieveEmail()).build(),
+                        Tag.builder().key(tagKey).value(tagValue).build()
+                    )
+                    .resources(instance.instanceId())
+                    .build();
 
-                String tagKey = DataManager.getConfigPropertyAsText("modules.deployment.ec2.tag_key");
-                String tagValue = DataManager.getConfigPropertyAsText("modules.deployment.ec2.tag_value");
-
-                Tag customTag = new Tag();
-                customTag.setKey(tagKey);
-                customTag.setValue(tagValue);
-
-                createTagsRequest = createTagsRequest.withTags(customTag);
                 getEC2ClientForDeployJob().createTags(createTagsRequest);
             } catch (Exception e) {
                 status.fail("Failed to create tags for instances.", e);
@@ -1062,7 +1092,7 @@ public class DeployJob extends MonitorableJob {
         TimeTracker ipCheckTracker = new TimeTracker(10, TimeUnit.MINUTES);
         // Store the instances with updated IP addresses here.
         List<Instance> updatedInstances = new ArrayList<>();
-        Filter instanceIdFilter = new Filter("instance-id", instanceIds);
+        Filter instanceIdFilter = Filter.builder().name("instance-id").values(instanceIds).build();
         // While all of the IPs have not been established, keep checking the EC2 instances, waiting a few seconds between
         // each check.
         String ipCheckMessage = "Checking that public IP address(es) have initialized for EC2 instance(s).";
@@ -1084,7 +1114,7 @@ public class DeployJob extends MonitorableJob {
                 return updatedInstances;
             }
             for (Instance instance : instancesWithIps) {
-                String publicIp = instance.getPublicIpAddress();
+                String publicIp = instance.publicIpAddress();
                 // If IP has been found, store the updated instance and IP.
                 if (publicIp != null) {
                     instanceIpAddresses.add(publicIp);
@@ -1114,7 +1144,7 @@ public class DeployJob extends MonitorableJob {
      * an error and adds to the status message as needed.
      */
     private boolean terminateInstances(List<Instance> instances) {
-        TerminateInstancesResult terminateInstancesResult;
+        TerminateInstancesResponse terminateInstancesResult;
         try {
             terminateInstancesResult = EC2Utils.terminateInstances(getEC2ClientForDeployJob(), instances);
         } catch (Exception e) {
@@ -1127,13 +1157,13 @@ public class DeployJob extends MonitorableJob {
 
         // verify that all instances have terminated
         boolean allInstancesTerminatedProperly = true;
-        for (InstanceStateChange terminatingInstance : terminateInstancesResult.getTerminatingInstances()) {
+        for (InstanceStateChange terminatingInstance : terminateInstancesResult.terminatingInstances()) {
             // instance state code == 32 means the instance is preparing to be terminated.
             // instance state code == 48 means it has been terminated.
-            int instanceStateCode = terminatingInstance.getCurrentState().getCode();
+            int instanceStateCode = terminatingInstance.currentState().code();
             if (instanceStateCode != 32 && instanceStateCode != 48) {
                 failJobWithAppendedMessage(
-                    String.format("Instance %s failed to properly terminate!", terminatingInstance.getInstanceId())
+                    String.format("Instance %s failed to properly terminate!", terminatingInstance.instanceId())
                 );
                 allInstancesTerminatedProperly = false;
             }
@@ -1426,7 +1456,8 @@ public class DeployJob extends MonitorableJob {
         if (dryRun) return true;
         status.message = String.format("uploading %s to S3", filename);
         try {
-            getS3ClientForDeployJob().putObject(s3Bucket, String.format("%s/%s", jobRelativePath, filename), contents);
+            getS3ClientForDeployJob().putObject(PutObjectRequest.builder().bucket(s3Bucket).key(String.format("%s/%s", jobRelativePath, filename))
+                .build(), RequestBody.fromString(contents));
         } catch (Exception e) {
             status.fail(String.format("Failed to upload file %s", filename), e);
             return false;
@@ -1500,8 +1531,15 @@ public class DeployJob extends MonitorableJob {
     }
 
     @JsonIgnore
-    public AmazonS3URI getS3FolderURI() {
-        return new AmazonS3URI(String.format("s3://%s/%s", otpServer.s3Bucket, getJobRelativePath()));
+    public S3Uri getS3FolderURI() {
+        /* AWS SDK for Java v2 migration: v2 S3Uri does not URL-encode a String URI.
+           If you relied on this functionality in v1 you must update your code to manually encode the String. */
+        return S3Utilities.builder().build().parseUri(URI.create(getRawS3URI()));
+    }
+
+    @JsonIgnore
+   public String getRawS3URI() {
+        return String.format("s3://%s/%s", otpServer.s3Bucket, getJobRelativePath());
     }
 
     @JsonIgnore

--- a/src/main/java/com/conveyal/datatools/manager/jobs/DeployJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/DeployJob.java
@@ -484,7 +484,7 @@ public class DeployJob extends MonitorableJob {
             }
 
             S3Utils.uploadAndWaitForCompletion(upload -> upload
-                .putObjectRequest(req -> req.bucket(bucket).key(getS3FolderURI().key().orElse(null) + "/" + ROUTER_CONFIG_FILENAME))
+                .putObjectRequest(req -> req.bucket(bucket).key(getJobRelativePath() + "/" + ROUTER_CONFIG_FILENAME))
                 .source(routerConfigFile)
                 // no transfer listener for router config upload, it is a small file.
             );
@@ -1508,11 +1508,6 @@ public class DeployJob extends MonitorableJob {
     @JsonIgnore
     public String getJobRelativePath() {
         return jobRelativePath;
-    }
-
-    @JsonIgnore
-    public S3Uri getS3FolderURI() {
-        return S3Utils.makeUri(getRawS3URI());
     }
 
     @JsonIgnore

--- a/src/main/java/com/conveyal/datatools/manager/jobs/DeployJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/DeployJob.java
@@ -31,15 +31,20 @@ import org.eclipse.jetty.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.core.sync.RequestBody;
-import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.ec2.Ec2Client;
-import software.amazon.awssdk.services.ec2.model.*;
+import software.amazon.awssdk.services.ec2.model.CreateTagsRequest;
+import software.amazon.awssdk.services.ec2.model.Filter;
+import software.amazon.awssdk.services.ec2.model.Instance;
+import software.amazon.awssdk.services.ec2.model.InstanceNetworkInterfaceSpecification;
+import software.amazon.awssdk.services.ec2.model.InstanceStateChange;
+import software.amazon.awssdk.services.ec2.model.InstanceType;
+import software.amazon.awssdk.services.ec2.model.RunInstancesRequest;
+import software.amazon.awssdk.services.ec2.model.Tag;
+import software.amazon.awssdk.services.ec2.model.TerminateInstancesResponse;
 import software.amazon.awssdk.services.ec2.waiters.Ec2Waiter;
 import software.amazon.awssdk.services.elasticloadbalancingv2.ElasticLoadBalancingV2Client;
-import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3Uri;
-import software.amazon.awssdk.services.s3.S3Utilities;
 import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.transfer.s3.progress.TransferListener;
@@ -53,7 +58,6 @@ import java.io.InputStream;
 import java.io.Serializable;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
-import java.net.URI;
 import java.net.URL;
 import java.nio.channels.Channels;
 import java.nio.channels.FileChannel;
@@ -107,7 +111,6 @@ public class DeployJob extends MonitorableJob {
      * status files can be created. This is that directory.
      */
     private static final String EC2_WEB_DIR = "/usr/share/nginx/client";
-    public static final S3Utilities S3_URI_UTILS = S3Utilities.builder().region(Region.AWS_GLOBAL).build();
 
     /**
      * S3 bucket to upload deployment to. If not null, uses {@link OtpServer#s3Bucket}. Otherwise, defaults to 
@@ -445,10 +448,10 @@ public class DeployJob extends MonitorableJob {
      * Upload to S3 the transit data bundle zip that contains GTFS zip files, OSM data, and config files.
      */
     private void uploadBundleToS3() throws IOException, CheckedAWSException {
-        S3Uri uri = /*AWS SDK for Java v2 migration: v2 S3Uri does not URL-encode a String URI. If you relied on this functionality in v1 you must update your code to manually encode the String.*/
-            S3_URI_UTILS.parseUri(URI.create(getS3BundleURI()));
+        String bundleURI = getS3BundleURI();
+        S3Uri uri = S3Utils.makeUri(bundleURI);
         String bucket = uri.bucket().orElse(null);
-        status.message = "Uploading bundle to " + getS3BundleURI();
+        status.message = "Uploading bundle to " + bundleURI;
         status.uploadingS3 = true;
         LOG.info("Uploading deployment {} to {}", deployment.name, uri);
 
@@ -498,7 +501,7 @@ public class DeployJob extends MonitorableJob {
             .build();
         getS3ClientForDeployJob().copyObject(copyObjRequest);
         LOG.info("Copied to s3://{}/{}", bucket, copyKey);
-        LOG.info("Uploaded to {}", getS3BundleURI());
+        LOG.info("Uploaded to {}", bundleURI);
         status.update("Upload to S3 complete.", status.percentComplete + 10);
         status.uploadingS3 = false;
     }
@@ -1505,9 +1508,7 @@ public class DeployJob extends MonitorableJob {
 
     @JsonIgnore
     public S3Uri getS3FolderURI() {
-        /* AWS SDK for Java v2 migration: v2 S3Uri does not URL-encode a String URI.
-           If you relied on this functionality in v1 you must update your code to manually encode the String. */
-        return S3_URI_UTILS.parseUri(URI.create(getRawS3URI()));
+        return S3Utils.makeUri(getRawS3URI());
     }
 
     @JsonIgnore

--- a/src/main/java/com/conveyal/datatools/manager/jobs/DeployJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/DeployJob.java
@@ -878,7 +878,7 @@ public class DeployJob extends MonitorableJob {
             } else {
                 // Deregister and terminate previous EC2 servers running that were associated with this server.
                 if (deployType.equals(DeployType.REPLACE)) {
-                    List<String> previousInstanceIds = previousInstances.stream().filter(instance -> "running".equals(instance.state.name()))
+                    List<String> previousInstanceIds = previousInstances.stream().filter(instance -> "running".equals(instance.state.getName()))
                         .map(instance -> instance.instanceId).collect(Collectors.toList());
                     // If there were previous instances assigned to the server, deregister/terminate them (now that the new
                     // instances are up and running).

--- a/src/main/java/com/conveyal/datatools/manager/jobs/DeployJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/DeployJob.java
@@ -31,6 +31,7 @@ import org.eclipse.jetty.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.awssdk.services.ec2.model.*;
 import software.amazon.awssdk.services.ec2.waiters.Ec2Waiter;
@@ -106,6 +107,7 @@ public class DeployJob extends MonitorableJob {
      * status files can be created. This is that directory.
      */
     private static final String EC2_WEB_DIR = "/usr/share/nginx/client";
+    public static final S3Utilities S3_URI_UTILS = S3Utilities.builder().region(Region.AWS_GLOBAL).build();
 
     /**
      * S3 bucket to upload deployment to. If not null, uses {@link OtpServer#s3Bucket}. Otherwise, defaults to 
@@ -451,7 +453,8 @@ public class DeployJob extends MonitorableJob {
      * Upload to S3 the transit data bundle zip that contains GTFS zip files, OSM data, and config files.
      */
     private void uploadBundleToS3() throws IOException, CheckedAWSException {
-        S3Uri uri = /*AWS SDK for Java v2 migration: v2 S3Uri does not URL-encode a String URI. If you relied on this functionality in v1 you must update your code to manually encode the String.*/S3Utilities.builder().build().parseUri(URI.create(getS3BundleURI()));
+        S3Uri uri = /*AWS SDK for Java v2 migration: v2 S3Uri does not URL-encode a String URI. If you relied on this functionality in v1 you must update your code to manually encode the String.*/
+            S3_URI_UTILS.parseUri(URI.create(getS3BundleURI()));
         String bucket = uri.bucket().orElse(null);
         status.message = "Uploading bundle to " + getS3BundleURI();
         status.uploadingS3 = true;
@@ -1512,7 +1515,7 @@ public class DeployJob extends MonitorableJob {
     public S3Uri getS3FolderURI() {
         /* AWS SDK for Java v2 migration: v2 S3Uri does not URL-encode a String URI.
            If you relied on this functionality in v1 you must update your code to manually encode the String. */
-        return S3Utilities.builder().build().parseUri(URI.create(getRawS3URI()));
+        return S3_URI_UTILS.parseUri(URI.create(getRawS3URI()));
     }
 
     @JsonIgnore

--- a/src/main/java/com/conveyal/datatools/manager/jobs/DeployJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/DeployJob.java
@@ -41,8 +41,6 @@ import software.amazon.awssdk.services.s3.S3Uri;
 import software.amazon.awssdk.services.s3.S3Utilities;
 import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
-import software.amazon.awssdk.transfer.s3.S3TransferManager;
-import software.amazon.awssdk.transfer.s3.model.UploadFileRequest;
 import software.amazon.awssdk.transfer.s3.progress.TransferListener;
 
 import java.io.File;
@@ -452,7 +450,7 @@ public class DeployJob extends MonitorableJob {
     /**
      * Upload to S3 the transit data bundle zip that contains GTFS zip files, OSM data, and config files.
      */
-    private void uploadBundleToS3() throws InterruptedException, IOException, CheckedAWSException {
+    private void uploadBundleToS3() throws IOException, CheckedAWSException {
         S3Uri uri = /*AWS SDK for Java v2 migration: v2 S3Uri does not URL-encode a String URI. If you relied on this functionality in v1 you must update your code to manually encode the String.*/S3Utilities.builder().build().parseUri(URI.create(getS3BundleURI()));
         String bucket = uri.bucket().orElse(null);
         status.message = "Uploading bundle to " + getS3BundleURI();
@@ -466,55 +464,37 @@ public class DeployJob extends MonitorableJob {
             }
 
             @Override
-            public void transferComplete(Context.TransferComplete context) {
-                // Equivalent to ProgressEventType.TRANSFER_COMPLETED_EVENT
-                System.out.println("Transfer completed");
-            }
-
-            @Override
             public void transferFailed(Context.TransferFailed context) {
-                // Equivalent to ProgressEventType.TRANSFER_FAILED_EVENT
-                System.out.println("Transfer failed: " + context.exception().getMessage());
+                var exception = context.exception();
+                status.fail(exception.getMessage(), new Exception(exception));
             }
         };
 
-        UploadFileRequest bundleUploadRequest = UploadFileRequest
-            .builder()
+        S3Utils.uploadAndWaitForCompletion(upload -> upload
             .putObjectRequest(req -> req.bucket(bucket).key(uri.key().orElse(null)))
             .source(deploymentTempFile)
             .addTransferListener(transferListener)
-            .build();
-
-        // Use Transfer Manager so we can monitor S3 bundle upload progress.
-        S3TransferManager transferManager = S3TransferManager.builder()
-            .s3Client(getS3AsyncClientForDeployJob())
-            .build();
-        try (transferManager) {
-            // Wait for transfer completion.
-            transferManager.uploadFile(bundleUploadRequest).completionFuture().join();
-
-            // Check if router config exists and upload as separate file using transfer manager. Note: this is because we
-            // need the router-config separately from the bundle for EC2 instances that download the graph only.
-            byte[] routerConfigAsBytes = deployment.generateRouterConfig();
-            if (routerConfigAsBytes != null) {
-                LOG.info("Uploading router-config.json to s3 bucket");
-                // Write router config to temp file.
-                File routerConfigFile = File.createTempFile("router-config", ".json");
-                try (FileOutputStream out = new FileOutputStream(routerConfigFile)) {
-                    out.write(routerConfigAsBytes);
-                }
-                UploadFileRequest routerConfigUploadRequest = UploadFileRequest
-                    .builder()
-                    .putObjectRequest(req -> req.bucket(bucket).key(getS3FolderURI().key().orElse(null) + "/" + ROUTER_CONFIG_FILENAME))
-                    .source(routerConfigFile)
-                    // no transfer listener for router config upload, it is a small file.
-                    .build();
-
-                // Upload router config (wait for transfer completion).
-                transferManager.uploadFile(routerConfigUploadRequest).completionFuture().join();
-                // Delete temp file.
-                routerConfigFile.delete();
+        );
+        
+        // Check if router config exists and upload as separate file using transfer manager. Note: this is because we
+        // need the router-config separately from the bundle for EC2 instances that download the graph only.
+        byte[] routerConfigAsBytes = deployment.generateRouterConfig();
+        if (routerConfigAsBytes != null) {
+            LOG.info("Uploading router-config.json to s3 bucket");
+            // Write router config to temp file.
+            File routerConfigFile = File.createTempFile("router-config", ".json");
+            try (FileOutputStream out = new FileOutputStream(routerConfigFile)) {
+                out.write(routerConfigAsBytes);
             }
+
+            S3Utils.uploadAndWaitForCompletion(upload -> upload
+                .putObjectRequest(req -> req.bucket(bucket).key(getS3FolderURI().key().orElse(null) + "/" + ROUTER_CONFIG_FILENAME))
+                .source(routerConfigFile)
+                // no transfer listener for router config upload, it is a small file.
+            );
+
+            // Delete temp file.
+            routerConfigFile.delete();
         }
 
         // copy to [name]-latest.zip
@@ -967,7 +947,7 @@ public class DeployJob extends MonitorableJob {
         if (userData == null) {
             // Fail job if it is not already failed.
             if (!status.error) status.fail("Error constructing EC2 user data.");
-            return Collections.EMPTY_LIST;
+            return Collections.emptyList();
         }
         // The subnet ID should only change if starting up a server in some other AWS account. This is not
         // likely to be a requirement.
@@ -999,7 +979,7 @@ public class DeployJob extends MonitorableJob {
                 ),
                 amiCheckException
             );
-            return Collections.EMPTY_LIST;
+            return Collections.emptyList();
         }
 
         // Pick proper instance type depending on whether graph is being built and what is defined.
@@ -1013,7 +993,7 @@ public class DeployJob extends MonitorableJob {
                 instanceType,
                 EC2Utils.DEFAULT_INSTANCE_TYPE
             ), e);
-            return Collections.EMPTY_LIST;
+            return Collections.emptyList();
         }
         status.message = String.format("Starting up %d new instance(s) to run OTP", count);
 
@@ -1027,14 +1007,12 @@ public class DeployJob extends MonitorableJob {
             .ebsOptimized(EBS_OPTIMIZED)
             .minCount(count)
             .maxCount(count)
-            .iamInstanceProfile(IamInstanceProfileSpecification.builder().arn(otpServer.ec2Info.iamInstanceProfileArn)
-                .build())
+            .iamInstanceProfile(profile -> profile.arn(otpServer.ec2Info.iamInstanceProfileArn))
             .imageId(amiId)
             .keyName(otpServer.ec2Info.keyName)
             // This will have the instance terminate when it is shut down.
             .instanceInitiatedShutdownBehavior("terminate")
-            .metadataOptions(InstanceMetadataOptionsRequest.builder().httpTokens("optional").httpEndpoint("enabled")
-                .build())
+            .metadataOptions(req -> req.httpTokens("optional").httpEndpoint("enabled"))
             .userData(Base64.encodeBase64String(userData.getBytes()))
             .build();
         List<Instance> instances;
@@ -1044,7 +1022,7 @@ public class DeployJob extends MonitorableJob {
             instances = getEC2ClientForDeployJob().runInstances(runInstancesRequest).instances();
         } catch (Exception e) {
             status.fail(String.format("DeployJob failed due to a problem with AWS: %s", e.getMessage()), e);
-            return Collections.EMPTY_LIST;
+            return Collections.emptyList();
         }
 
         status.message = "Waiting for instance(s) to start";
@@ -1057,7 +1035,7 @@ public class DeployJob extends MonitorableJob {
             LOG.info("Instance status is OK after {} ms", (System.currentTimeMillis() - beginWaiting));
         } catch (Exception e) {
             status.fail("Waiter for instance status check failed. You may need to terminate the failed instances.", e);
-            return Collections.EMPTY_LIST;
+            return Collections.emptyList();
         }
 
         String tagKey = DataManager.getConfigPropertyAsText("modules.deployment.ec2.tag_key");

--- a/src/main/java/com/conveyal/datatools/manager/jobs/DeployJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/DeployJob.java
@@ -45,8 +45,6 @@ import software.amazon.awssdk.services.ec2.waiters.Ec2Waiter;
 import software.amazon.awssdk.services.elasticloadbalancingv2.ElasticLoadBalancingV2Client;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3Uri;
-import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
-import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.transfer.s3.progress.TransferListener;
 
 import java.io.File;

--- a/src/main/java/com/conveyal/datatools/manager/jobs/DeployJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/DeployJob.java
@@ -497,9 +497,13 @@ public class DeployJob extends MonitorableJob {
 
         // copy to [name]-latest.zip
         String copyKey = getLatestS3BundleKey();
-        CopyObjectRequest copyObjRequest = CopyObjectRequest.builder().sourceBucket(bucket).sourceKey(uri.key().orElse(null)).destinationBucket(uri.bucket().orElse(null)).destinationKey(copyKey)
-            .build();
-        getS3ClientForDeployJob().copyObject(copyObjRequest);
+        getS3ClientForDeployJob().copyObject(
+            req -> req
+                .sourceBucket(bucket)
+                .sourceKey(uri.key().orElse(null))
+                .destinationBucket(uri.bucket().orElse(null))
+                .destinationKey(copyKey)
+        );
         LOG.info("Copied to s3://{}/{}", bucket, copyKey);
         LOG.info("Uploaded to {}", bundleURI);
         status.update("Upload to S3 complete.", status.percentComplete + 10);
@@ -1432,8 +1436,10 @@ public class DeployJob extends MonitorableJob {
         if (dryRun) return true;
         status.message = String.format("uploading %s to S3", filename);
         try {
-            getS3ClientForDeployJob().putObject(PutObjectRequest.builder().bucket(s3Bucket).key(String.format("%s/%s", jobRelativePath, filename))
-                .build(), RequestBody.fromString(contents));
+            getS3ClientForDeployJob().putObject(
+                req -> req.bucket(s3Bucket).key(String.format("%s/%s", jobRelativePath, filename)),
+                RequestBody.fromString(contents)
+            );
         } catch (Exception e) {
             status.fail(String.format("Failed to upload file %s", filename), e);
             return false;

--- a/src/main/java/com/conveyal/datatools/manager/jobs/DeployJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/DeployJob.java
@@ -1204,7 +1204,7 @@ public class DeployJob extends MonitorableJob {
             : "1.x";
         manifest.prefixLogUploadsWithInstanceId = true;
         manifest.serverStartupTimeoutSeconds = 3300;
-        manifest.s3UploadPath = getS3FolderURI().toString();
+        manifest.s3UploadPath = getS3FolderURI().uri().toString();
         manifest.statusFileLocation = String.format("%s/%s", EC2_WEB_DIR, OTP_RUNNER_STATUS_FILE);
         manifest.uploadOtpRunnerLogs = true;
         // add settings applicable to current instance. Two different manifest files are generated when deploying with
@@ -1524,7 +1524,7 @@ public class DeployJob extends MonitorableJob {
     /** Join list of paths to S3 URI for job folder to create a fully qualified URI (e.g., s3://bucket/path/to/file). */
     private String joinToS3FolderUri(CharSequence... paths) {
         List<CharSequence> pathList = new ArrayList<>();
-        pathList.add(getS3FolderURI().toString());
+        pathList.add(getS3FolderURI().uri().toString());
         pathList.addAll(Arrays.asList(paths));
         return String.join("/", pathList);
     }

--- a/src/main/java/com/conveyal/datatools/manager/jobs/DeployJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/DeployJob.java
@@ -1204,7 +1204,7 @@ public class DeployJob extends MonitorableJob {
             : "1.x";
         manifest.prefixLogUploadsWithInstanceId = true;
         manifest.serverStartupTimeoutSeconds = 3300;
-        manifest.s3UploadPath = getS3FolderURI().uri().toString();
+        manifest.s3UploadPath = getRawS3URI();
         manifest.statusFileLocation = String.format("%s/%s", EC2_WEB_DIR, OTP_RUNNER_STATUS_FILE);
         manifest.uploadOtpRunnerLogs = true;
         // add settings applicable to current instance. Two different manifest files are generated when deploying with
@@ -1524,7 +1524,7 @@ public class DeployJob extends MonitorableJob {
     /** Join list of paths to S3 URI for job folder to create a fully qualified URI (e.g., s3://bucket/path/to/file). */
     private String joinToS3FolderUri(CharSequence... paths) {
         List<CharSequence> pathList = new ArrayList<>();
-        pathList.add(getS3FolderURI().uri().toString());
+        pathList.add(getRawS3URI());
         pathList.addAll(Arrays.asList(paths));
         return String.join("/", pathList);
     }
@@ -1592,7 +1592,7 @@ public class DeployJob extends MonitorableJob {
             this.role = job.otpServer.role;
             this.s3Bucket = job.s3Bucket;
             this.status = job.status;
-            this.buildArtifactsFolder = job.getS3FolderURI().toString();
+            this.buildArtifactsFolder = job.getRawS3URI();
         }
     }
 

--- a/src/main/java/com/conveyal/datatools/manager/jobs/DeployJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/DeployJob.java
@@ -442,14 +442,6 @@ public class DeployJob extends MonitorableJob {
     }
 
     /**
-     * Similar to above, but creating a async client instead.
-     */
-    @JsonIgnore
-    public S3AsyncClient getS3AsyncClientForDeployJob() throws CheckedAWSException {
-        return S3Utils.getS3AsyncClient(otpServer.role, customRegion);
-    }
-
-    /**
      * Upload to S3 the transit data bundle zip that contains GTFS zip files, OSM data, and config files.
      */
     private void uploadBundleToS3() throws IOException, CheckedAWSException {

--- a/src/main/java/com/conveyal/datatools/manager/jobs/FeedUpdater.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/FeedUpdater.java
@@ -1,6 +1,6 @@
 package com.conveyal.datatools.manager.jobs;
 
-import com.conveyal.datatools.common.utils.aws.CheckedAWSException;
+import com.conveyal.datatools.common.utils.aws.S3Utils;
 import com.conveyal.datatools.manager.extensions.mtc.MtcFeedResource;
 import com.conveyal.datatools.manager.models.ExternalFeedSourceProperty;
 import com.conveyal.datatools.manager.models.FeedSource;
@@ -200,8 +200,7 @@ public class FeedUpdater {
 
         LOG.debug(eTagForFeed.toString());
         for (S3Object objSummary : filteredObjectSummaries) {
-            String eTag = /*AWS SDK for Java v2 migration: NOTE: V2's eTag() preserves surrounding quotes in the response, whereas V1's getETag() strips them - https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/migration-s3-client.html#V1s-ObjectMetadata-using-V1s-getETag*/
-                objSummary.eTag().replaceAll("^\"|\"$", "");
+            String eTag = S3Utils.cleanETag(objSummary.eTag());
             String keyName = objSummary.key();
             LOG.debug("{} etag = {}", keyName, eTag);
 

--- a/src/main/java/com/conveyal/datatools/manager/jobs/FeedUpdater.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/FeedUpdater.java
@@ -18,7 +18,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.core.ResponseInputStream;
-import software.amazon.awssdk.services.s3.model.*;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.ListObjectsResponse;
+import software.amazon.awssdk.services.s3.model.S3Object;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -121,7 +123,7 @@ public class FeedUpdater {
     public static List<String> getFeedIds(List<S3Object> s3objects) {
         return s3objects.stream()
             .map(FeedUpdater::getFeedId)
-            .filter(id -> id.length() != 0)
+            .filter(id -> !id.isEmpty())
             .collect(Collectors.toList());
     }
 

--- a/src/main/java/com/conveyal/datatools/manager/jobs/FeedUpdater.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/FeedUpdater.java
@@ -1,9 +1,5 @@
 package com.conveyal.datatools.manager.jobs;
 
-import com.amazonaws.AmazonServiceException;
-import com.amazonaws.services.s3.model.ObjectListing;
-import com.amazonaws.services.s3.model.S3Object;
-import com.amazonaws.services.s3.model.S3ObjectSummary;
 import com.conveyal.datatools.common.utils.aws.CheckedAWSException;
 import com.conveyal.datatools.manager.extensions.mtc.MtcFeedResource;
 import com.conveyal.datatools.manager.models.ExternalFeedSourceProperty;
@@ -20,6 +16,9 @@ import com.mongodb.client.model.Accumulators;
 import org.bson.conversions.Bson;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.services.s3.model.*;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -114,12 +113,12 @@ public class FeedUpdater {
         return new FeedUpdater(completedFeedRetriever);
     }
 
-    private static String getFeedId(S3ObjectSummary objSummary) {
-        String[] parts = objSummary.getKey().split("/");
+    private static String getFeedId(S3Object objSummary) {
+        String[] parts = objSummary.key().split("/");
         return parts.length > 1 ? parts[1].replace(".zip", "") : "";
     }
 
-    public static List<String> getFeedIds(List<S3ObjectSummary> s3objects) {
+    public static List<String> getFeedIds(List<S3Object> s3objects) {
         return s3objects.stream()
             .map(FeedUpdater::getFeedId)
             .filter(id -> id.length() != 0)
@@ -189,10 +188,10 @@ public class FeedUpdater {
         Map<String, String> newTags = new HashMap<>();
         // iterate over feeds in download_prefix folder and register to (MTC project)
         // Note: objectSummaries is at least an empty list (not null).
-        List<S3ObjectSummary> filteredObjectSummaries = completedFeedRetriever
+        List<S3Object> filteredObjectSummaries = completedFeedRetriever
             .retrieveCompletedFeeds()
             // Skip directory objects and empty/null/invalid feed ids
-            .stream().filter(s -> !bucketFolder.equals(s.getKey()) && !"null".equals(getFeedId(s)))
+            .stream().filter(s -> !bucketFolder.equals(s.key()) && !"null".equals(getFeedId(s)))
             .collect(Collectors.toList());
 
         Map<String, FeedSource> allFeedSourcesById = getFeedSourcesByFeedId(filteredObjectSummaries);
@@ -200,9 +199,10 @@ public class FeedUpdater {
         Map<String, FeedVersionSummary> latestSentVersionsByFeedSourceId = getLatestVersionsSentForPublishing(allFeedSourcesById.values());
 
         LOG.debug(eTagForFeed.toString());
-        for (S3ObjectSummary objSummary : filteredObjectSummaries) {
-            String eTag = objSummary.getETag();
-            String keyName = objSummary.getKey();
+        for (S3Object objSummary : filteredObjectSummaries) {
+            String eTag = /*AWS SDK for Java v2 migration: NOTE: V2's eTag() preserves surrounding quotes in the response, whereas V1's getETag() strips them - https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/migration-s3-client.html#V1s-ObjectMetadata-using-V1s-getETag*/
+                objSummary.eTag().replaceAll("^\"|\"$", "");
+            String keyName = objSummary.key();
             LOG.debug("{} etag = {}", keyName, eTag);
 
             String feedId = getFeedId(objSummary);
@@ -216,7 +216,7 @@ public class FeedUpdater {
             if (shouldMarkFeedAsProcessed(eTag, latestVersionSentForPublishing)) {
                 try {
                     // Don't mark a feed version as published if previous published version is before sentToExternalPublisher.
-                    if (!objSummary.getLastModified().before(latestVersionSentForPublishing.sentToExternalPublisher)) {
+                    if (!objSummary.lastModified().isBefore(latestVersionSentForPublishing.sentToExternalPublisher.toInstant())) {
                         LOG.info("New version found for {} at s3://{}/{}. ETag = {}.", feedId, feedBucket, keyName, eTag);
                         updatePublishedFeedVersion(feedId, feedSource.name, latestVersionSentForPublishing);
                         // TODO: Explore if MD5 checksum can be used to find matching feed version.
@@ -238,7 +238,7 @@ public class FeedUpdater {
         return newTags;
     }
 
-    private static Map<String, FeedSource> getFeedSourcesByFeedId(List<S3ObjectSummary> objectSummaries) {
+    private static Map<String, FeedSource> getFeedSourcesByFeedId(List<S3Object> objectSummaries) {
         // Single Mongo query to get external properties for all feeds reported in S3.
         List<ExternalFeedSourceProperty> allProperties = Persistence.externalFeedSourceProperties.getFiltered(
             and(eq("name", AGENCY_ID_FIELDNAME), in("value", getFeedIds(objectSummaries)))
@@ -379,13 +379,14 @@ public class FeedUpdater {
     private FeedVersion findMatchingFeedVersion(
         String keyName,
         FeedSource feedSource
-    ) throws AmazonServiceException, IOException, CheckedAWSException {
+    ) throws AwsServiceException, IOException, CheckedAWSException {
         String filename = keyName.split("/")[1];
         String feedId = filename.replace(".zip", "");
-        S3Object object = MtcFeedResource.getS3Client().getObject(feedBucket, keyName);
+        ResponseInputStream<GetObjectResponse> object = MtcFeedResource.getS3Client().getObject(GetObjectRequest.builder().bucket(feedBucket).key(keyName)
+            .build());
         File file = new File(FeedStore.basePath, filename);
         try (
-            InputStream in = object.getObjectContent();
+            InputStream in = object;
             OutputStream out = new FileOutputStream(file);
         ) {
             ByteStreams.copy(in, out);
@@ -418,7 +419,7 @@ public class FeedUpdater {
      * Helper interface for fetching a list of feeds deemed production-complete.
      */
     public interface CompletedFeedRetriever {
-        List<S3ObjectSummary> retrieveCompletedFeeds();
+        List<S3Object> retrieveCompletedFeeds();
     }
 
     /**
@@ -428,9 +429,11 @@ public class FeedUpdater {
      */
     public class DefaultCompletedFeedRetriever implements CompletedFeedRetriever {
         @Override
-        public List<S3ObjectSummary> retrieveCompletedFeeds() {
-            ObjectListing gtfsList = MtcFeedResource.getS3Client().listObjects(feedBucket, bucketFolder);
-            return gtfsList.getObjectSummaries();
+        public List<S3Object> retrieveCompletedFeeds() {
+            ListObjectsResponse gtfsList = MtcFeedResource.getS3Client().listObjects(
+                ListObjectsRequest.builder().bucket(feedBucket).prefix(bucketFolder).build()
+            );
+            return gtfsList.contents();
         }
     }
 }

--- a/src/main/java/com/conveyal/datatools/manager/jobs/FeedUpdater.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/FeedUpdater.java
@@ -378,11 +378,12 @@ public class FeedUpdater {
     private FeedVersion findMatchingFeedVersion(
         String keyName,
         FeedSource feedSource
-    ) throws AwsServiceException, IOException, CheckedAWSException {
+    ) throws AwsServiceException, IOException {
         String filename = keyName.split("/")[1];
         String feedId = filename.replace(".zip", "");
-        ResponseInputStream<GetObjectResponse> object = MtcFeedResource.getS3Client().getObject(GetObjectRequest.builder().bucket(feedBucket).key(keyName)
-            .build());
+        ResponseInputStream<GetObjectResponse> object = MtcFeedResource.getS3Client().getObject(
+            req -> req.bucket(feedBucket).key(keyName)
+        );
         File file = new File(FeedStore.basePath, filename);
         try (
             InputStream in = object;
@@ -430,7 +431,7 @@ public class FeedUpdater {
         @Override
         public List<S3Object> retrieveCompletedFeeds() {
             ListObjectsResponse gtfsList = MtcFeedResource.getS3Client().listObjects(
-                ListObjectsRequest.builder().bucket(feedBucket).prefix(bucketFolder).build()
+                list -> list.bucket(feedBucket).prefix(bucketFolder)
             );
             return gtfsList.contents();
         }

--- a/src/main/java/com/conveyal/datatools/manager/jobs/MergeFeedsJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/MergeFeedsJob.java
@@ -27,7 +27,6 @@ import org.bson.codecs.pojo.annotations.BsonIgnore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.core.sync.RequestBody;
-import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -328,8 +327,10 @@ public class MergeFeedsJob extends FeedSourceJob {
             if (DataManager.useS3) {
                 String s3Key = String.join("/", "project", filename);
                 try {
-                    S3Utils.getDefaultS3Client().putObject(PutObjectRequest.builder().bucket(S3Utils.DEFAULT_BUCKET).key(s3Key)
-                        .build(), RequestBody.fromFile(mergedTempFile));
+                    S3Utils.getDefaultS3Client().putObject(
+                        req -> req.bucket(S3Utils.DEFAULT_BUCKET).key(s3Key),
+                        RequestBody.fromFile(mergedTempFile)
+                    );
                 } catch (CheckedAWSException e) {
                     String message = "Could not upload store merged feed for new version";
                     logAndReportToBugsnag(e, message);

--- a/src/main/java/com/conveyal/datatools/manager/jobs/MergeFeedsJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/MergeFeedsJob.java
@@ -26,6 +26,8 @@ import com.google.common.collect.Lists;
 import org.bson.codecs.pojo.annotations.BsonIgnore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -326,7 +328,8 @@ public class MergeFeedsJob extends FeedSourceJob {
             if (DataManager.useS3) {
                 String s3Key = String.join("/", "project", filename);
                 try {
-                    S3Utils.getDefaultS3Client().putObject(S3Utils.DEFAULT_BUCKET, s3Key, mergedTempFile);
+                    S3Utils.getDefaultS3Client().putObject(PutObjectRequest.builder().bucket(S3Utils.DEFAULT_BUCKET).key(s3Key)
+                        .build(), RequestBody.fromFile(mergedTempFile));
                 } catch (CheckedAWSException e) {
                     String message = "Could not upload store merged feed for new version";
                     logAndReportToBugsnag(e, message);

--- a/src/main/java/com/conveyal/datatools/manager/jobs/MonitorServerStatusJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/MonitorServerStatusJob.java
@@ -18,12 +18,10 @@ import org.apache.http.impl.client.HttpClients;
 import org.apache.http.util.EntityUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import software.amazon.awssdk.services.ec2.model.DescribeInstancesRequest;
 import software.amazon.awssdk.services.ec2.model.DescribeInstancesResponse;
 import software.amazon.awssdk.services.ec2.model.Instance;
 import software.amazon.awssdk.services.ec2.model.Reservation;
 import software.amazon.awssdk.services.elasticloadbalancingv2.ElasticLoadBalancingV2Client;
-import software.amazon.awssdk.services.elasticloadbalancingv2.model.DescribeTargetHealthRequest;
 import software.amazon.awssdk.services.elasticloadbalancingv2.model.DescribeTargetHealthResponse;
 import software.amazon.awssdk.services.elasticloadbalancingv2.model.RegisterTargetsRequest;
 import software.amazon.awssdk.services.elasticloadbalancingv2.model.TargetDescription;
@@ -151,8 +149,7 @@ public class MonitorServerStatusJob extends MonitorableJob {
             // REGISTER INSTANCE WITH LOAD BALANCER
             RegisterTargetsRequest registerTargetsRequest = RegisterTargetsRequest.builder()
                 .targetGroupArn(otpServer.ec2Info.targetGroupArn)
-                .targets(TargetDescription.builder().id(instance.instanceId())
-                    .build())
+                .targets(TargetDescription.builder().id(instance.instanceId()).build())
                 .build();
             boolean targetAddedSuccessfully = false;
             // Wait for two minutes for targets to register.
@@ -166,10 +163,9 @@ public class MonitorServerStatusJob extends MonitorableJob {
                 elbClient.registerTargets(registerTargetsRequest);
                 waitAndCheckInstanceHealth("instance to register with ELB target group");
                 // Check that the instance ID shows up in the health check.
-                DescribeTargetHealthRequest healthRequest = DescribeTargetHealthRequest.builder()
-                    .targetGroupArn(otpServer.ec2Info.targetGroupArn)
-                    .build();
-                DescribeTargetHealthResponse healthResult = elbClient.describeTargetHealth(healthRequest);
+                DescribeTargetHealthResponse healthResult = elbClient.describeTargetHealth(
+                    req -> req.targetGroupArn(otpServer.ec2Info.targetGroupArn)
+                );
                 for (TargetHealthDescription health : healthResult.targetHealthDescriptions()) {
                     if (instance.instanceId().equals(health.target().id())) {
                         LOG.info("Instance {} successfully added to target group!", instance.instanceId());
@@ -255,12 +251,9 @@ public class MonitorServerStatusJob extends MonitorableJob {
      * ${@link MonitorServerStatusJob#MAX_INSTANCE_HEALTH_RETRIES} value.
      */
     private void checkInstanceHealth(int attemptNumber) throws InstanceHealthException, InterruptedException {
-        DescribeInstancesRequest request = DescribeInstancesRequest.builder()
-            .instanceIds(Collections.singletonList(instance.instanceId()))
-            .build();
         DescribeInstancesResponse result;
         try {
-            result = deployJob.getEC2ClientForDeployJob().describeInstances(request);
+            result = deployJob.getEC2ClientForDeployJob().describeInstances(req -> req.instanceIds(instance.instanceId()));
         } catch (Exception e) {
             LOG.warn(
                 "Failed on attempt {}/{} to execute request to obtain instance health!",

--- a/src/main/java/com/conveyal/datatools/manager/jobs/MonitorServerStatusJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/MonitorServerStatusJob.java
@@ -282,7 +282,7 @@ public class MonitorServerStatusJob extends MonitorableJob {
                     // Code 16 is running. Anything above that is either stopped, terminated or about to be stopped or
                     // terminated
                     if (reservationInstance.state().code() > 16) {
-                        throw new InstanceHealthException(reservationInstance.state().name().name());
+                        throw new InstanceHealthException(reservationInstance.state().nameAsString());
                     }
                 }
             }

--- a/src/main/java/com/conveyal/datatools/manager/jobs/MonitorServerStatusJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/MonitorServerStatusJob.java
@@ -213,7 +213,7 @@ public class MonitorServerStatusJob extends MonitorableJob {
      * Gets the expected path to the otp-runner logs that get uploaded to s3
      */
     private String getOtpRunnerLogS3Path() {
-        return String.format("%s/%s-otp-runner.log", deployJob.getS3FolderURI(), instance.instanceId());
+        return String.format("%s/%s-otp-runner.log", deployJob.getRawS3URI(), instance.instanceId());
     }
 
     /**

--- a/src/main/java/com/conveyal/datatools/manager/jobs/MonitorServerStatusJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/MonitorServerStatusJob.java
@@ -1,15 +1,5 @@
 package com.conveyal.datatools.manager.jobs;
 
-import com.amazonaws.services.ec2.model.DescribeInstancesRequest;
-import com.amazonaws.services.ec2.model.DescribeInstancesResult;
-import com.amazonaws.services.ec2.model.Instance;
-import com.amazonaws.services.ec2.model.Reservation;
-import com.amazonaws.services.elasticloadbalancingv2.AmazonElasticLoadBalancing;
-import com.amazonaws.services.elasticloadbalancingv2.model.DescribeTargetHealthRequest;
-import com.amazonaws.services.elasticloadbalancingv2.model.DescribeTargetHealthResult;
-import com.amazonaws.services.elasticloadbalancingv2.model.RegisterTargetsRequest;
-import com.amazonaws.services.elasticloadbalancingv2.model.TargetDescription;
-import com.amazonaws.services.elasticloadbalancingv2.model.TargetHealthDescription;
 import com.conveyal.datatools.common.status.MonitorableJob;
 import com.conveyal.datatools.manager.auth.Auth0UserProfile;
 import com.conveyal.datatools.manager.models.Deployment;
@@ -28,11 +18,19 @@ import org.apache.http.impl.client.HttpClients;
 import org.apache.http.util.EntityUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.ec2.model.DescribeInstancesRequest;
+import software.amazon.awssdk.services.ec2.model.DescribeInstancesResponse;
+import software.amazon.awssdk.services.ec2.model.Instance;
+import software.amazon.awssdk.services.ec2.model.Reservation;
+import software.amazon.awssdk.services.elasticloadbalancingv2.ElasticLoadBalancingV2Client;
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.DescribeTargetHealthRequest;
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.DescribeTargetHealthResponse;
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.RegisterTargetsRequest;
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.TargetDescription;
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.TargetHealthDescription;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static com.conveyal.datatools.manager.jobs.DeployJob.OTP_RUNNER_STATUS_FILE;
@@ -58,7 +56,7 @@ public class MonitorServerStatusJob extends MonitorableJob {
     public MonitorServerStatusJob(Auth0UserProfile owner, DeployJob deployJob, Instance instance, boolean graphAlreadyBuilt) {
         super(
             owner,
-            String.format("Monitor server setup %s", instance.getPublicIpAddress()),
+            String.format("Monitor server setup %s", instance.publicIpAddress()),
             JobType.MONITOR_SERVER_STATUS
         );
         this.deployJob = deployJob;
@@ -71,7 +69,7 @@ public class MonitorServerStatusJob extends MonitorableJob {
 
     @JsonProperty
     public String getInstanceId () {
-        return instance != null ? instance.getInstanceId() : null;
+        return instance != null ? instance.instanceId() : null;
     }
 
     @JsonProperty
@@ -82,7 +80,7 @@ public class MonitorServerStatusJob extends MonitorableJob {
     @Override
     public void jobLogic() {
         // Get OTP URL for instance to check for availability.
-        String ipUrl = "http://" + instance.getPublicIpAddress();
+        String ipUrl = "http://" + instance.publicIpAddress();
         if (otpServer.ec2Info == null || otpServer.ec2Info.targetGroupArn == null) {
             // Fail the job from the outset if there is no target group defined.
             failJob("There is no load balancer under which to register ec2 instance.");
@@ -151,27 +149,30 @@ public class MonitorServerStatusJob extends MonitorableJob {
             status.update("Graph loaded!", 90);
             // After the router is available, the EC2 instance can be registered with the load balancer.
             // REGISTER INSTANCE WITH LOAD BALANCER
-            RegisterTargetsRequest registerTargetsRequest = new RegisterTargetsRequest()
-                .withTargetGroupArn(otpServer.ec2Info.targetGroupArn)
-                .withTargets(new TargetDescription().withId(instance.getInstanceId()));
+            RegisterTargetsRequest registerTargetsRequest = RegisterTargetsRequest.builder()
+                .targetGroupArn(otpServer.ec2Info.targetGroupArn)
+                .targets(TargetDescription.builder().id(instance.instanceId())
+                    .build())
+                .build();
             boolean targetAddedSuccessfully = false;
             // Wait for two minutes for targets to register.
             TimeTracker registerTargetTracker = new TimeTracker(2, TimeUnit.MINUTES);
             // obtain an ELB client suitable for this deploy job. It is important to obtain a client this way to ensure
             // that the proper AWS credentials are used and that the client has a valid session if it is obtained from a
             // role.
-            AmazonElasticLoadBalancing elbClient = deployJob.getELBClientForDeployJob();
+            ElasticLoadBalancingV2Client elbClient = deployJob.getELBClientForDeployJob();
             while (!targetAddedSuccessfully) {
                 // Register target with target group.
                 elbClient.registerTargets(registerTargetsRequest);
                 waitAndCheckInstanceHealth("instance to register with ELB target group");
                 // Check that the instance ID shows up in the health check.
-                DescribeTargetHealthRequest healthRequest = new DescribeTargetHealthRequest()
-                    .withTargetGroupArn(otpServer.ec2Info.targetGroupArn);
-                DescribeTargetHealthResult healthResult = elbClient.describeTargetHealth(healthRequest);
-                for (TargetHealthDescription health : healthResult.getTargetHealthDescriptions()) {
-                    if (instance.getInstanceId().equals(health.getTarget().getId())) {
-                        LOG.info("Instance {} successfully added to target group!", instance.getInstanceId());
+                DescribeTargetHealthRequest healthRequest = DescribeTargetHealthRequest.builder()
+                    .targetGroupArn(otpServer.ec2Info.targetGroupArn)
+                    .build();
+                DescribeTargetHealthResponse healthResult = elbClient.describeTargetHealth(healthRequest);
+                for (TargetHealthDescription health : healthResult.targetHealthDescriptions()) {
+                    if (instance.instanceId().equals(health.target().id())) {
+                        LOG.info("Instance {} successfully added to target group!", instance.instanceId());
                         targetAddedSuccessfully = true;
                     }
                 }
@@ -212,7 +213,7 @@ public class MonitorServerStatusJob extends MonitorableJob {
      * Gets the expected path to the otp-runner logs that get uploaded to s3
      */
     private String getOtpRunnerLogS3Path() {
-        return String.format("%s/%s-otp-runner.log", deployJob.getS3FolderURI(), instance.getInstanceId());
+        return String.format("%s/%s-otp-runner.log", deployJob.getS3FolderURI(), instance.instanceId());
     }
 
     /**
@@ -254,9 +255,10 @@ public class MonitorServerStatusJob extends MonitorableJob {
      * ${@link MonitorServerStatusJob#MAX_INSTANCE_HEALTH_RETRIES} value.
      */
     private void checkInstanceHealth(int attemptNumber) throws InstanceHealthException, InterruptedException {
-        DescribeInstancesRequest request = new DescribeInstancesRequest()
-            .withInstanceIds(Collections.singletonList(instance.getInstanceId()));
-        DescribeInstancesResult result;
+        DescribeInstancesRequest request = DescribeInstancesRequest.builder()
+            .instanceIds(Collections.singletonList(instance.instanceId()))
+            .build();
+        DescribeInstancesResponse result;
         try {
             result = deployJob.getEC2ClientForDeployJob().describeInstances(request);
         } catch (Exception e) {
@@ -274,13 +276,13 @@ public class MonitorServerStatusJob extends MonitorableJob {
             checkInstanceHealth(attemptNumber + 1);
             return;
         }
-        for (Reservation reservation : result.getReservations()) {
-            for (Instance reservationInstance : reservation.getInstances()) {
-                if (reservationInstance.getInstanceId().equals(instance.getInstanceId())) {
+        for (Reservation reservation : result.reservations()) {
+            for (Instance reservationInstance : reservation.instances()) {
+                if (reservationInstance.instanceId().equals(instance.instanceId())) {
                     // Code 16 is running. Anything above that is either stopped, terminated or about to be stopped or
                     // terminated
-                    if (reservationInstance.getState().getCode() > 16) {
-                        throw new InstanceHealthException(reservationInstance.getState().getName());
+                    if (reservationInstance.state().code() > 16) {
+                        throw new InstanceHealthException(reservationInstance.state().name().name());
                     }
                 }
             }

--- a/src/main/java/com/conveyal/datatools/manager/jobs/PeliasUpdateJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/PeliasUpdateJob.java
@@ -12,6 +12,7 @@ import com.conveyal.datatools.manager.utils.json.JsonUtil;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.http.Header;
 import org.apache.http.message.BasicHeader;
+import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Uri;
 import software.amazon.awssdk.services.s3.S3Utilities;
 
@@ -69,7 +70,8 @@ public class PeliasUpdateJob extends MonitorableJob {
         }
 
         // Get log upload URI from deployment (the latest build artifacts folder is where the logs get uploaded to)
-        this.logUploadS3URI = /*AWS SDK for Java v2 migration: v2 S3Uri does not URL-encode a String URI. If you relied on this functionality in v1 you must update your code to manually encode the String.*/S3Utilities.builder().build().parseUri(URI.create(deployment.deployJobSummaries.get(deployment.deployJobSummaries.size() - 1).buildArtifactsFolder));
+        /*AWS SDK for Java v2 migration: v2 S3Uri does not URL-encode a String URI. If you relied on this functionality in v1 you must update your code to manually encode the String.*/
+        this.logUploadS3URI = S3Utilities.builder().region(Region.AWS_GLOBAL).build().parseUri(URI.create(deployment.deployJobSummaries.get(deployment.deployJobSummaries.size() - 1).buildArtifactsFolder));
     }
 
     /**

--- a/src/main/java/com/conveyal/datatools/manager/jobs/PeliasUpdateJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/PeliasUpdateJob.java
@@ -1,12 +1,10 @@
 package com.conveyal.datatools.manager.jobs;
 
-import com.amazonaws.services.s3.AmazonS3URI;
 import com.conveyal.datatools.common.status.MonitorableJob;
 import com.conveyal.datatools.common.utils.aws.S3Utils;
 import com.conveyal.datatools.manager.auth.Auth0UserProfile;
 import com.conveyal.datatools.manager.models.Deployment;
 import com.conveyal.datatools.manager.models.FeedVersion;
-import com.conveyal.datatools.manager.models.OtpServer;
 import com.conveyal.datatools.manager.persistence.Persistence;
 import com.conveyal.datatools.manager.utils.HttpUtils;
 import com.conveyal.datatools.manager.utils.SimpleHttpResponse;
@@ -14,6 +12,8 @@ import com.conveyal.datatools.manager.utils.json.JsonUtil;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.http.Header;
 import org.apache.http.message.BasicHeader;
+import software.amazon.awssdk.services.s3.S3Uri;
+import software.amazon.awssdk.services.s3.S3Utilities;
 
 import java.io.IOException;
 import java.net.URI;
@@ -51,9 +51,9 @@ public class PeliasUpdateJob extends MonitorableJob {
     /**
      * S3 URI to upload logs to
      */
-    private final AmazonS3URI logUploadS3URI;
+    private final S3Uri logUploadS3URI;
 
-    public PeliasUpdateJob(Auth0UserProfile owner, String name, Deployment deployment, AmazonS3URI logUploadS3URI) {
+    public PeliasUpdateJob(Auth0UserProfile owner, String name, Deployment deployment, S3Uri logUploadS3URI) {
         super(owner, name, JobType.UPDATE_PELIAS);
         this.deployment = deployment;
         this.timer = new Timer();
@@ -69,7 +69,7 @@ public class PeliasUpdateJob extends MonitorableJob {
         }
 
         // Get log upload URI from deployment (the latest build artifacts folder is where the logs get uploaded to)
-        this.logUploadS3URI = new AmazonS3URI(deployment.deployJobSummaries.get(deployment.deployJobSummaries.size() - 1).buildArtifactsFolder);
+        this.logUploadS3URI = /*AWS SDK for Java v2 migration: v2 S3Uri does not URL-encode a String URI. If you relied on this functionality in v1 you must update your code to manually encode the String.*/S3Utilities.builder().build().parseUri(URI.create(deployment.deployJobSummaries.get(deployment.deployJobSummaries.size() - 1).buildArtifactsFolder));
     }
 
     /**

--- a/src/main/java/com/conveyal/datatools/manager/jobs/PeliasUpdateJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/PeliasUpdateJob.java
@@ -12,9 +12,7 @@ import com.conveyal.datatools.manager.utils.json.JsonUtil;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.http.Header;
 import org.apache.http.message.BasicHeader;
-import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Uri;
-import software.amazon.awssdk.services.s3.S3Utilities;
 
 import java.io.IOException;
 import java.net.URI;
@@ -70,8 +68,7 @@ public class PeliasUpdateJob extends MonitorableJob {
         }
 
         // Get log upload URI from deployment (the latest build artifacts folder is where the logs get uploaded to)
-        /*AWS SDK for Java v2 migration: v2 S3Uri does not URL-encode a String URI. If you relied on this functionality in v1 you must update your code to manually encode the String.*/
-        this.logUploadS3URI = S3Utilities.builder().region(Region.AWS_GLOBAL).build().parseUri(URI.create(deployment.deployJobSummaries.get(deployment.deployJobSummaries.size() - 1).buildArtifactsFolder));
+        this.logUploadS3URI = S3Utils.makeUri(deployment.deployJobSummaries.get(deployment.deployJobSummaries.size() - 1).buildArtifactsFolder);
     }
 
     /**

--- a/src/main/java/com/conveyal/datatools/manager/jobs/RecreateBuildImageJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/RecreateBuildImageJob.java
@@ -6,7 +6,11 @@ import com.conveyal.datatools.manager.auth.Auth0UserProfile;
 import com.conveyal.datatools.manager.models.OtpServer;
 import com.conveyal.datatools.manager.persistence.Persistence;
 import com.conveyal.datatools.manager.utils.TimeTracker;
-import software.amazon.awssdk.services.ec2.model.*;
+import software.amazon.awssdk.services.ec2.model.CreateImageRequest;
+import software.amazon.awssdk.services.ec2.model.CreateImageResponse;
+import software.amazon.awssdk.services.ec2.model.DescribeImagesResponse;
+import software.amazon.awssdk.services.ec2.model.Image;
+import software.amazon.awssdk.services.ec2.model.Instance;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -61,15 +65,12 @@ public class RecreateBuildImageJob extends MonitorableJob {
         String createdImageId = createImageResult.imageId();
         status.update("Waiting for graph build image to be created...", 25);
         boolean imageCreated = false;
-        DescribeImagesRequest describeImagesRequest = DescribeImagesRequest.builder()
-            .imageIds(createdImageId)
-            .build();
         while (!imageCreated && !status.error) {
             DescribeImagesResponse describeImagesResult = null;
             try {
                 describeImagesResult = parentDeployJob
                     .getEC2ClientForDeployJob()
-                    .describeImages(describeImagesRequest);
+                    .describeImages(req -> req.imageIds(createdImageId));
             } catch (Exception e) {
                 terminateInstanceAndFailWithMessage("Failed to make request to get image creation status!", e);
                 return;
@@ -120,11 +121,8 @@ public class RecreateBuildImageJob extends MonitorableJob {
                 !graphBuildAmiId.equals(otpServer.ec2Info.amiId)
         ) {
             status.message = "Deregistering old build image";
-            DeregisterImageRequest deregisterImageRequest = DeregisterImageRequest.builder()
-                .imageId(graphBuildAmiId)
-                .build();
             try {
-                parentDeployJob.getEC2ClientForDeployJob().deregisterImage(deregisterImageRequest);
+                parentDeployJob.getEC2ClientForDeployJob().deregisterImage(req -> req.imageId(graphBuildAmiId));
             } catch (Exception e) {
                 terminateInstanceAndFailWithMessage("Failed to deregister previous graph building image!", e);
                 return;

--- a/src/main/java/com/conveyal/datatools/manager/jobs/RecreateBuildImageJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/RecreateBuildImageJob.java
@@ -1,19 +1,12 @@
 package com.conveyal.datatools.manager.jobs;
 
-import com.amazonaws.services.ec2.model.CreateImageRequest;
-import com.amazonaws.services.ec2.model.CreateImageResult;
-import com.amazonaws.services.ec2.model.DeregisterImageRequest;
-import com.amazonaws.services.ec2.model.DescribeImagesRequest;
-import com.amazonaws.services.ec2.model.DescribeImagesResult;
-import com.amazonaws.services.ec2.model.Image;
-import com.amazonaws.services.ec2.model.Instance;
 import com.conveyal.datatools.common.status.MonitorableJob;
 import com.conveyal.datatools.common.utils.aws.EC2Utils;
-import com.conveyal.datatools.manager.DataManager;
 import com.conveyal.datatools.manager.auth.Auth0UserProfile;
 import com.conveyal.datatools.manager.models.OtpServer;
 import com.conveyal.datatools.manager.persistence.Persistence;
 import com.conveyal.datatools.manager.utils.TimeTracker;
+import software.amazon.awssdk.services.ec2.model.*;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -47,11 +40,12 @@ public class RecreateBuildImageJob extends MonitorableJob {
     public void jobLogic() {
         status.update("Creating build image", 5);
         // Create a new image of this instance.
-        CreateImageRequest createImageRequest = new CreateImageRequest()
-            .withInstanceId(graphBuildingInstances.get(0).getInstanceId())
-            .withName(otpServer.ec2Info.buildImageName)
-            .withDescription(otpServer.ec2Info.buildImageDescription);
-        CreateImageResult createImageResult = null;
+        CreateImageRequest createImageRequest = CreateImageRequest.builder()
+            .instanceId(graphBuildingInstances.get(0).instanceId())
+            .name(otpServer.ec2Info.buildImageName)
+            .description(otpServer.ec2Info.buildImageDescription)
+            .build();
+        CreateImageResponse createImageResult = null;
         try {
             createImageResult = parentDeployJob
                 .getEC2ClientForDeployJob()
@@ -64,13 +58,14 @@ public class RecreateBuildImageJob extends MonitorableJob {
         // Wait for the image to be created (it can take a few minutes). Also, make sure the parent DeployJob hasn't
         // failed this job already.
         TimeTracker imageCreationTracker = new TimeTracker(1, TimeUnit.HOURS);
-        String createdImageId = createImageResult.getImageId();
+        String createdImageId = createImageResult.imageId();
         status.update("Waiting for graph build image to be created...", 25);
         boolean imageCreated = false;
-        DescribeImagesRequest describeImagesRequest = new DescribeImagesRequest()
-            .withImageIds(createdImageId);
+        DescribeImagesRequest describeImagesRequest = DescribeImagesRequest.builder()
+            .imageIds(createdImageId)
+            .build();
         while (!imageCreated && !status.error) {
-            DescribeImagesResult describeImagesResult = null;
+            DescribeImagesResponse describeImagesResult = null;
             try {
                 describeImagesResult = parentDeployJob
                     .getEC2ClientForDeployJob()
@@ -79,11 +74,11 @@ public class RecreateBuildImageJob extends MonitorableJob {
                 terminateInstanceAndFailWithMessage("Failed to make request to get image creation status!", e);
                 return;
             }
-            for (Image image : describeImagesResult.getImages()) {
-                if (image.getImageId().equals(createdImageId)) {
+            for (Image image : describeImagesResult.images()) {
+                if (image.imageId().equals(createdImageId)) {
                     // obtain the image state.
                     // See https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/ec2/model/ImageState.html
-                    String imageState = image.getState().toLowerCase();
+                    String imageState = image.state().name().toLowerCase();
                     if (imageState.equals("pending")) {
                         if (imageCreationTracker.hasTimedOut()) {
                             terminateInstanceAndFailWithMessage(
@@ -125,8 +120,9 @@ public class RecreateBuildImageJob extends MonitorableJob {
                 !graphBuildAmiId.equals(otpServer.ec2Info.amiId)
         ) {
             status.message = "Deregistering old build image";
-            DeregisterImageRequest deregisterImageRequest = new DeregisterImageRequest()
-                .withImageId(graphBuildAmiId);
+            DeregisterImageRequest deregisterImageRequest = DeregisterImageRequest.builder()
+                .imageId(graphBuildAmiId)
+                .build();
             try {
                 parentDeployJob.getEC2ClientForDeployJob().deregisterImage(deregisterImageRequest);
             } catch (Exception e) {

--- a/src/main/java/com/conveyal/datatools/manager/models/Deployment.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/Deployment.java
@@ -1,6 +1,5 @@
 package com.conveyal.datatools.manager.models;
 
-import com.amazonaws.services.ec2.model.Filter;
 import com.conveyal.datatools.common.utils.aws.CheckedAWSException;
 import com.conveyal.datatools.common.utils.aws.EC2Utils;
 import com.conveyal.datatools.manager.DataManager;
@@ -22,6 +21,7 @@ import org.apache.logging.log4j.util.Strings;
 import org.bson.codecs.pojo.annotations.BsonIgnore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.ec2.model.Filter;
 
 import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
@@ -146,7 +146,11 @@ public class Deployment extends Model implements Serializable {
     /** Fetch ec2 instances tagged with this deployment's ID. */
     public List<EC2InstanceSummary> retrieveEC2Instances() throws CheckedAWSException {
         if (!"true".equals(DataManager.getConfigPropertyAsText("modules.deployment.ec2.enabled"))) return Collections.EMPTY_LIST;
-        Filter deploymentFilter = new Filter("tag:deploymentId", Collections.singletonList(id));
+        Filter deploymentFilter = Filter
+            .builder()
+            .name("tag:deploymentId")
+            .values(id)
+            .build();
         // Check if the latest deployment used alternative credentials/AWS role.
         String role = null;
         String region = null;

--- a/src/main/java/com/conveyal/datatools/manager/models/EC2InstanceSummary.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/EC2InstanceSummary.java
@@ -1,8 +1,8 @@
 package com.conveyal.datatools.manager.models;
 
-import com.amazonaws.services.ec2.model.Instance;
-import com.amazonaws.services.ec2.model.InstanceState;
-import com.amazonaws.services.ec2.model.Tag;
+import software.amazon.awssdk.services.ec2.model.Instance;
+import software.amazon.awssdk.services.ec2.model.InstanceState;
+import software.amazon.awssdk.services.ec2.model.Tag;
 
 import java.io.Serializable;
 import java.util.Date;
@@ -32,23 +32,23 @@ public class EC2InstanceSummary implements Serializable {
     public EC2InstanceSummary () { }
 
     public EC2InstanceSummary (Instance ec2Instance) {
-        publicIpAddress = ec2Instance.getPublicIpAddress();
-        privateIpAddress = ec2Instance.getPrivateIpAddress();
-        publicDnsName = ec2Instance.getPublicDnsName();
-        instanceType = ec2Instance.getInstanceType();
-        instanceId = ec2Instance.getInstanceId();
-        imageId = ec2Instance.getImageId();
-        List<Tag> tags = ec2Instance.getTags();
+        publicIpAddress = ec2Instance.publicIpAddress();
+        privateIpAddress = ec2Instance.privateIpAddress();
+        publicDnsName = ec2Instance.publicDnsName();
+        instanceType = ec2Instance.instanceType().name();
+        instanceId = ec2Instance.instanceId();
+        imageId = ec2Instance.imageId();
+        List<Tag> tags = ec2Instance.tags();
         // Set project and deployment ID if they exist.
         for (Tag tag : tags) {
-            if (tag.getKey().equals("projectId")) projectId = tag.getValue();
-            if (tag.getKey().equals("deploymentId")) deploymentId = tag.getValue();
-            if (tag.getKey().equals("jobId")) jobId = tag.getValue();
-            if (tag.getKey().equals("Name")) name = tag.getValue();
+            if (tag.key().equals("projectId")) projectId = tag.value();
+            if (tag.key().equals("deploymentId")) deploymentId = tag.value();
+            if (tag.key().equals("jobId")) jobId = tag.value();
+            if (tag.key().equals("Name")) name = tag.value();
         }
-        state = ec2Instance.getState();
-        availabilityZone = ec2Instance.getPlacement().getAvailabilityZone();
-        launchTime = ec2Instance.getLaunchTime();
-        stateTransitionReason = ec2Instance.getStateTransitionReason();
+        state = ec2Instance.state();
+        availabilityZone = ec2Instance.placement().availabilityZone();
+        launchTime = Date.from(ec2Instance.launchTime());
+        stateTransitionReason = ec2Instance.stateTransitionReason();
     }
 }

--- a/src/main/java/com/conveyal/datatools/manager/models/EC2InstanceSummary.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/EC2InstanceSummary.java
@@ -1,5 +1,6 @@
 package com.conveyal.datatools.manager.models;
 
+import com.conveyal.datatools.common.utils.aws.InstanceStateAws1;
 import software.amazon.awssdk.services.ec2.model.Instance;
 import software.amazon.awssdk.services.ec2.model.InstanceState;
 import software.amazon.awssdk.services.ec2.model.Tag;
@@ -23,7 +24,7 @@ public class EC2InstanceSummary implements Serializable {
     public String jobId;
     public String deploymentId;
     public String name;
-    public InstanceState state;
+    public InstanceStateAws1 state;
     public String availabilityZone;
     public Date launchTime;
     public String stateTransitionReason;
@@ -46,7 +47,10 @@ public class EC2InstanceSummary implements Serializable {
             if (tag.key().equals("jobId")) jobId = tag.value();
             if (tag.key().equals("Name")) name = tag.value();
         }
-        state = ec2Instance.state();
+        InstanceState instanceState = ec2Instance.state();
+        state = new InstanceStateAws1()
+            .withName(instanceState.nameAsString())
+            .withCode(instanceState.code());
         availabilityZone = ec2Instance.placement().availabilityZone();
         launchTime = Date.from(ec2Instance.launchTime());
         stateTransitionReason = ec2Instance.stateTransitionReason();

--- a/src/main/java/com/conveyal/datatools/manager/models/FeedSource.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/FeedSource.java
@@ -1,9 +1,5 @@
 package com.conveyal.datatools.manager.models;
 
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.model.CannedAccessControlList;
-import com.amazonaws.services.s3.model.DeleteObjectsRequest;
-import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.conveyal.datatools.common.status.FeedSourceJob;
 import com.conveyal.datatools.common.status.MonitorableJob;
 import com.conveyal.datatools.common.utils.Scheduler;
@@ -33,6 +29,13 @@ import org.bson.codecs.pojo.annotations.BsonIgnore;
 import org.bson.conversions.Bson;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectsRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
+import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
 
 import java.io.File;
 import java.io.IOException;
@@ -597,33 +600,36 @@ public class FeedSource extends Model implements Cloneable {
         // Note: If modules.enterprise.prefer_s3_links is not set and the feed source has a fetch URL,
         // this method will not be called, and the feed download link will point to the fetch URL instead.
         if (DataManager.useS3) {
-            AmazonS3 defaultS3Client = S3Utils.getDefaultS3Client();
-            boolean sourceExists = defaultS3Client.doesObjectExist(S3Utils.DEFAULT_BUCKET, sourceKey);
-            ObjectMetadata sourceMetadata = sourceExists
-                    ? defaultS3Client.getObjectMetadata(S3Utils.DEFAULT_BUCKET, sourceKey)
-                    : null;
-            boolean latestExists = defaultS3Client.doesObjectExist(S3Utils.DEFAULT_BUCKET, latestVersionKey);
-            ObjectMetadata latestVersionMetadata = latestExists
-                    ? defaultS3Client.getObjectMetadata(S3Utils.DEFAULT_BUCKET, latestVersionKey)
-                    : null;
+            S3Client defaultS3Client = S3Utils.getDefaultS3Client();
+            HeadObjectResponse sourceMetadata = S3Utils.getHeadObject(defaultS3Client, S3Utils.DEFAULT_BUCKET, sourceKey);
+            HeadObjectResponse latestVersionMetadata = S3Utils.getHeadObject(defaultS3Client, S3Utils.DEFAULT_BUCKET, latestVersionKey);
+
             boolean latestVersionMatchesSource = sourceMetadata != null &&
                     latestVersionMetadata != null &&
-                    sourceMetadata.getETag().equals(latestVersionMetadata.getETag());
-            if (sourceExists && latestVersionMatchesSource) {
+                    /*AWS SDK for Java v2 migration: NOTE: V2's eTag() preserves surrounding quotes in the response, whereas V1's getETag() strips them - https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/migration-s3-client.html#V1s-ObjectMetadata-using-V1s-getETag*/
+sourceMetadata.eTag().replaceAll("^\"|\"$", "").equals(/*AWS SDK for Java v2 migration: NOTE: V2's eTag() preserves surrounding quotes in the response, whereas V1's getETag() strips them - https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/migration-s3-client.html#V1s-ObjectMetadata-using-V1s-getETag*/
+latestVersionMetadata.eTag().replaceAll("^\"|\"$", ""));
+            if (sourceMetadata != null && latestVersionMatchesSource) {
                 LOG.info("copying feed {} to s3 public folder", this);
-                defaultS3Client.setObjectAcl(S3Utils.DEFAULT_BUCKET, sourceKey, CannedAccessControlList.PublicRead);
-                defaultS3Client.copyObject(S3Utils.DEFAULT_BUCKET, sourceKey, S3Utils.DEFAULT_BUCKET, publicKey);
-                defaultS3Client.setObjectAcl(S3Utils.DEFAULT_BUCKET, publicKey, CannedAccessControlList.PublicRead);
+                /*AWS SDK for Java v2 migration: Transform for AccessControlList and CannedAccessControlList not supported. In v2, CannedAccessControlList is replaced by BucketCannedACL for buckets and ObjectCannedACL for objects. Please reference https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/migration-s3-client.html#V1-AccessControlList*/
+                defaultS3Client.putObjectAcl(req -> req.bucket(S3Utils.DEFAULT_BUCKET).key(sourceKey).acl(ObjectCannedACL.PUBLIC_READ));
+                defaultS3Client.copyObject(CopyObjectRequest.builder().sourceBucket(S3Utils.DEFAULT_BUCKET).sourceKey(sourceKey).destinationBucket(S3Utils.DEFAULT_BUCKET).destinationKey(publicKey)
+                    .build());
+                /*AWS SDK for Java v2 migration: Transform for AccessControlList and CannedAccessControlList not supported. In v2, CannedAccessControlList is replaced by BucketCannedACL for buckets and ObjectCannedACL for objects. Please reference https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/migration-s3-client.html#V1-AccessControlList*/
+                defaultS3Client.putObjectAcl(req -> req.bucket(S3Utils.DEFAULT_BUCKET).key(publicKey).acl(ObjectCannedACL.PUBLIC_READ));
             } else {
                 LOG.warn("Latest feed source {} on s3 at {} does not exist or does not match latest version. Using latest version instead.", this, sourceKey);
-                if (defaultS3Client.doesObjectExist(S3Utils.DEFAULT_BUCKET, latestVersionKey)) {
+                if (latestVersionMetadata != null) {
                     LOG.info("copying feed version {} to s3 public folder", versionId);
-                    defaultS3Client.setObjectAcl(S3Utils.DEFAULT_BUCKET, latestVersionKey, CannedAccessControlList.PublicRead);
-                    defaultS3Client.copyObject(S3Utils.DEFAULT_BUCKET, latestVersionKey, S3Utils.DEFAULT_BUCKET, publicKey);
-                    defaultS3Client.setObjectAcl(S3Utils.DEFAULT_BUCKET, publicKey, CannedAccessControlList.PublicRead);
+                    /*AWS SDK for Java v2 migration: Transform for AccessControlList and CannedAccessControlList not supported. In v2, CannedAccessControlList is replaced by BucketCannedACL for buckets and ObjectCannedACL for objects. Please reference https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/migration-s3-client.html#V1-AccessControlList*/
+                    defaultS3Client.putObjectAcl(req -> req.bucket(S3Utils.DEFAULT_BUCKET).key(latestVersionKey).acl(ObjectCannedACL.PUBLIC_READ));
+                    defaultS3Client.copyObject(CopyObjectRequest.builder().sourceBucket(S3Utils.DEFAULT_BUCKET).sourceKey(latestVersionKey).destinationBucket(S3Utils.DEFAULT_BUCKET).destinationKey(publicKey)
+                        .build());
+                    /*AWS SDK for Java v2 migration: Transform for AccessControlList and CannedAccessControlList not supported. In v2, CannedAccessControlList is replaced by BucketCannedACL for buckets and ObjectCannedACL for objects. Please reference https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/migration-s3-client.html#V1-AccessControlList*/
+                    defaultS3Client.putObjectAcl(req -> req.bucket(S3Utils.DEFAULT_BUCKET).key(publicKey).acl(ObjectCannedACL.PUBLIC_READ));
 
                     // also copy latest version to feedStore latest
-                    defaultS3Client.copyObject(S3Utils.DEFAULT_BUCKET, latestVersionKey, S3Utils.DEFAULT_BUCKET, sourceKey);
+                    defaultS3Client.copyObject(CopyObjectRequest.builder().sourceBucket(S3Utils.DEFAULT_BUCKET).sourceKey(latestVersionKey).destinationBucket(S3Utils.DEFAULT_BUCKET).destinationKey(sourceKey).build());
                 }
             }
         } else {
@@ -638,11 +644,12 @@ public class FeedSource extends Model implements Cloneable {
     public void makePrivate() throws CheckedAWSException {
         String sourceKey = S3Utils.DEFAULT_BUCKET_GTFS_FOLDER + this.id + ".zip";
         String publicKey = toPublicKey();
-        AmazonS3 defaultS3Client = S3Utils.getDefaultS3Client();
-        if (defaultS3Client.doesObjectExist(S3Utils.DEFAULT_BUCKET, sourceKey)) {
+        S3Client defaultS3Client = S3Utils.getDefaultS3Client();
+        if (S3Utils.objectExists(defaultS3Client, S3Utils.DEFAULT_BUCKET, sourceKey)) {
             LOG.info("removing feed {} from s3 public folder", this);
-            defaultS3Client.setObjectAcl(S3Utils.DEFAULT_BUCKET, sourceKey, CannedAccessControlList.AuthenticatedRead);
-            defaultS3Client.deleteObject(S3Utils.DEFAULT_BUCKET, publicKey);
+            /*AWS SDK for Java v2 migration: Transform for AccessControlList and CannedAccessControlList not supported. In v2, CannedAccessControlList is replaced by BucketCannedACL for buckets and ObjectCannedACL for objects. Please reference https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/migration-s3-client.html#V1-AccessControlList*/
+            defaultS3Client.putObjectAcl(req -> req.bucket(S3Utils.DEFAULT_BUCKET).key(sourceKey).acl(ObjectCannedACL.AUTHENTICATED_READ));
+            defaultS3Client.deleteObject(DeleteObjectRequest.builder().bucket(S3Utils.DEFAULT_BUCKET).key(publicKey).build());
         }
     }
 
@@ -695,9 +702,15 @@ public class FeedSource extends Model implements Cloneable {
             }
             // Delete latest copy of feed source on S3.
             if (DataManager.useS3) {
-                AmazonS3 defaultS3Client = S3Utils.getDefaultS3Client();
-                DeleteObjectsRequest delete = new DeleteObjectsRequest(S3Utils.DEFAULT_BUCKET);
-                delete.withKeys("public/" + this.name + ".zip", S3Utils.DEFAULT_BUCKET_GTFS_FOLDER + this.id + ".zip");
+                S3Client defaultS3Client = S3Utils.getDefaultS3Client();
+                DeleteObjectsRequest delete = DeleteObjectsRequest
+                    .builder()
+                    .bucket(S3Utils.DEFAULT_BUCKET)
+                    .delete(reg -> reg.objects(
+                        ObjectIdentifier.builder().key("public/" + this.name + ".zip").build(),
+                        ObjectIdentifier.builder().key(S3Utils.DEFAULT_BUCKET_GTFS_FOLDER + this.id + ".zip").build()
+                    ))
+                    .build();
                 defaultS3Client.deleteObjects(delete);
             }
             // Remove all external properties for this feed source.

--- a/src/main/java/com/conveyal/datatools/manager/models/FeedSource.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/FeedSource.java
@@ -30,8 +30,6 @@ import org.bson.conversions.Bson;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
-import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.DeleteObjectsRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
@@ -607,29 +605,60 @@ public class FeedSource extends Model implements Cloneable {
             boolean latestVersionMatchesSource = sourceMetadata != null &&
                     latestVersionMetadata != null &&
                     /*AWS SDK for Java v2 migration: NOTE: V2's eTag() preserves surrounding quotes in the response, whereas V1's getETag() strips them - https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/migration-s3-client.html#V1s-ObjectMetadata-using-V1s-getETag*/
-sourceMetadata.eTag().replaceAll("^\"|\"$", "").equals(/*AWS SDK for Java v2 migration: NOTE: V2's eTag() preserves surrounding quotes in the response, whereas V1's getETag() strips them - https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/migration-s3-client.html#V1s-ObjectMetadata-using-V1s-getETag*/
-latestVersionMetadata.eTag().replaceAll("^\"|\"$", ""));
+                    sourceMetadata.eTag().replaceAll("^\"|\"$", "").equals(latestVersionMetadata.eTag().replaceAll("^\"|\"$", ""));
             if (sourceMetadata != null && latestVersionMatchesSource) {
                 LOG.info("copying feed {} to s3 public folder", this);
-                /*AWS SDK for Java v2 migration: Transform for AccessControlList and CannedAccessControlList not supported. In v2, CannedAccessControlList is replaced by BucketCannedACL for buckets and ObjectCannedACL for objects. Please reference https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/migration-s3-client.html#V1-AccessControlList*/
-                defaultS3Client.putObjectAcl(req -> req.bucket(S3Utils.DEFAULT_BUCKET).key(sourceKey).acl(ObjectCannedACL.PUBLIC_READ));
-                defaultS3Client.copyObject(CopyObjectRequest.builder().sourceBucket(S3Utils.DEFAULT_BUCKET).sourceKey(sourceKey).destinationBucket(S3Utils.DEFAULT_BUCKET).destinationKey(publicKey)
-                    .build());
-                /*AWS SDK for Java v2 migration: Transform for AccessControlList and CannedAccessControlList not supported. In v2, CannedAccessControlList is replaced by BucketCannedACL for buckets and ObjectCannedACL for objects. Please reference https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/migration-s3-client.html#V1-AccessControlList*/
-                defaultS3Client.putObjectAcl(req -> req.bucket(S3Utils.DEFAULT_BUCKET).key(publicKey).acl(ObjectCannedACL.PUBLIC_READ));
+                defaultS3Client.putObjectAcl(
+                    req -> req
+                        .bucket(S3Utils.DEFAULT_BUCKET)
+                        .key(sourceKey)
+                        .acl(ObjectCannedACL.PUBLIC_READ)
+                );
+                defaultS3Client.copyObject(
+                    req -> req
+                        .sourceBucket(S3Utils.DEFAULT_BUCKET)
+                        .sourceKey(sourceKey)
+                        .destinationBucket(S3Utils.DEFAULT_BUCKET)
+                        .destinationKey(publicKey)
+                );
+                defaultS3Client.putObjectAcl(
+                    req -> req
+                        .bucket(S3Utils.DEFAULT_BUCKET)
+                        .key(publicKey)
+                        .acl(ObjectCannedACL.PUBLIC_READ)
+                );
             } else {
                 LOG.warn("Latest feed source {} on s3 at {} does not exist or does not match latest version. Using latest version instead.", this, sourceKey);
                 if (latestVersionMetadata != null) {
                     LOG.info("copying feed version {} to s3 public folder", versionId);
-                    /*AWS SDK for Java v2 migration: Transform for AccessControlList and CannedAccessControlList not supported. In v2, CannedAccessControlList is replaced by BucketCannedACL for buckets and ObjectCannedACL for objects. Please reference https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/migration-s3-client.html#V1-AccessControlList*/
-                    defaultS3Client.putObjectAcl(req -> req.bucket(S3Utils.DEFAULT_BUCKET).key(latestVersionKey).acl(ObjectCannedACL.PUBLIC_READ));
-                    defaultS3Client.copyObject(CopyObjectRequest.builder().sourceBucket(S3Utils.DEFAULT_BUCKET).sourceKey(latestVersionKey).destinationBucket(S3Utils.DEFAULT_BUCKET).destinationKey(publicKey)
-                        .build());
-                    /*AWS SDK for Java v2 migration: Transform for AccessControlList and CannedAccessControlList not supported. In v2, CannedAccessControlList is replaced by BucketCannedACL for buckets and ObjectCannedACL for objects. Please reference https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/migration-s3-client.html#V1-AccessControlList*/
-                    defaultS3Client.putObjectAcl(req -> req.bucket(S3Utils.DEFAULT_BUCKET).key(publicKey).acl(ObjectCannedACL.PUBLIC_READ));
+                    defaultS3Client.putObjectAcl(
+                        req -> req
+                            .bucket(S3Utils.DEFAULT_BUCKET)
+                            .key(latestVersionKey)
+                            .acl(ObjectCannedACL.PUBLIC_READ)
+                    );
+                    defaultS3Client.copyObject(
+                        req -> req
+                            .sourceBucket(S3Utils.DEFAULT_BUCKET)
+                            .sourceKey(latestVersionKey)
+                            .destinationBucket(S3Utils.DEFAULT_BUCKET)
+                            .destinationKey(publicKey)
+                    );
+                    defaultS3Client.putObjectAcl(
+                        req -> req
+                            .bucket(S3Utils.DEFAULT_BUCKET)
+                            .key(publicKey)
+                            .acl(ObjectCannedACL.PUBLIC_READ)
+                    );
 
                     // also copy latest version to feedStore latest
-                    defaultS3Client.copyObject(CopyObjectRequest.builder().sourceBucket(S3Utils.DEFAULT_BUCKET).sourceKey(latestVersionKey).destinationBucket(S3Utils.DEFAULT_BUCKET).destinationKey(sourceKey).build());
+                    defaultS3Client.copyObject(
+                        req -> req
+                            .sourceBucket(S3Utils.DEFAULT_BUCKET)
+                            .sourceKey(latestVersionKey)
+                            .destinationBucket(S3Utils.DEFAULT_BUCKET)
+                            .destinationKey(sourceKey)
+                    );
                 }
             }
         } else {
@@ -647,9 +676,13 @@ latestVersionMetadata.eTag().replaceAll("^\"|\"$", ""));
         S3Client defaultS3Client = S3Utils.getDefaultS3Client();
         if (S3Utils.objectExists(defaultS3Client, S3Utils.DEFAULT_BUCKET, sourceKey)) {
             LOG.info("removing feed {} from s3 public folder", this);
-            /*AWS SDK for Java v2 migration: Transform for AccessControlList and CannedAccessControlList not supported. In v2, CannedAccessControlList is replaced by BucketCannedACL for buckets and ObjectCannedACL for objects. Please reference https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/migration-s3-client.html#V1-AccessControlList*/
-            defaultS3Client.putObjectAcl(req -> req.bucket(S3Utils.DEFAULT_BUCKET).key(sourceKey).acl(ObjectCannedACL.AUTHENTICATED_READ));
-            defaultS3Client.deleteObject(DeleteObjectRequest.builder().bucket(S3Utils.DEFAULT_BUCKET).key(publicKey).build());
+            defaultS3Client.putObjectAcl(
+                req -> req
+                    .bucket(S3Utils.DEFAULT_BUCKET)
+                    .key(sourceKey)
+                    .acl(ObjectCannedACL.AUTHENTICATED_READ)
+            );
+            defaultS3Client.deleteObject(req -> req.bucket(S3Utils.DEFAULT_BUCKET).key(publicKey));
         }
     }
 

--- a/src/main/java/com/conveyal/datatools/manager/models/FeedSource.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/FeedSource.java
@@ -604,8 +604,7 @@ public class FeedSource extends Model implements Cloneable {
 
             boolean latestVersionMatchesSource = sourceMetadata != null &&
                     latestVersionMetadata != null &&
-                    /*AWS SDK for Java v2 migration: NOTE: V2's eTag() preserves surrounding quotes in the response, whereas V1's getETag() strips them - https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/migration-s3-client.html#V1s-ObjectMetadata-using-V1s-getETag*/
-                    sourceMetadata.eTag().replaceAll("^\"|\"$", "").equals(latestVersionMetadata.eTag().replaceAll("^\"|\"$", ""));
+                    S3Utils.eTagsMatch(sourceMetadata.eTag(), latestVersionMetadata.eTag());
             if (sourceMetadata != null && latestVersionMatchesSource) {
                 LOG.info("copying feed {} to s3 public folder", this);
                 defaultS3Client.putObjectAcl(

--- a/src/main/java/com/conveyal/datatools/manager/models/OtpServer.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/OtpServer.java
@@ -73,7 +73,7 @@ public class OtpServer extends Model {
         Filter serverFilter = Filter
             .builder()
             .name("tag:serverId")
-            .values(Collections.singletonList(id))
+            .values(id)
             .build();
         return EC2Utils.fetchEC2InstanceSummaries(getEC2Client(), serverFilter);
     }
@@ -86,7 +86,7 @@ public class OtpServer extends Model {
         Filter serverFilter = Filter
             .builder()
             .name("tag:serverId")
-            .values(Collections.singletonList(id))
+            .values(id)
             .build();
         return EC2Utils.fetchEC2Instances(getEC2Client(), serverFilter);
     }

--- a/src/main/java/com/conveyal/datatools/manager/models/OtpServer.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/OtpServer.java
@@ -1,8 +1,5 @@
 package com.conveyal.datatools.manager.models;
 
-import com.amazonaws.services.ec2.AmazonEC2;
-import com.amazonaws.services.ec2.model.Filter;
-import com.amazonaws.services.ec2.model.Instance;
 import com.conveyal.datatools.common.utils.aws.CheckedAWSException;
 import com.conveyal.datatools.common.utils.aws.EC2Utils;
 import com.conveyal.datatools.common.utils.aws.EC2ValidationResult;
@@ -15,6 +12,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import org.bson.codecs.pojo.annotations.BsonIgnore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.ec2.Ec2Client;
+import software.amazon.awssdk.services.ec2.model.Filter;
+import software.amazon.awssdk.services.ec2.model.Instance;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -70,7 +70,11 @@ public class OtpServer extends Model {
     public List<EC2InstanceSummary> retrieveEC2InstanceSummaries() throws CheckedAWSException {
         // Prevent calling EC2 method on servers that do not have EC2 info defined because this is a JSON property.
         if (ec2Info == null) return Collections.emptyList();
-        Filter serverFilter = new Filter("tag:serverId", Collections.singletonList(id));
+        Filter serverFilter = Filter
+            .builder()
+            .name("tag:serverId")
+            .values(Collections.singletonList(id))
+            .build();
         return EC2Utils.fetchEC2InstanceSummaries(getEC2Client(), serverFilter);
     }
 
@@ -79,7 +83,11 @@ public class OtpServer extends Model {
             !"true".equals(DataManager.getConfigPropertyAsText("modules.deployment.ec2.enabled")) ||
                 ec2Info == null
         ) return Collections.emptyList();
-        Filter serverFilter = new Filter("tag:serverId", Collections.singletonList(id));
+        Filter serverFilter = Filter
+            .builder()
+            .name("tag:serverId")
+            .values(Collections.singletonList(id))
+            .build();
         return EC2Utils.fetchEC2Instances(getEC2Client(), serverFilter);
     }
 
@@ -104,7 +112,7 @@ public class OtpServer extends Model {
 
     @JsonIgnore
     @BsonIgnore
-    public AmazonEC2 getEC2Client() throws CheckedAWSException {
+    public Ec2Client getEC2Client() throws CheckedAWSException {
         return EC2Utils.getEC2Client(role, getRegion());
     }
 

--- a/src/main/java/com/conveyal/datatools/manager/persistence/FeedStore.java
+++ b/src/main/java/com/conveyal/datatools/manager/persistence/FeedStore.java
@@ -17,8 +17,6 @@ import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
-import software.amazon.awssdk.transfer.s3.S3TransferManager;
-import software.amazon.awssdk.transfer.s3.model.UploadFileRequest;
 import software.amazon.awssdk.transfer.s3.progress.TransferListener;
 
 import java.io.File;
@@ -197,20 +195,12 @@ public class FeedStore {
                     }
                 };
 
-                UploadFileRequest uploadRequest = UploadFileRequest
-                    .builder()
-                    .putObjectRequest(req -> req.bucket(S3Utils.DEFAULT_BUCKET).key(S3Utils.makeGtfsFolderObjectKey(s3FileName)))
-                    .source(gtfsFile)
-                    .addTransferListener(transferListener)
-                    .build();
-
-                S3TransferManager transferManager = S3TransferManager
-                    .builder()
-                    .s3Client(S3Utils.getDefaultS3AsyncClient())
-                    .build();
-                try (transferManager) {
-                    // You can block and wait for the upload to finish
-                    transferManager.uploadFile(uploadRequest).completionFuture().join();
+                try {
+                    S3Utils.uploadAndWaitForCompletion(upload -> upload
+                        .putObjectRequest(req -> req.bucket(S3Utils.DEFAULT_BUCKET).key(S3Utils.makeGtfsFolderObjectKey(s3FileName)))
+                        .source(gtfsFile)
+                        .addTransferListener(transferListener)
+                    );
                 } catch (SdkException e) {
                     LOG.error("Unable to upload file, upload aborted.", e);
                     return false;

--- a/src/main/java/com/conveyal/datatools/manager/persistence/FeedStore.java
+++ b/src/main/java/com/conveyal/datatools/manager/persistence/FeedStore.java
@@ -133,7 +133,7 @@ public class FeedStore {
      * future use. Note: uploading the file to S3 is handled elsewhere as a finishing step, e.g., at the
      * conclusion of a successful feed processing/validation step.
      */
-    public File newFeed (String id, InputStream inputStream, FeedSource feedSource) throws IOException {
+    public File newFeed(String id, InputStream inputStream, FeedSource feedSource) throws IOException {
         // write feed to specified ID.
         // NOTE: depending on the feed store, there may not be a feedSource provided (e.g., gtfsplus)
         File file = new File(path, id);

--- a/src/main/java/com/conveyal/datatools/manager/persistence/FeedStore.java
+++ b/src/main/java/com/conveyal/datatools/manager/persistence/FeedStore.java
@@ -1,14 +1,5 @@
 package com.conveyal.datatools.manager.persistence;
 
-import com.amazonaws.AmazonClientException;
-import com.amazonaws.AmazonServiceException;
-import com.amazonaws.services.s3.model.CopyObjectRequest;
-import com.amazonaws.services.s3.model.GetObjectRequest;
-import com.amazonaws.services.s3.model.PutObjectRequest;
-import com.amazonaws.services.s3.model.S3Object;
-import com.amazonaws.services.s3.transfer.TransferManager;
-import com.amazonaws.services.s3.transfer.TransferManagerBuilder;
-import com.amazonaws.services.s3.transfer.Upload;
 import com.conveyal.datatools.common.utils.aws.CheckedAWSException;
 import com.conveyal.datatools.common.utils.aws.S3Utils;
 import com.conveyal.datatools.manager.DataManager;
@@ -19,6 +10,16 @@ import gnu.trove.list.array.TLongArrayList;
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.core.exception.SdkException;
+import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.transfer.s3.S3TransferManager;
+import software.amazon.awssdk.transfer.s3.model.UploadFileRequest;
+import software.amazon.awssdk.transfer.s3.progress.TransferListener;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -66,7 +67,8 @@ public class FeedStore {
     public void deleteFeed (String id) throws CheckedAWSException {
         // If the application is using s3 storage, delete the remote copy.
         if (DataManager.useS3){
-            S3Utils.getDefaultS3Client().deleteObject(S3Utils.DEFAULT_BUCKET, S3Utils.makeGtfsFolderObjectKey(id));
+            S3Utils.getDefaultS3Client().deleteObject(DeleteObjectRequest.builder().bucket(S3Utils.DEFAULT_BUCKET).key(S3Utils.makeGtfsFolderObjectKey(id))
+                .build());
         }
         // Always delete local copy (whether storing exclusively on local disk or using s3).
         File feed = getLocalFeed(id);
@@ -96,18 +98,16 @@ public class FeedStore {
             String uri = S3Utils.getDefaultBucketUriForKey(key);
             LOG.info("Downloading feed from {}", uri);
             try (
-                S3Object object = S3Utils.getDefaultS3Client().getObject(
-                    new GetObjectRequest(S3Utils.DEFAULT_BUCKET, key)
-                );
-                InputStream objectData = object.getObjectContent();
+                ResponseInputStream<GetObjectResponse> responseStream = S3Utils.getDefaultS3Client().getObject(
+                    GetObjectRequest.builder().bucket(S3Utils.DEFAULT_BUCKET).key(key).build())
             ) {
                 try {
-                    return createTempFile(id, objectData);
+                    return createTempFile(id, responseStream);
                 } catch (IOException e) {
                     // TODO: Log to bugsnag?
                     LOG.error("Error creating temp file", e);
                 }
-            } catch (AmazonServiceException | CheckedAWSException | IOException e) {
+            } catch (AwsServiceException | CheckedAWSException | IOException e) {
                 LOG.error("Error downloading " + uri, e);
                 return null;
             }
@@ -179,54 +179,54 @@ public class FeedStore {
         if (S3Utils.DEFAULT_BUCKET != null) {
             try {
                 LOG.info("Uploading feed {} to S3 from {}", s3FileName, gtfsFile.getAbsolutePath());
-                TransferManager tm = TransferManagerBuilder.standard().withS3Client(S3Utils.getDefaultS3Client()).build();
-                PutObjectRequest request = new PutObjectRequest(S3Utils.DEFAULT_BUCKET, S3Utils.makeGtfsFolderObjectKey(s3FileName), gtfsFile);
                 // Subscribe to the event and provide event handler.
                 TLongList transferredBytes = new TLongArrayList();
                 long totalBytes = gtfsFile.length();
                 LOG.info("Total kilobytes: {}", totalBytes / 1000);
-                request.setGeneralProgressListener(progressEvent -> {
-                    if (transferredBytes.size() == 75) {
-                        LOG.info("Each dot is {} kilobytes",transferredBytes.sum() / 1000);
-                    }
-                    if (transferredBytes.size() % 75 == 0) {
-                        System.out.print(".");
-                    }
-//                    LOG.info("Uploaded {}/{}", transferredBytes.sum(), totalBytes);
-                    transferredBytes.add(progressEvent.getBytesTransferred());
-                });
-                // TransferManager processes all transfers asynchronously,
-                // so this call will return immediately.
-                Upload upload = tm.upload(request);
 
-                try {
+                TransferListener transferListener = new TransferListener() {
+                    @Override
+                    public void bytesTransferred(Context.BytesTransferred context) {
+                        if (transferredBytes.size() == 75) {
+                            LOG.info("Each dot is {} kilobytes", transferredBytes.sum() / 1000);
+                        }
+                        if (transferredBytes.size() % 75 == 0) {
+                            System.out.print(".");
+                        }
+                        transferredBytes.add(context.progressSnapshot().transferredBytes());
+                    }
+                };
+
+                UploadFileRequest uploadRequest = UploadFileRequest
+                    .builder()
+                    .putObjectRequest(req -> req.bucket(S3Utils.DEFAULT_BUCKET).key(S3Utils.makeGtfsFolderObjectKey(s3FileName)))
+                    .source(gtfsFile)
+                    .addTransferListener(transferListener)
+                    .build();
+
+                S3TransferManager transferManager = S3TransferManager
+                    .builder()
+                    .s3Client(S3Utils.getDefaultS3AsyncClient())
+                    .build();
+                try (transferManager) {
                     // You can block and wait for the upload to finish
-                    upload.waitForCompletion();
-                } catch (AmazonClientException | InterruptedException e) {
+                    transferManager.uploadFile(uploadRequest).completionFuture().join();
+                } catch (SdkException e) {
                     LOG.error("Unable to upload file, upload aborted.", e);
                     return false;
                 }
-
-                // Shutdown the Transfer Manager, but don't shut down the underlying S3 client.
-                // The default behavior for shutdownNow shut's down the underlying s3 client
-                // which will cause any following s3 operations to fail.
-                tm.shutdownNow(false);
 
                 if (feedSource != null){
                     LOG.info("Copying feed on s3 to latest version");
 
                     // copy to [feedSourceId].zip
                     String copyKey = S3Utils.DEFAULT_BUCKET_GTFS_FOLDER + feedSource.id + ".zip";
-                    CopyObjectRequest copyObjRequest = new CopyObjectRequest(
-                        S3Utils.DEFAULT_BUCKET,
-                        S3Utils.makeGtfsFolderObjectKey(s3FileName),
-                        S3Utils.DEFAULT_BUCKET,
-                        copyKey
-                    );
+                    CopyObjectRequest copyObjRequest = CopyObjectRequest.builder().sourceBucket(S3Utils.DEFAULT_BUCKET).sourceKey(S3Utils.makeGtfsFolderObjectKey(s3FileName)).destinationBucket(S3Utils.DEFAULT_BUCKET).destinationKey(copyKey)
+                        .build();
                     S3Utils.getDefaultS3Client().copyObject(copyObjRequest);
                 }
                 return true;
-            } catch (AmazonServiceException | CheckedAWSException e) {
+            } catch (AwsServiceException | CheckedAWSException e) {
                 LOG.error("Error uploading feed to S3", e);
                 return false;
             }

--- a/src/main/java/com/conveyal/datatools/manager/persistence/FeedStore.java
+++ b/src/main/java/com/conveyal/datatools/manager/persistence/FeedStore.java
@@ -13,9 +13,6 @@ import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.core.exception.SdkException;
-import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
-import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
-import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.transfer.s3.progress.TransferListener;
 
@@ -65,8 +62,11 @@ public class FeedStore {
     public void deleteFeed (String id) throws CheckedAWSException {
         // If the application is using s3 storage, delete the remote copy.
         if (DataManager.useS3){
-            S3Utils.getDefaultS3Client().deleteObject(DeleteObjectRequest.builder().bucket(S3Utils.DEFAULT_BUCKET).key(S3Utils.makeGtfsFolderObjectKey(id))
-                .build());
+            S3Utils.getDefaultS3Client().deleteObject(
+                req -> req
+                    .bucket(S3Utils.DEFAULT_BUCKET)
+                    .key(S3Utils.makeGtfsFolderObjectKey(id))
+            );
         }
         // Always delete local copy (whether storing exclusively on local disk or using s3).
         File feed = getLocalFeed(id);
@@ -97,7 +97,8 @@ public class FeedStore {
             LOG.info("Downloading feed from {}", uri);
             try (
                 ResponseInputStream<GetObjectResponse> responseStream = S3Utils.getDefaultS3Client().getObject(
-                    GetObjectRequest.builder().bucket(S3Utils.DEFAULT_BUCKET).key(key).build())
+                    req -> req.bucket(S3Utils.DEFAULT_BUCKET).key(key)
+                )
             ) {
                 try {
                     return createTempFile(id, responseStream);
@@ -197,7 +198,11 @@ public class FeedStore {
 
                 try {
                     S3Utils.uploadAndWaitForCompletion(upload -> upload
-                        .putObjectRequest(req -> req.bucket(S3Utils.DEFAULT_BUCKET).key(S3Utils.makeGtfsFolderObjectKey(s3FileName)))
+                        .putObjectRequest(
+                            req -> req
+                                .bucket(S3Utils.DEFAULT_BUCKET)
+                                .key(S3Utils.makeGtfsFolderObjectKey(s3FileName))
+                        )
                         .source(gtfsFile)
                         .addTransferListener(transferListener)
                     );
@@ -211,9 +216,13 @@ public class FeedStore {
 
                     // copy to [feedSourceId].zip
                     String copyKey = S3Utils.DEFAULT_BUCKET_GTFS_FOLDER + feedSource.id + ".zip";
-                    CopyObjectRequest copyObjRequest = CopyObjectRequest.builder().sourceBucket(S3Utils.DEFAULT_BUCKET).sourceKey(S3Utils.makeGtfsFolderObjectKey(s3FileName)).destinationBucket(S3Utils.DEFAULT_BUCKET).destinationKey(copyKey)
-                        .build();
-                    S3Utils.getDefaultS3Client().copyObject(copyObjRequest);
+                    S3Utils.getDefaultS3Client().copyObject(
+                        req -> req
+                            .sourceBucket(S3Utils.DEFAULT_BUCKET)
+                            .sourceKey(S3Utils.makeGtfsFolderObjectKey(s3FileName))
+                            .destinationBucket(S3Utils.DEFAULT_BUCKET)
+                            .destinationKey(copyKey)
+                    );
                 }
                 return true;
             } catch (AwsServiceException | CheckedAWSException e) {

--- a/src/test/java/com/conveyal/datatools/common/utils/aws/S3UtilsTest.java
+++ b/src/test/java/com/conveyal/datatools/common/utils/aws/S3UtilsTest.java
@@ -4,12 +4,18 @@ import com.conveyal.datatools.DatatoolsTest;
 import com.conveyal.datatools.UnitTest;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.s3.S3Uri;
 
 import java.io.IOException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class S3UtilsTest extends UnitTest {
+
+    public static final String BUCKET = "bucket-name";
+    public static final String KEY = "public/index.html";
+    public static final String URL = String.format("https://%s.s3.amazonaws.com/%s", BUCKET, KEY);
+
     /**
      * Create feed version for GTFS+ validation test.
      */
@@ -21,11 +27,13 @@ class S3UtilsTest extends UnitTest {
 
     @Test
     void canGetDefaultBucketUrlForKey() {
-        final String FILENAME = "public/index.html";
+        assertEquals(URL, S3Utils.getDefaultBucketUrlForKey(KEY));
+    }
 
-        assertEquals(
-            "https://bucket-name.s3.amazonaws.com/public/index.html",
-            S3Utils.getDefaultBucketUrlForKey(FILENAME)
-        );
+    @Test
+    void canMakeUri() {
+        S3Uri uri = S3Utils.makeUri(URL);
+        assertEquals(BUCKET, uri.bucket().orElse(null));
+        assertEquals(KEY, uri.key().orElse(null));
     }
 }

--- a/src/test/java/com/conveyal/datatools/manager/extensions/mtc/MtcFeedResourceTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/extensions/mtc/MtcFeedResourceTest.java
@@ -1,7 +1,5 @@
 package com.conveyal.datatools.manager.extensions.mtc;
 
-import com.amazonaws.auth.AWSCredentials;
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.conveyal.datatools.DatatoolsTest;
 import com.conveyal.datatools.TestUtils;
 import com.conveyal.datatools.UnitTest;
@@ -24,6 +22,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 
 import java.io.IOException;
 import java.sql.SQLException;
@@ -274,15 +274,15 @@ class MtcFeedResourceTest extends UnitTest {
         assertNotNull(s3wrapper);
 
         // Either application.data.s3_region or extensions.mtc.s3_region from server.yml.tmp.
-        assertEquals(overwriteDefaults ? "us-west-2" : "us-east-1", s3wrapper.s3Client.getRegion().toAWSRegion().getName());
+        assertEquals(overwriteDefaults ? "us-west-2" : "us-east-1", s3wrapper.region);
 
         // The credentials should reflect the content in the mock-aws-credentials file referenced above.
         if (overwriteDefaults) {
-            AWSCredentials credentials = s3wrapper.credentials.getCredentials();
-            assertEquals("mock-id-123", credentials.getAWSAccessKeyId());
-            assertEquals("mock-secret-123", credentials.getAWSSecretKey());
+            AwsCredentials credentials = s3wrapper.credentials.resolveCredentials();
+            assertEquals("mock-id-123", credentials.accessKeyId());
+            assertEquals("mock-secret-123", credentials.secretAccessKey());
         } else {
-            assertEquals(DefaultAWSCredentialsProviderChain.class, s3wrapper.credentials.getClass());
+            assertEquals(DefaultCredentialsProvider.class, s3wrapper.credentials.getClass());
         }
     }
 }

--- a/src/test/java/com/conveyal/datatools/manager/extensions/mtc/MtcFeedResourceTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/extensions/mtc/MtcFeedResourceTest.java
@@ -109,11 +109,7 @@ class MtcFeedResourceTest extends UnitTest {
     @AfterEach
     void resetState() {
         DataManager.overrideConfigProperty(CONFIG_MTC_CREDENTIALS, defaultMtcAwsCredentials);
-
-        String currentMtcRegion = getConfigPropertyAsText(CONFIG_MTC_REGION);
-        if (currentMtcRegion != null && !currentMtcRegion.equals(defaultMtcAwsRegion)) {
-            DataManager.overrideConfigProperty(CONFIG_MTC_REGION, defaultMtcAwsRegion);
-        }
+        DataManager.overrideConfigProperty(CONFIG_MTC_REGION, defaultMtcAwsRegion);
     }
 
     @Test
@@ -262,7 +258,7 @@ class MtcFeedResourceTest extends UnitTest {
     }
 
     @ParameterizedTest
-    @ValueSource(booleans = { false, true })
+    @ValueSource(booleans = { true, false })
     void canUseCorrectMtcCredentials(boolean overwriteDefaults) {
         if (overwriteDefaults) {
             DataManager.overrideConfigProperty(CONFIG_MTC_REGION, "us-west-2");

--- a/src/test/java/com/conveyal/datatools/manager/jobs/AutoPublishJobTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/jobs/AutoPublishJobTest.java
@@ -312,10 +312,10 @@ public class AutoPublishJobTest extends UnitTest {
                 return new ArrayList<>();
             } else {
                 S3Object objSummary = S3Object.builder()
+                    .eTag("test-etag")
+                    .key(String.format("%s/%s", TEST_COMPLETED_FOLDER, agencyId))
+                    .lastModified(publishDate.toInstant())
                     .build();
-                objSummary = objSummary.toBuilder().eTag("test-etag").build();
-                objSummary = objSummary.toBuilder().key(String.format("%s/%s", TEST_COMPLETED_FOLDER, agencyId)).build();
-                objSummary = objSummary.toBuilder().lastModified(publishDate.toInstant()).build();
                 return Lists.newArrayList(objSummary);
             }
         }

--- a/src/test/java/com/conveyal/datatools/manager/jobs/AutoPublishJobTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/jobs/AutoPublishJobTest.java
@@ -1,6 +1,5 @@
 package com.conveyal.datatools.manager.jobs;
 
-import com.amazonaws.services.s3.model.S3ObjectSummary;
 import com.conveyal.datatools.DatatoolsTest;
 import com.conveyal.datatools.UnitTest;
 import com.conveyal.datatools.manager.auth.Auth0Connection;
@@ -18,6 +17,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import software.amazon.awssdk.services.s3.model.S3Object;
 
 import java.io.IOException;
 import java.time.LocalDate;
@@ -294,7 +294,7 @@ public class AutoPublishJobTest extends UnitTest {
     }
 
     /**
-     * Mocks the results of an {@link S3ObjectSummary} retrieval before/after the
+     * Mocks the results of an {@link S3Object} retrieval before/after the
      * external MTC publishing process is complete.
      */
     private static class TestCompletedFeedRetriever implements FeedUpdater.CompletedFeedRetriever {
@@ -307,14 +307,15 @@ public class AutoPublishJobTest extends UnitTest {
         }
 
         @Override
-        public List<S3ObjectSummary> retrieveCompletedFeeds() {
+        public List<S3Object> retrieveCompletedFeeds() {
             if (!isPublishingComplete) {
                 return new ArrayList<>();
             } else {
-                S3ObjectSummary objSummary = new S3ObjectSummary();
-                objSummary.setETag("test-etag");
-                objSummary.setKey(String.format("%s/%s", TEST_COMPLETED_FOLDER, agencyId));
-                objSummary.setLastModified(publishDate);
+                S3Object objSummary = S3Object.builder()
+                    .build();
+                objSummary = objSummary.toBuilder().eTag("test-etag").build();
+                objSummary = objSummary.toBuilder().key(String.format("%s/%s", TEST_COMPLETED_FOLDER, agencyId)).build();
+                objSummary = objSummary.toBuilder().lastModified(publishDate.toInstant()).build();
                 return Lists.newArrayList(objSummary);
             }
         }

--- a/src/test/java/com/conveyal/datatools/manager/jobs/DeployJobTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/jobs/DeployJobTest.java
@@ -1,7 +1,5 @@
 package com.conveyal.datatools.manager.jobs;
 
-import com.amazonaws.AmazonServiceException;
-import com.amazonaws.services.ec2.model.Instance;
 import com.conveyal.datatools.DatatoolsTest;
 import com.conveyal.datatools.UnitTest;
 import com.conveyal.datatools.common.utils.aws.CheckedAWSException;
@@ -19,6 +17,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.services.ec2.model.Instance;
 
 import java.io.File;
 import java.io.IOException;
@@ -241,7 +241,7 @@ public class DeployJobTest extends UnitTest {
      * RUN_AWS_DEPLOY_JOB_TESTS environment variable is set to "true"
      */
     @AfterAll
-    public static void cleanUp() throws AmazonServiceException, CheckedAWSException {
+    public static void cleanUp() throws AwsServiceException, CheckedAWSException {
         assumeTrue(getBooleanEnvVar("RUN_AWS_DEPLOY_JOB_TESTS"));
         List<Instance> instances = server.retrieveEC2Instances();
         List<String> ids = EC2Utils.getIds(instances);

--- a/src/test/java/com/conveyal/datatools/manager/jobs/FeedUpdaterTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/jobs/FeedUpdaterTest.java
@@ -1,6 +1,5 @@
 package com.conveyal.datatools.manager.jobs;
 
-import com.amazonaws.services.s3.model.S3ObjectSummary;
 import com.conveyal.datatools.DatatoolsTest;
 import com.conveyal.datatools.manager.models.ExternalFeedSourceProperty;
 import com.conveyal.datatools.manager.models.FeedSource;
@@ -13,6 +12,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.s3.model.S3Object;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -70,17 +70,16 @@ class FeedUpdaterTest {
 
     @Test
     void shouldGetFeedIdsFromS3ObjectSummaries() {
-        List<S3ObjectSummary> s3objects = Lists.newArrayList(
+        List<S3Object> s3objects = Lists.newArrayList(
                 "s3bucket/firstFeed.zip",
                 "s3bucket/otherFeed.zip",
                 "s3bucket/"
             )
             .stream()
-            .map(k -> {
-                S3ObjectSummary s3Obj = new S3ObjectSummary();
-                s3Obj.setKey(k);
-                return s3Obj;
-            })
+            .map(k -> S3Object.builder()
+                    .key(k)
+                    .build()
+            )
             .collect(Collectors.toList());
         List<String> expectedIds = Lists.newArrayList(
             FIRST_FEED,


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR upgrades AWS SDK to version 2.x. The largest benefit of upgrading is AWS access using federated (SSO) login during development without having to use temporary access keys. Existing access-key-based access should still work. Also, AWS SDK 1.x is out of support now.

Things to test:
- Import a feed version and download that feed version (using a config where `application.data.use_s3_storage = true`).
- Deploy an OTP instance (using a config where `modules.deployment.enabled = true`
