### PR TITLE
Rider Categories Merging

### DIFF
--- a/src/main/java/com/conveyal/datatools/manager/gtfsplus/GtfsPlusValidation.java
+++ b/src/main/java/com/conveyal/datatools/manager/gtfsplus/GtfsPlusValidation.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 import java.util.Enumeration;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
@@ -240,6 +241,7 @@ public class GtfsPlusValidation implements Serializable {
         int rowIndex = 0;
         int rowsWithWrongNumberOfColumns = 0;
         int emptyRows = 0;
+        long nonNullFieldsCount = Arrays.stream(fieldsFound).filter(Objects::nonNull).count();
         while (csvReader.readRecord()) {
             // First, check that row has the correct number of fields.
             int recordColumnCount = csvReader.getColumnCount();
@@ -249,7 +251,7 @@ public class GtfsPlusValidation implements Serializable {
                 // report that as such (and skip validating column values).
                 emptyRows++;
             } else {
-                if (recordColumnCount != fieldsFound.length) {
+                if (recordColumnCount != nonNullFieldsCount) {
                     rowsWithWrongNumberOfColumns++;
                 }
                 // Validate each value in row. Note: we iterate over the fields and not values because a row may be missing

--- a/src/main/java/com/conveyal/datatools/manager/gtfsplus/tables/GtfsPlusTable.java
+++ b/src/main/java/com/conveyal/datatools/manager/gtfsplus/tables/GtfsPlusTable.java
@@ -97,7 +97,7 @@ public class GtfsPlusTable {
         DIRECTIONS,
         STOP_ATTRIBUTES,
         TIMEPOINTS,
-        RIDER_CATEGORIES,
+        // RIDER_CATEGORIES is already listed in standard tables (Fares V2), so we don't include it twice.
         FARE_RIDER_CATEGORIES,
         CALENDAR_ATTRIBUTES,
         FAREZONE_ATTRIBUTES,

--- a/src/main/java/com/conveyal/datatools/manager/jobs/feedmerge/MergeLineContext.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/feedmerge/MergeLineContext.java
@@ -231,12 +231,16 @@ public class MergeLineContext {
 
     public void startNewRow() throws IOException {
         keyValue = csvReader.get(keyFieldIndex);
-        // Get the spec fields to export
-        List<Field> specFields = table.specFields();
-        // Filter the spec fields on the set of fields found in all feeds to be merged.
-        sharedSpecFields = specFields.stream()
-            .filter(f -> containsField(allFields, f.name))
-            .collect(Collectors.toList());
+        if (table == Table.RIDER_CATEGORIES) {
+            sharedSpecFields = List.copyOf(allFields);
+        } else {
+            // Get the spec fields and custom/proprietary fields to export
+            List<Field> specFields = table.specFields();
+            // Filter the spec fields on the set of fields found in all feeds to be merged.
+            sharedSpecFields = specFields.stream()
+                .filter(f -> containsField(allFields, f.name))
+                .collect(Collectors.toList());
+        }
     }
 
     /**
@@ -607,13 +611,11 @@ public class MergeLineContext {
         // row except for the identifiers receiving a prefix to avoid ID conflicts.
         for (int specFieldIndex = 0; specFieldIndex < sharedSpecFields.size(); specFieldIndex++) {
             Field field = sharedSpecFields.get(specFieldIndex);
+            int fieldIndex = fieldsFoundList.stream().map(f -> f.name).collect(Collectors.toList()).indexOf(field.name);
             // Default value to write is unchanged from value found in csv (i.e. val). Note: if looking to
             // modify the value that is written in the merged file, you must update valueToWrite (e.g.,
             // updating this feed's end_date or accounting for cases where IDs conflict).
-            FieldContext fieldContext = new FieldContext(
-                field,
-                csvReader.get(fieldsFoundList.indexOf(field))
-            );
+            FieldContext fieldContext = new FieldContext(field, csvReader.get(fieldIndex));
             originalRowValues[specFieldIndex] = fieldContext.getValueToWrite();
             if (!skipRecord) {
                 // Handle filling in agency_id if missing when merging regional feeds. If false is returned,

--- a/src/main/java/com/conveyal/datatools/manager/utils/MergeFeedUtils.java
+++ b/src/main/java/com/conveyal/datatools/manager/utils/MergeFeedUtils.java
@@ -21,11 +21,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -113,9 +114,10 @@ public class MergeFeedUtils {
             ).collect(Collectors.toList());
     }
 
-    /** Get all fields found in the feeds being merged for a specific table. */
+    /** Get all fields found, without duplication, in the feeds being merged for a specific table. */
     public static Set<Field> getAllFields(List<FeedToMerge> feedsToMerge, Table table) throws IOException {
-        Set<Field> sharedFields = new HashSet<>();
+        Map<String, Field> fieldMap = new HashMap<>();
+
         // First, iterate over each feed to collect the shared fields that need to be output in the merged table.
         for (FeedToMerge feed : feedsToMerge) {
             CsvReader csvReader = CsvReaderUtil.getCsvReaderAccordingToFileName(table, feed.zipFile, null);
@@ -126,12 +128,14 @@ public class MergeFeedUtils {
             try {
                 // Get fields found from headers and add them to the shared fields set.
                 Field[] fieldsFoundInZip = table.getFieldsFromFieldHeaders(csvReader.getHeaders(), null);
-                sharedFields.addAll(Arrays.asList(fieldsFoundInZip));
+                for (final Field field : fieldsFoundInZip) {
+                    fieldMap.putIfAbsent(field.name, field);
+                }
             } finally {
                 csvReader.close();
             }
         }
-        return sharedFields;
+        return Set.copyOf(fieldMap.values());
     }
 
     /**

--- a/src/test/java/com/conveyal/datatools/manager/gtfsplus/GtfsPlusValidationTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/gtfsplus/GtfsPlusValidationTest.java
@@ -23,9 +23,13 @@ import java.util.Date;
 import java.util.Objects;
 import java.util.stream.Stream;
 
+import static com.conveyal.datatools.TestUtils.createFeedVersion;
 import static com.conveyal.datatools.TestUtils.createFeedVersionFromGtfsZip;
+import static com.conveyal.datatools.TestUtils.zipFolderFiles;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /** Runs test to verify that GTFS+ validation runs as expected. */
 class GtfsPlusValidationTest extends UnitTest {
@@ -213,9 +217,19 @@ class GtfsPlusValidationTest extends UnitTest {
 
         LOG.info("Validating GTFS+ directions.txt in Golden Gate Ferry using incomplete realtime_routes.txt should produce no errors");
         GtfsPlusValidation validation = GtfsPlusValidation.validate(ggfIncompleteDirections.id);
-        assertThat(
-            "Should have no GTFS+ validation issue on the directions.txt table",
-            validation.issues.size(), equalTo(0)
+        assertTrue(
+            validation.issues.isEmpty(),
+            "Should have no GTFS+ validation issue on the directions.txt table"
+        );
+    }
+
+    @Test
+    void shouldDetectExtraGtfsPlusFields() throws Exception {
+        FeedVersion version = createFeedVersion(goldenGateFerry, zipFolderFiles("rider-categories-extra-fields"));
+        GtfsPlusValidation validation = GtfsPlusValidation.validate(version.id);
+        assertFalse(
+            validation.issues.isEmpty(),
+            "Should have caught those extra non-GTFS+ fields in rider_category.txt."
         );
     }
 }

--- a/src/test/java/com/conveyal/datatools/manager/gtfsplus/GtfsPlusValidationTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/gtfsplus/GtfsPlusValidationTest.java
@@ -4,7 +4,6 @@ import com.conveyal.datatools.DatatoolsTest;
 import com.conveyal.datatools.UnitTest;
 import com.conveyal.datatools.manager.DataManager;
 import com.conveyal.datatools.manager.auth.Auth0Connection;
-import com.conveyal.datatools.manager.jobs.MergeFeedsJobTest;
 import com.conveyal.datatools.manager.models.FeedSource;
 import com.conveyal.datatools.manager.models.FeedVersion;
 import com.conveyal.datatools.manager.models.Project;
@@ -29,8 +28,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 /** Runs test to verify that GTFS+ validation runs as expected. */
-public class GtfsPlusValidationTest extends UnitTest {
-    private static final Logger LOG = LoggerFactory.getLogger(MergeFeedsJobTest.class);
+class GtfsPlusValidationTest extends UnitTest {
+    private static final Logger LOG = LoggerFactory.getLogger(GtfsPlusValidationTest.class);
     private static FeedVersion bartVersion1;
     private static FeedVersion bartVersion1WithQuotedValues;
     private static FeedVersion lavtaVersion1;
@@ -43,7 +42,7 @@ public class GtfsPlusValidationTest extends UnitTest {
      * Create feed version for GTFS+ validation test.
      */
     @BeforeAll
-    public static void setUp() throws IOException {
+    static void setUp() throws IOException {
         // Start server if it isn't already running.
         DatatoolsTest.setUp();
         Auth0Connection.setAuthDisabled(true);

--- a/src/test/java/com/conveyal/datatools/manager/jobs/MergeFeedsJobTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/jobs/MergeFeedsJobTest.java
@@ -348,12 +348,19 @@ public class MergeFeedsJobTest extends UnitTest {
 
         assertFeedMergeSucceeded(mergeFeedsJob);
 
-        // 3 records should be loaded into Postgres (independently of the UI-performed GTFS+ loading).
+        // 3 records should be loaded into Postgres.
         assertEquals(3, mergeFeedsJob.mergedVersion.feedLoadResult.riderCategories.rowCount);
 
-        // GTFS+ rider_category_description field should be imported from the merged feed.
+        // GTFS+ rider_category_description field should be imported in Postgres from the merged feed.
+        // From the Fares V2 spec, only the rider_category_id field is present because the other fields are
+        // missing from the original feeds before merging.
         SqlAssert sqlAssert = new SqlAssert(mergeFeedsJob.mergedVersion);
-        sqlAssert.riderCategories.assertCount(3, "(rider_category_description = '') IS FALSE");
+        sqlAssert.riderCategories.assertCount(1, "rider_category_id = '1'");
+        sqlAssert.riderCategories.assertCount(1, "rider_category_id = '2'");
+        sqlAssert.riderCategories.assertCount(1, "rider_category_id = '5'");
+        sqlAssert.riderCategories.assertCount(1, "rider_category_description = 'Youth'");
+        sqlAssert.riderCategories.assertCount(1, "rider_category_description = 'Adult'");
+        sqlAssert.riderCategories.assertCount(1, "rider_category_description = 'Eligible Discount (Senior / Disabled / Medicare cardholder)'");
     }
 
     /**

--- a/src/test/java/com/conveyal/datatools/manager/jobs/MergeFeedsJobTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/jobs/MergeFeedsJobTest.java
@@ -372,7 +372,7 @@ class MergeFeedsJobTest extends UnitTest {
         SqlAssert sqlBaseAssert = new SqlAssert(fakeTransitBase);
         sqlBaseAssert.riderCategories.assertCount(2, "(rider_category_description = '') IS FALSE");
         SqlAssert sqlFutureAssert = new SqlAssert(fakeTransitFuture);
-        sqlFutureAssert.riderCategories.assertCount(3, "(rider_category_description = '') IS FALSE");
+        sqlFutureAssert.riderCategories.assertCount(2, "(rider_category_description = '') IS FALSE");
 
         Set<Field> allFields = MergeFeedUtils.getAllFields(
             List.of(new FeedToMerge(fakeTransitBase), new FeedToMerge(fakeTransitFuture)),

--- a/src/test/java/com/conveyal/datatools/manager/jobs/MergeFeedsJobTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/jobs/MergeFeedsJobTest.java
@@ -5,14 +5,18 @@ import com.conveyal.datatools.UnitTest;
 import com.conveyal.datatools.manager.auth.Auth0Connection;
 import com.conveyal.datatools.manager.auth.Auth0UserProfile;
 import com.conveyal.datatools.manager.gtfsplus.GtfsPlusValidation;
+import com.conveyal.datatools.manager.jobs.feedmerge.FeedToMerge;
 import com.conveyal.datatools.manager.jobs.feedmerge.MergeFeedsType;
 import com.conveyal.datatools.manager.jobs.feedmerge.MergeStrategy;
 import com.conveyal.datatools.manager.models.FeedSource;
 import com.conveyal.datatools.manager.models.FeedVersion;
 import com.conveyal.datatools.manager.models.Project;
 import com.conveyal.datatools.manager.persistence.Persistence;
+import com.conveyal.datatools.manager.utils.MergeFeedUtils;
 import com.conveyal.datatools.manager.utils.SqlAssert;
 import com.conveyal.gtfs.error.NewGTFSErrorType;
+import com.conveyal.gtfs.loader.Field;
+import com.conveyal.gtfs.loader.Table;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -23,7 +27,9 @@ import java.io.IOException;
 import java.sql.SQLException;
 import java.util.Date;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static com.conveyal.datatools.TestUtils.assertThatFeedHasNoErrorsOfType;
 import static com.conveyal.datatools.TestUtils.createFeedVersion;
@@ -325,6 +331,28 @@ public class MergeFeedsJobTest extends UnitTest {
 
         // expect that the record in calendar table has the correct start_date.
         sqlAssert.calendar.assertCount(1, "start_date='20170918' and monday=1");
+    }
+
+    /**
+     * Ensures that custom/proprietary fields in a feed CSV file are detected without duplication.
+     */
+    @Test
+    void canGetAllFields() throws SQLException, IOException {
+        // A proprietary (GTFS+) field rider_category_description should be loaded in both feeds.
+        SqlAssert sqlBaseAssert = new SqlAssert(fakeTransitBase);
+        sqlBaseAssert.riderCategories.assertCount(2, "(rider_category_description = '') IS FALSE");
+        SqlAssert sqlFutureAssert = new SqlAssert(fakeTransitFuture);
+        sqlFutureAssert.riderCategories.assertCount(3, "(rider_category_description = '') IS FALSE");
+
+        Set<Field> allFields = MergeFeedUtils.getAllFields(
+            List.of(new FeedToMerge(fakeTransitBase), new FeedToMerge(fakeTransitFuture)),
+            Table.RIDER_CATEGORIES
+        );
+
+        assertEquals(2, allFields.size());
+
+        Set<String> fieldNames = allFields.stream().map(f -> f.name).collect(Collectors.toSet());
+        assertEquals(Set.of("rider_category_id", "rider_category_description"), fieldNames);
     }
 
     /**

--- a/src/test/java/com/conveyal/datatools/manager/jobs/MergeFeedsJobTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/jobs/MergeFeedsJobTest.java
@@ -44,7 +44,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 /**
  * Tests for the various {@link MergeFeedsJob} merge types.
  */
-public class MergeFeedsJobTest extends UnitTest {
+class MergeFeedsJobTest extends UnitTest {
     private static final Logger LOG = LoggerFactory.getLogger(MergeFeedsJobTest.class);
     private static final Auth0UserProfile user = Auth0UserProfile.createTestAdminUser();
     private static FeedVersion bartVersion1;
@@ -90,7 +90,7 @@ public class MergeFeedsJobTest extends UnitTest {
      * Prepare and start a testing-specific web server
      */
     @BeforeAll
-    public static void setUp() throws IOException {
+    static void setUp() throws IOException {
         // start server if it isn't already running
         DatatoolsTest.setUp();
         ProcessSingleFeedJob.ENABLE_ADDITIONAL_VALIDATION = false;
@@ -168,7 +168,7 @@ public class MergeFeedsJobTest extends UnitTest {
      * Delete project on tear down (feed sources/versions will also be deleted).
      */
     @AfterAll
-    public static void tearDown() {
+    static void tearDown() {
         Auth0Connection.setAuthDisabled(Auth0Connection.getDefaultAuthDisabled());
         if (project != null) {
             project.delete();

--- a/src/test/java/com/conveyal/datatools/manager/jobs/MergeFeedsJobTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/jobs/MergeFeedsJobTest.java
@@ -334,11 +334,10 @@ class MergeFeedsJobTest extends UnitTest {
     }
 
     /**
-     * Ensures that an MTC merge of feeds will merge rider_categories.txt successfully according to MTC's GTFS+ spec,
-     * ignoring the GTFS Fares V2 spec fields.
+     * Ensures that rider_categories.txt are merged including MTC's GTFS+ fields that are not part of the Fares V2 spec.
      */
     @Test
-    void mergeMTCShouldMergeRiderCategoriesUsingGTFSPlusFields() throws Exception {
+    void mergeMTCShouldMergeRiderCategoriesGtfsPlusFields() throws Exception {
         Set<FeedVersion> versions = new HashSet<>();
         versions.add(fakeTransitBase);
         versions.add(fakeTransitFuture);
@@ -385,8 +384,6 @@ class MergeFeedsJobTest extends UnitTest {
             List.of(new FeedToMerge(fakeTransitBase), new FeedToMerge(fakeTransitFuture)),
             Table.RIDER_CATEGORIES
         );
-
-        assertEquals(2, allFields.size());
 
         Set<String> fieldNames = allFields.stream().map(f -> f.name).collect(Collectors.toSet());
         assertEquals(Set.of("rider_category_id", "rider_category_description"), fieldNames);

--- a/src/test/java/com/conveyal/datatools/manager/jobs/MergeFeedsJobTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/jobs/MergeFeedsJobTest.java
@@ -313,7 +313,7 @@ public class MergeFeedsJobTest extends UnitTest {
         MergeFeedsJob mergeFeedsJob = new MergeFeedsJob(user, versions, "merged_output", MergeFeedsType.SERVICE_PERIOD);
         // Run the job in this thread (we're not concerned about concurrency here).
         mergeFeedsJob.run();
-        // Result should fail.
+        // Result should succeed.
         assertFalse(
             mergeFeedsJob.mergeFeedsResult.failed,
             "Merge feeds job should succeed with CHECK_STOP_TIMES strategy."
@@ -331,6 +331,29 @@ public class MergeFeedsJobTest extends UnitTest {
 
         // expect that the record in calendar table has the correct start_date.
         sqlAssert.calendar.assertCount(1, "start_date='20170918' and monday=1");
+    }
+
+    /**
+     * Ensures that an MTC merge of feeds will merge rider_categories.txt successfully according to MTC's GTFS+ spec,
+     * ignoring the GTFS Fares V2 spec fields.
+     */
+    @Test
+    void mergeMTCShouldMergeRiderCategoriesUsingGTFSPlusFields() throws SQLException {
+        Set<FeedVersion> versions = new HashSet<>();
+        versions.add(fakeTransitBase);
+        versions.add(fakeTransitFuture);
+        MergeFeedsJob mergeFeedsJob = new MergeFeedsJob(user, versions, "merged_output", MergeFeedsType.SERVICE_PERIOD);
+        // Run the job in this thread (we're not concerned about concurrency here).
+        mergeFeedsJob.run();
+
+        assertFeedMergeSucceeded(mergeFeedsJob);
+
+        // 3 records should be loaded into Postgres (independently of the UI-performed GTFS+ loading).
+        assertEquals(3, mergeFeedsJob.mergedVersion.feedLoadResult.riderCategories.rowCount);
+
+        // GTFS+ rider_category_description field should be imported from the merged feed.
+        SqlAssert sqlAssert = new SqlAssert(mergeFeedsJob.mergedVersion);
+        sqlAssert.riderCategories.assertCount(3, "(rider_category_description = '') IS FALSE");
     }
 
     /**

--- a/src/test/java/com/conveyal/datatools/manager/jobs/MergeFeedsJobTest.java
+++ b/src/test/java/com/conveyal/datatools/manager/jobs/MergeFeedsJobTest.java
@@ -338,7 +338,7 @@ class MergeFeedsJobTest extends UnitTest {
      * ignoring the GTFS Fares V2 spec fields.
      */
     @Test
-    void mergeMTCShouldMergeRiderCategoriesUsingGTFSPlusFields() throws SQLException {
+    void mergeMTCShouldMergeRiderCategoriesUsingGTFSPlusFields() throws Exception {
         Set<FeedVersion> versions = new HashSet<>();
         versions.add(fakeTransitBase);
         versions.add(fakeTransitFuture);
@@ -361,6 +361,13 @@ class MergeFeedsJobTest extends UnitTest {
         sqlAssert.riderCategories.assertCount(1, "rider_category_description = 'Youth'");
         sqlAssert.riderCategories.assertCount(1, "rider_category_description = 'Adult'");
         sqlAssert.riderCategories.assertCount(1, "rider_category_description = 'Eligible Discount (Senior / Disabled / Medicare cardholder)'");
+
+        // There should not be other fields in that table (they would be caught by GTFS+ validation).
+        GtfsPlusValidation validation = GtfsPlusValidation.validate(mergeFeedsJob.mergedVersion.id);
+        assertEquals(
+            0,
+            validation.issues.stream().filter(i -> i.tableId.equals(Table.RIDER_CATEGORIES.name)).count()
+        );
     }
 
     /**

--- a/src/test/java/com/conveyal/datatools/manager/utils/SqlAssert.java
+++ b/src/test/java/com/conveyal/datatools/manager/utils/SqlAssert.java
@@ -22,6 +22,7 @@ public class SqlAssert {
     public final SqlTableAssert trips = new SqlTableAssert(Table.TRIPS);
     public final SqlTableAssert stops = new SqlTableAssert(Table.STOPS);
     public final SqlTableAssert patterns = new SqlTableAssert(Table.PATTERNS);
+    public final SqlTableAssert riderCategories = new SqlTableAssert(Table.RIDER_CATEGORIES);
 
     public SqlAssert(FeedVersion version) {
         this.version = version;

--- a/src/test/resources/com/conveyal/datatools/gtfs/merge-data-base/rider_categories.txt
+++ b/src/test/resources/com/conveyal/datatools/gtfs/merge-data-base/rider_categories.txt
@@ -1,0 +1,3 @@
+rider_category_id,rider_category_description
+1,Adult
+5,Youth

--- a/src/test/resources/com/conveyal/datatools/gtfs/merge-data-future/rider_categories.txt
+++ b/src/test/resources/com/conveyal/datatools/gtfs/merge-data-future/rider_categories.txt
@@ -1,4 +1,3 @@
 rider_category_id,rider_category_description
 1,Adult
 2,Eligible Discount (Senior / Disabled / Medicare cardholder)
-5,Youth

--- a/src/test/resources/com/conveyal/datatools/gtfs/merge-data-future/rider_categories.txt
+++ b/src/test/resources/com/conveyal/datatools/gtfs/merge-data-future/rider_categories.txt
@@ -1,0 +1,4 @@
+rider_category_id,rider_category_description
+1,Adult
+2,Eligible Discount (Senior / Disabled / Medicare cardholder)
+5,Youth

--- a/src/test/resources/com/conveyal/datatools/gtfs/rider-categories-extra-fields/rider_categories.txt
+++ b/src/test/resources/com/conveyal/datatools/gtfs/rider-categories-extra-fields/rider_categories.txt
@@ -1,0 +1,3 @@
+rider_category_id,rider_category_description,rider_category_name
+1,Adult,Adult
+2,Eligible Discount (Senior / Disabled / Medicare cardholder),Discounted


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR attempts to resolve merging of the rider_categories.txt, whether it is from the Fares V2 spec or the GTFS+ spec. The minimal set of fields found in rider_categories.txt from the feed versions to merge will be used, and values merged, regardless of whether rider_categories.txt is from GTFS+ or Fares V2. (Merging of whole Fares V2 feeds is out of scope).
